### PR TITLE
feat(report): notify WhatsApp group on report generation

### DIFF
--- a/docs/tech/reports/README.md
+++ b/docs/tech/reports/README.md
@@ -8,3 +8,19 @@ Generate reports for events.
 
 - UI: `src/components/GenerateReportButton.tsx`, `src/app/report/[eventId]/page.tsx`
 - API: `src/app/api/report/**`
+
+## WhatsApp Notification (WaAPI)
+
+After a successful report generation, the API can send a WhatsApp group notification with a deep link to the report.
+
+Required environment variables:
+
+- `WAAPI_NOTIFICATIONS_ENABLED=true`
+- `WAAPI_INSTANCE_ID=<your_instance_id>`
+- `WAAPI_API_TOKEN=<your_waapi_api_token>`
+- `WAAPI_GROUP_CHAT_ID=1467733237@g.us`
+- `APP_URL=https://<your-domain>`
+
+Optional:
+
+- `WAAPI_BASE_URL=https://waapi.app/api/v1` (defaults to this value)

--- a/docs/tech/reports/README.md
+++ b/docs/tech/reports/README.md
@@ -18,7 +18,7 @@ Required environment variables:
 - `WAAPI_NOTIFICATIONS_ENABLED=true`
 - `WAAPI_INSTANCE_ID=<your_instance_id>`
 - `WAAPI_API_TOKEN=<your_waapi_api_token>`
-- `WAAPI_GROUP_CHAT_ID=1467733237@g.us`
+- `WAAPI_GROUP_CHAT_ID=<your_group_chat_id>` (e.g. `1234567890@g.us`)
 - `APP_URL=https://<your-domain>`
 
 Optional:

--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { getReport, setReport, kvGetJson } from "../../../../lib/kv";
 import { MVP_PLACEHOLDER } from "../../../../lib/mvpNarrative";
+import { sendMatchReportToWhatsAppGroup } from "../../../../lib/services/waapiService";
 import type { TeamEvent } from "../../../../types";
 
 type RawEvent = {
@@ -489,11 +491,19 @@ Regels:
       mvpResult: previous?.mvpResult,
     };
     await setReport(eventId, report);
+
+    // Notification failures are non-blocking: report generation must still succeed.
+    await sendMatchReportToWhatsAppGroup({
+      eventId,
+      opponentTeam: narrativeInput.opponentTeam,
+      ourScore: narrativeInput.ourScore,
+      opponentScore: narrativeInput.opponentScore,
+    });
+
     return NextResponse.json({ ok: true, report });
-  } catch (e: any) {
-    return NextResponse.json(
-      { error: "failed", message: e?.message || String(e) },
-      { status: 500 },
-    );
+  } catch (error: unknown) {
+    Sentry.captureException(error);
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: "failed", message }, { status: 500 });
   }
 }

--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -492,12 +492,14 @@ Regels:
     };
     await setReport(eventId, report);
 
