### PR TITLE
Fix/docs runtime vercel

### DIFF
--- a/.cursor/rules/always.md
+++ b/.cursor/rules/always.md
@@ -15,9 +15,11 @@ These rules are always attached to the model context for this repo.
 - Follow Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `perf:`, `build:`, `ci:`.
 - Keep subject ≤72 chars; use imperative mood.
 - Reference issues in the body when relevant (e.g., `Closes #123`).
+- always create a new branch when starting a new feature
 
 ## Test norms
 
+- Always run a local compilation first before pushing
 - Co-locate tests next to source or in a `__tests__` folder.
 - Aim for fast unit tests, focused integration tests, and minimal E2E smoke.
 - For regressions, add a failing test first.

--- a/.github/workflows/cache-verify.yml
+++ b/.github/workflows/cache-verify.yml
@@ -1,0 +1,24 @@
+name: Cache Verify
+
+on:
+  pull_request:
+    paths:
+      - "src/lib/db.ts"
+      - "src/app/api/**"
+      - "scripts/verify-cache.ts"
+
+jobs:
+  verify-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install --no-audit --no-fund
+      - name: Generate Prisma Client
+        run: npx prisma generate --accelerate
+      - name: Verify cache behavior
+        run: node node_modules/tsx/dist/cli.mjs scripts/verify-cache.ts
+        env:
+          PRISMA_CACHE_ENABLED: "1"

--- a/.github/workflows/cache-verify.yml
+++ b/.github/workflows/cache-verify.yml
@@ -22,3 +22,4 @@ jobs:
         run: node node_modules/tsx/dist/cli.mjs scripts/verify-cache.ts
         env:
           PRISMA_CACHE_ENABLED: "1"
+          DATABASE_URL: ${{ secrets.DIRECT_DATABASE_URL }}

