### PR TITLE
Pull request comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+## Learned User Preferences
+
+- Use `Sentry.captureException(error)` in catch blocks where exceptions are handled.
+- Instrument meaningful UI and API operations with `Sentry.startSpan`, including relevant attributes.
+- Import Sentry as `import * as Sentry from "@sentry/nextjs"` when using Sentry features.
+- When doing test coverage analysis, only use tests listed in `enabled_tests.txt`, use the OpenAPI spec for scope, and follow `coverage_report.md` format exactly.
+- GitHub CLI usage is allowed for GitHub-related tasks.
+
+## Learned Workspace Facts
+
+- The repository root contains a Next.js app and the primary technical docs live under `docs/`.
+- Cursor Cloud setup and troubleshooting guidance is documented in `docs/cursor-cloud-setup.md`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 - Every API route must include either Zod schemas or a docblock describing request/response.
 - Update the relevant `docs/tech/.../README.md` when changing a feature.
 - Run `npm run docs:generate` before merging.
+- For Cursor Cloud and local development setup notes, see `docs/cursor-cloud-setup.md`.
 
 ## Optional: Generate ERD locally
 

--- a/docs/cursor-cloud-setup.md
+++ b/docs/cursor-cloud-setup.md
@@ -1,0 +1,36 @@
+# Cursor Cloud local setup
+
+## Services overview
+
+H3-Teamy is a Next.js 16 (App Router / Turbopack) web app for managing a Dutch waterpolo team. The primary local service is the Next.js dev server on port 3000. PostgreSQL is required for database-backed features such as authentication, RSVP, and attendance.
+
+## Running the app locally
+
+1. Start PostgreSQL (cluster 16).
+2. Start the Next.js dev server with `npm run dev`.
+
+## Database notes
+
+- PostgreSQL 16 is expected for local development.
+- Set `DATABASE_URL` in `.env` to your local database connection string.
+- After installing dependencies, run `npx prisma generate` (without `--accelerate`) and `npx prisma db push` to sync the schema.
+- The repository `postinstall` script runs `prisma generate --accelerate`, which can fail locally; if needed, install with `npm install --legacy-peer-deps --ignore-scripts` and run Prisma generation manually.
+
+## Known local dependency issues
+
+- Prisma version mismatch can happen if `prisma` and `@prisma/client` major versions diverge; keep them aligned to the same major and preferably same version.
+- `@asteasolutions/zod-to-openapi` may require a different Zod major version than the app currently uses; use `--legacy-peer-deps` when needed for local installs.
+- `eslint` major-version mismatches with `eslint-config-next` can break `npm run lint`.
+- `react` and `react-dom` major-version mismatches can break component test runtime.
+
+## Lint, test, and build
+
+- Lint: `npm run lint`
+- Type check: `npx tsc --noEmit`
+- Tests: `npx vitest run`
+- Build: `npm run build`
+- Format check: `npm run format`
+
+## Environment variables
+
+For basic local development, configure `DATABASE_URL`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`. For optional integrations and extended environment variables, see `.cursor/rules/always.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites `AGENTS.md` to a strict format, moving setup and troubleshooting content into a new `docs/cursor-cloud-setup.md` file. This addresses review comments on PR #54, ensuring `AGENTS.md` contains only agent memory and operational guidance lives in the documentation. `docs/CONTRIBUTING.md` is updated to link to the new setup guide.

## Docs

- [x] Updated relevant feature docs (`AGENTS.md`, `docs/cursor-cloud-setup.md`, `docs/CONTRIBUTING.md`)
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s): `AGENTS.md`, `docs/cursor-cloud-setup.md`
  - Functional spec section(s):

<div><a href="https://cursor.com/agents/bc-9b674103-cd06-47e1-b178-000707242c9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b674103-cd06-47e1-b178-000707242c9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->