-    // Notification failures are non-blocking: report generation must still succeed.
-    await sendMatchReportToWhatsAppGroup({
+    // Fire-and-forget so report generation response is never blocked.
+    sendMatchReportToWhatsAppGroup({
       eventId,
       opponentTeam: narrativeInput.opponentTeam,
       ourScore: narrativeInput.ourScore,
       opponentScore: narrativeInput.opponentScore,
+    }).catch((error: unknown) => {
+      Sentry.captureException(error);
     });
 
     return NextResponse.json({ ok: true, report });

--- a/src/lib/services/waapiService.test.ts
+++ b/src/lib/services/waapiService.test.ts
@@ -69,6 +69,26 @@ describe("waapiService", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(0);
   });
 
+  it("returns disabled when WAAPI notifications are disabled", async () => {
+    vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "false");
+
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const result = await sendMatchReportToWhatsAppGroup({ eventId: "evt-1" });
+
+    expect(result).toEqual({ sent: false, reason: "disabled" });
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns invalid_event_id for blank eventId", async () => {
+    vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "true");
+
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const result = await sendMatchReportToWhatsAppGroup({ eventId: "   " });
+
+    expect(result).toEqual({ sent: false, reason: "invalid_event_id" });
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
   it("returns upstream_error when WaAPI responds with non-ok", async () => {
     vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "true");
     vi.stubEnv("WAAPI_INSTANCE_ID", "instance-123");
@@ -88,6 +108,9 @@ describe("waapiService", () => {
       details: "Bad Request",
     });
     expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(
+      expect.any(Error),
+    );
   });
 
   it("captures exception when fetch throws", async () => {

--- a/src/lib/services/waapiService.test.ts
+++ b/src/lib/services/waapiService.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Sentry from "@sentry/nextjs";
+import { sendMatchReportToWhatsAppGroup } from "./waapiService";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("waapiService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("sends a message with group chat id and deep link", async () => {
+    vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "true");
+    vi.stubEnv("WAAPI_BASE_URL", "https://waapi.app/api/v1");
+    vi.stubEnv("WAAPI_INSTANCE_ID", "instance-123");
+    vi.stubEnv("WAAPI_API_TOKEN", "token-abc");
+    vi.stubEnv("WAAPI_GROUP_CHAT_ID", "1467733237@g.us");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const result = await sendMatchReportToWhatsAppGroup({
+      eventId: "evt-1",
+      opponentTeam: "Opponent",
+      ourScore: 12,
+      opponentScore: 9,
+    });
+
+    expect(result).toEqual({ sent: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://waapi.app/api/v1/instances/instance-123/client/action/send-message",
+    );
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: "Bearer token-abc",
+      },
+    });
+    expect(init?.body).toContain("1467733237@g.us");
+    expect(init?.body).toContain("https://teamy.example/report/evt-1");
+  });
+
+  it("returns missing_config when required env is absent", async () => {
+    vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "true");
+    vi.stubEnv("WAAPI_INSTANCE_ID", "");
+    vi.stubEnv("WAAPI_API_TOKEN", "");
+    vi.stubEnv("WAAPI_GROUP_CHAT_ID", "");
+    vi.stubEnv("APP_URL", "");
+
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const result = await sendMatchReportToWhatsAppGroup({ eventId: "evt-1" });
+
+    expect(result).toEqual({ sent: false, reason: "missing_config" });
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns upstream_error when WaAPI responds with non-ok", async () => {
+    vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "true");
+    vi.stubEnv("WAAPI_INSTANCE_ID", "instance-123");
+    vi.stubEnv("WAAPI_API_TOKEN", "token-abc");
+    vi.stubEnv("WAAPI_GROUP_CHAT_ID", "1467733237@g.us");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("Bad Request", { status: 400 }),
+    );
+
+    const result = await sendMatchReportToWhatsAppGroup({ eventId: "evt-1" });
+
+    expect(result).toEqual({
+      sent: false,
+      reason: "upstream_error",
+      details: "Bad Request",
+    });
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures exception when fetch throws", async () => {
+    vi.stubEnv("WAAPI_NOTIFICATIONS_ENABLED", "true");
+    vi.stubEnv("WAAPI_INSTANCE_ID", "instance-123");
+    vi.stubEnv("WAAPI_API_TOKEN", "token-abc");
+    vi.stubEnv("WAAPI_GROUP_CHAT_ID", "1467733237@g.us");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network"));
+
+    const result = await sendMatchReportToWhatsAppGroup({ eventId: "evt-1" });
+
+    expect(result).toEqual({ sent: false, reason: "request_failed" });
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(
+      expect.any(Error),
+    );
+  });
+});