--- a/docs/_generated/routes.md
+++ b/docs/_generated/routes.md
@@ -1,0 +1,5 @@
+# Routes Inventory
+
+## API Routes
+
+## Pages

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,170 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "H3 Teamy API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": ""
+    }
+  ],
+  "components": {
+    "schemas": {
+      "PasswordResetRequestBody": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": ["email"]
+      },
+      "PasswordResetRequestResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": ["ok"]
+      },
+      "PasswordResetConfirmBody": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "minLength": 1
+          },
+          "newPassword": {
+            "type": "string",
+            "minLength": 8
+          }
+        },
+        "required": ["token", "newPassword"]
+      },
+      "PasswordResetConfirmResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "ok": {
+                "type": "boolean"
+              }
+            },
+            "required": ["ok"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": ["error"]
+          }
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/api/auth/password/reset-request": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                },
+                "required": ["email"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/password/reset-confirm": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "newPassword": {
+                    "type": "string",
+                    "minLength": 8
+                  }
+                },
+                "required": ["token", "newPassword"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["error"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "prisma:generate": "prisma generate",
-    "prebuild": "node scripts/generate-icons.js",
+    "prebuild": "node scripts/generate-icons.js && npm run docs:generate",
     "postinstall": "prisma generate --accelerate",
     "prepare": "husky install",
     "docs:scan": "tsx scripts/docs/scan-routes.ts",

--- a/scripts/verify-cache.ts
+++ b/scripts/verify-cache.ts
@@ -1,0 +1,60 @@
+import { prisma } from "../src/lib/db";
+
+async function time<T>(
+  fn: () => Promise<T>,
+): Promise<{ ms: number; value: T }> {
+  const start = Date.now();
+  const value = await fn();
+  return { ms: Date.now() - start, value };
+}
+
+async function main() {
+  process.env.PRISMA_CACHE_ENABLED = process.env.PRISMA_CACHE_ENABLED || "1";
+
+  // Warm cache run: roster-like read
+  const first = await time(() =>
+    prisma.user.findMany({
+      select: { id: true, firstName: true, lastName: true },
+    }),
+  );
+  const second = await time(() =>
+    prisma.user.findMany({
+      select: { id: true, firstName: true, lastName: true },
+    }),
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        firstMs: first.ms,
+        secondMs: second.ms,
+        count: Array.isArray(second.value) ? second.value.length : null,
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Compare payloads
+  if (JSON.stringify(first.value) !== JSON.stringify(second.value)) {
+    console.warn("Warning: payloads differ between cached and fresh reads.");
+  }
+
+  // Toggle cache off and compare timing
+  process.env.PRISMA_CACHE_ENABLED = "0";
+  const cold = await time(() =>
+    prisma.user.findMany({
+      select: { id: true, firstName: true, lastName: true },
+    }),
+  );
+  console.log(JSON.stringify({ cacheOffMs: cold.ms }, null, 2));
+}
+
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 
 export const dynamic = "force-static";
+export const runtime = "nodejs";
 
 async function readFileSafe(p: string): Promise<string | null> {
   try {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -5,14 +5,57 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-const prismaInstance =
+const basePrisma =
   global.prisma ||
   (() => {
     const url = process.env.PRISMA_DATABASE_URL || process.env.DATABASE_URL;
-    return url ? new PrismaClient({ datasources: { db: { url } } }) : new PrismaClient();
+    return url
+      ? new PrismaClient({ datasources: { db: { url } } })
+      : new PrismaClient();
   })();
+
+// Add TTL/SWR caching for read queries via Prisma Postgres
+function buildCachedClient(p: PrismaClient): PrismaClient {
+  try {
+    // @ts-ignore - $extends is available on PrismaClient
+    const extended = p.$extends({
+      query: {
+        $allModels: {
+          async $allOperations({ model, operation, args, query }: any) {
+            const cacheEnabled = process.env.PRISMA_CACHE_ENABLED !== "0";
+            const isRead = [
+              "findUnique",
+              "findMany",
+              "findFirst",
+              "count",
+              "aggregate",
+            ].includes(operation);
+            if (!cacheEnabled || !isRead) return query(args);
+
+            const rosterRead = model === "User" && operation === "findMany";
+            const profileRead = model === "User" && operation === "findUnique";
+            const ttl = rosterRead
+              ? 300
+              : profileRead
+                ? 600
+                : Number(process.env.CACHE_TTL || 60);
+            const swr = rosterRead
+              ? 60
+              : profileRead
+                ? 120
+                : Number(process.env.CACHE_SWR || 0);
+            return query({ ...args, cacheStrategy: { ttl, swr } });
+          },
+        },
+      },
+    });
+    return extended as unknown as PrismaClient;
+  } catch {
+    return p;
+  }
+}
+
+const prismaInstance = buildCachedClient(basePrisma);
 
 export const prisma = prismaInstance;
 if (process.env.NODE_ENV !== "production") global.prisma = prismaInstance;
-
-


### PR DESCRIPTION
## Summary

Describe the change.

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s):
  - Functional spec section(s):

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Prisma read-query caching with TTL/SWR, add a CI workflow to verify cache behavior, and wire up docs generation/runtime with new generated docs.
> 
> - **Backend**:
>   - **Prisma caching**: Extend `src/lib/db.ts` to add TTL/SWR caching for read ops (env-controlled via `PRISMA_CACHE_ENABLED`; special handling for `User` reads).
>   - **Cache verification**: Add `scripts/verify-cache.ts` and GitHub Action `.github/workflows/cache-verify.yml` to time cached vs uncached queries on PRs.
> - **Docs**:
>   - **Generation**: Update `package.json` `prebuild` to run `docs:generate`.
>   - **Runtime**: Set `export const runtime = "nodejs"` in `src/app/docs/page.tsx`.
>   - **Artifacts**: Add `docs/api/openapi.json` and `docs/_generated/routes.md`.
> - **Repo rules**: Minor additions to `.cursor/rules/always.md` (branching and local compilation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f60a345322dbc1fa1f98e260975d8f4b04c72f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->