--- a/src/lib/services/waapiService.ts
+++ b/src/lib/services/waapiService.ts
@@ -1,0 +1,119 @@
+import * as Sentry from "@sentry/nextjs";
+
+type MatchReportNotificationInput = {
+  eventId: string;
+  opponentTeam?: string;
+  ourScore?: number;
+  opponentScore?: number;
+};
+
+type NotificationResult =
+  | { sent: true }
+  | {
+      sent: false;
+      reason:
+        | "disabled"
+        | "missing_config"
+        | "invalid_event_id"
+        | "upstream_error"
+        | "request_failed";
+      details?: string;
+    };
+
+type WaapiConfig = {
+  baseUrl: string;
+  instanceId: string;
+  apiToken: string;
+  groupChatId: string;
+  appUrl: string;
+};
+
+function getWaapiConfig(): WaapiConfig | null {
+  const baseUrl = (
+    process.env.WAAPI_BASE_URL || "https://waapi.app/api/v1"
+  ).trim();
+  const instanceId = (process.env.WAAPI_INSTANCE_ID || "").trim();
+  const apiToken = (process.env.WAAPI_API_TOKEN || "").trim();
+  const groupChatId = (process.env.WAAPI_GROUP_CHAT_ID || "").trim();
+  const appUrl = (process.env.APP_URL || "").trim().replace(/\/$/, "");
+  const enabled = process.env.WAAPI_NOTIFICATIONS_ENABLED === "true";
+
+  if (!enabled) return null;
+  if (!instanceId || !apiToken || !groupChatId || !appUrl) return null;
+
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ""),
+    instanceId,
+    apiToken,
+    groupChatId,
+    appUrl,
+  };
+}
+
+function buildMessage(
+  input: MatchReportNotificationInput,
+  reportUrl: string,
+): string {
+  const scorePart =
+    typeof input.ourScore === "number" &&
+    typeof input.opponentScore === "number"
+      ? ` (${input.ourScore}-${input.opponentScore})`
+      : "";
+  const opponentPart = input.opponentTeam ? ` tegen ${input.opponentTeam}` : "";
+  return `Wedstrijdverslag van De Rijn Heren 3${opponentPart} staat klaar${scorePart}. Lees het hier: ${reportUrl}`;
+}
+
+/**
+ * Sends a WhatsApp notification to the configured team group when a match report is generated.
+ *
+ * @param input - Match metadata used to build a user-friendly WhatsApp message and report deep link.
+ * @returns A structured result indicating whether the message was sent or skipped/failed.
+ */
+export async function sendMatchReportToWhatsAppGroup(
+  input: MatchReportNotificationInput,
+): Promise<NotificationResult> {
+  if (!input.eventId?.trim()) {
+    return { sent: false, reason: "invalid_event_id" };
+  }
+
+  const enabled = process.env.WAAPI_NOTIFICATIONS_ENABLED === "true";
+  if (!enabled) {
+    return { sent: false, reason: "disabled" };
+  }
+
+  const config = getWaapiConfig();
+  if (!config) {
+    return { sent: false, reason: "missing_config" };
+  }
+
+  const reportUrl = `${config.appUrl}/report/${encodeURIComponent(input.eventId)}`;
+  const message = buildMessage(input, reportUrl);
+  const endpoint = `${config.baseUrl}/instances/${encodeURIComponent(config.instanceId)}/client/action/send-message`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${config.apiToken}`,
+      },
+      body: JSON.stringify({
+        chatId: config.groupChatId,
+        message,
+      }),
+    });
+
+    if (!response.ok) {
+      const details = await response.text();
+      Sentry.captureException(
+        new Error(`WaAPI send-message failed: ${response.status} ${details}`),
+      );
+      return { sent: false, reason: "upstream_error", details };
+    }
+
+    return { sent: true };
+  } catch (error: unknown) {
+    Sentry.captureException(error);
+    return { sent: false, reason: "request_failed" };
+  }
+}

--- a/src/lib/services/waapiService.ts
+++ b/src/lib/services/waapiService.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
 
 type MatchReportNotificationInput = {
   eventId: string;
@@ -28,25 +29,25 @@ type WaapiConfig = {
   appUrl: string;
 };
 
-function getWaapiConfig(): WaapiConfig | null {
-  const baseUrl = (
-    process.env.WAAPI_BASE_URL || "https://waapi.app/api/v1"
-  ).trim();
-  const instanceId = (process.env.WAAPI_INSTANCE_ID || "").trim();
-  const apiToken = (process.env.WAAPI_API_TOKEN || "").trim();
-  const groupChatId = (process.env.WAAPI_GROUP_CHAT_ID || "").trim();
-  const appUrl = (process.env.APP_URL || "").trim().replace(/\/$/, "");
-  const enabled = process.env.WAAPI_NOTIFICATIONS_ENABLED === "true";
+const WaapiConfigSchema = z.object({
+  WAAPI_BASE_URL: z.string().trim().url().default("https://waapi.app/api/v1"),
+  WAAPI_INSTANCE_ID: z.string().trim().min(1),
+  WAAPI_API_TOKEN: z.string().trim().min(1),
+  WAAPI_GROUP_CHAT_ID: z.string().trim().min(1),
+  APP_URL: z.string().trim().url(),
+});
 
-  if (!enabled) return null;
-  if (!instanceId || !apiToken || !groupChatId || !appUrl) return null;
+function getWaapiConfig(): WaapiConfig | null {
+  const parsed = WaapiConfigSchema.safeParse(process.env);
+  if (!parsed.success) return null;
+  const env = parsed.data;
 
   return {
-    baseUrl: baseUrl.replace(/\/$/, ""),
-    instanceId,
-    apiToken,
-    groupChatId,
-    appUrl,
+    baseUrl: env.WAAPI_BASE_URL.replace(/\/$/, ""),
+    instanceId: env.WAAPI_INSTANCE_ID,
+    apiToken: env.WAAPI_API_TOKEN,
+    groupChatId: env.WAAPI_GROUP_CHAT_ID,
+    appUrl: env.APP_URL.replace(/\/$/, ""),
   };
 }
 
@@ -66,7 +67,7 @@ function buildMessage(
 /**
  * Sends a WhatsApp notification to the configured team group when a match report is generated.
  *
- * @param input - Match metadata used to build a user-friendly WhatsApp message and report deep link.
+ * @param input - Match metadata used to build a user-friendly WhatsApp message and report deep link. `input.eventId` must be a non-empty non-blank string; otherwise the function immediately returns `{ sent: false, reason: "invalid_event_id" }` and does not send a message.
  * @returns A structured result indicating whether the message was sent or skipped/failed.
  */
 export async function sendMatchReportToWhatsAppGroup(
@@ -89,6 +90,8 @@ export async function sendMatchReportToWhatsAppGroup(
   const reportUrl = `${config.appUrl}/report/${encodeURIComponent(input.eventId)}`;
   const message = buildMessage(input, reportUrl);
   const endpoint = `${config.baseUrl}/instances/${encodeURIComponent(config.instanceId)}/client/action/send-message`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
   try {
     const response = await fetch(endpoint, {
@@ -101,7 +104,9 @@ export async function sendMatchReportToWhatsAppGroup(
         chatId: config.groupChatId,
         message,
       }),
+      signal: controller.signal,
     });
+    clearTimeout(timeoutId);
 
     if (!response.ok) {
       const details = await response.text();
@@ -113,6 +118,16 @@ export async function sendMatchReportToWhatsAppGroup(
 
     return { sent: true };
   } catch (error: unknown) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === "AbortError") {
+      const timeoutError = new Error("WaAPI request timed out after 10s");
+      Sentry.captureException(timeoutError);
+      return {
+        sent: false,
+        reason: "request_failed",
+        details: "timeout",
+      };
+    }
     Sentry.captureException(error);
     return { sent: false, reason: "request_failed" };
   }


### PR DESCRIPTION
Send a WaAPI text message with a report deep link to the configured team group after a match report is saved. Keep notification failures non-blocking, capture errors in Sentry, and add unit tests for the new service.

## Summary

Describe the change.

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s):
  - Functional spec section(s):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now automatically send WhatsApp group notifications with a deep link upon generation; notifications are sent asynchronously.

* **Documentation**
  * Added configuration guide for WhatsApp notifications, including required environment variables and optional base URL.

* **Tests**
  * Added comprehensive test coverage for WhatsApp notification delivery scenarios, including success, disabled/missing config, invalid event IDs, and upstream/network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->