### PR TITLE
feat: Space Invaders mini-game under RSVP matches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+# CodeRabbit — zie https://docs.coderabbit.ai/reference/configuration
+# Docstring coverage: minimaal 80% (pre-merge check; zie docs/CONTRIBUTING.md)
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: nl-NL
+
+reviews:
+  profile: chill
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 80
+  finishing_touches:
+    docstrings:
+      enabled: true
+
+code_generation:
+  docstrings:
+    language: nl-NL
+    path_instructions:
+      - path: "src/**/*.{ts,tsx}"
+        instructions: |
+          Gebruik JSDoc (`/** ... */`) op geëxporteerde functies, hooks, types en React-componenten.
+          Voeg @param en @returns toe waar dat de API verduidelijkt; noem korte edge cases (clamping, null).

--- a/.cursor/rules/agentic-workflow.mdc
+++ b/.cursor/rules/agentic-workflow.mdc
@@ -141,6 +141,7 @@ This file defines the strict coding standards for all AI agents (Cursor, Opencod
   2. Wait for completion (`gh run watch --exit-status`).
   3. If failed, inspect failed logs, apply a focused fix, commit, and push.
   4. Repeat until required checks pass.
+  5. **PR review comments:** If you addressed inline review threads (CodeRabbit, humans, bots), **resolve those threads on GitHub** after the fix is on the PR branch so the UI shows them as done—not only “fixed in code.” Use GraphQL `resolveReviewThread` via `gh api graphql` (list `reviewThreads` on the PR, then mutate each `id` where `isResolved` is false), or resolve manually in the PR **Files changed** tab.
 - Keep each fix scoped to a single failure cause whenever possible.
 - Never bypass hooks (no `--no-verify`) to force progress.
 - If a failure appears flaky, retry once and report flake evidence.
@@ -148,3 +149,4 @@ This file defines the strict coding standards for all AI agents (Cursor, Opencod
   - current CI status
   - failure summary and applied fixes
   - PR URL once checks are green
+  - confirmation that addressed review threads were resolved (or N/A if none)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Docs
 
 on:
   push:
-    branches: [image]
+    branches: [main, image]
   pull_request:
-    branches: [image]
+    branches: [main, image]
 
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
@@ -35,3 +35,30 @@ jobs:
             docs/api
             docs/data
             docs/specs/functional.md
+
+  commit-docs:
+    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'image')
+    needs: build-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm install --no-audit --no-fund --legacy-peer-deps --ignore-scripts
+      - run: npx prisma generate
+      - run: npm run docs:generate
+      - name: Commit and push generated docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/_generated docs/api docs/specs/functional.md
+          git add docs/data 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "chore(docs): regenerate [skip ci]"
+            git push
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 ## Learned User Preferences
 
+- CodeRabbit docstring coverage is configured in `.coderabbit.yaml` (threshold **80%**); add JSDoc on exported `src/**/*.ts(x)` symbols and use CodeRabbit “Generate docstrings” when needed.
 - Use GitHub CLI for GitHub actions (PRs, checks, comments, merges) when possible.
 - Use the `loop-on-ci` workflow when asked: watch CI, inspect failures, apply focused fixes, and iterate until green. Also check for unresolved review comments (CodeRabbit, Cursor bot) and address them before considering the loop complete.
 - When syncing Vercel environment configuration, treat remote settings as source of truth and sync local values from remote.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - CodeRabbit docstring coverage is configured in `.coderabbit.yaml` (threshold **80%**); add JSDoc on exported `src/**/*.ts(x)` symbols and use CodeRabbit “Generate docstrings” when needed.
 - Use GitHub CLI for GitHub actions (PRs, checks, comments, merges) when possible.
-- Use the `loop-on-ci` workflow when asked: watch CI, inspect failures, apply focused fixes, and iterate until green. Also check for unresolved review comments (CodeRabbit, Cursor bot) and address them before considering the loop complete.
+- Use the `loop-on-ci` workflow when asked: watch CI, inspect failures, apply focused fixes, and iterate until green. Also check for unresolved review comments (CodeRabbit, Cursor bot) and address them before considering the loop complete; **after implementing those fixes, resolve the matching PR review threads** (e.g. GitHub GraphQL `resolveReviewThread` with `gh api graphql`) so the PR clearly shows the work as done.
 - When syncing Vercel environment configuration, treat remote settings as source of truth and sync local values from remote.
 - Use the GitHub CLI when GitHub information is needed.
 - Follow the provided Sentry instrumentation patterns for Next.js projects.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Docs Contribution Guide
 
+## CodeRabbit & docstrings (min. 80%)
+
+- Het repository bevat [`.coderabbit.yaml`](../.coderabbit.yaml) met **pre-merge docstring coverage**: drempel **80%**, modus **warning** (zichtbaar in de PR-check totdat de dekking klopt).
+- **Geëxporteerde** functies, hooks, types en componenten in `src/**/*.{ts,tsx}`: voorzie van zinvolle JSDoc (`/** ... */`), liefst met `@param` / `@returns` waar dat helpt.
+- Ontbreekt er documentatie: gebruik in de PR walkthrough **Generate docstrings** of het commando `@coderabbitai generate docstrings` (zie [CodeRabbit docstrings](https://docs.coderabbit.ai/finishing-touches/docstrings/)).
+
+## API & feature docs
+
 - Every API route must include either Zod schemas or a docblock describing request/response.
 - Update the relevant `docs/tech/.../README.md` when changing a feature.
 - Run `npm run docs:generate` before merging.

--- a/docs/_generated/routes.md
+++ b/docs/_generated/routes.md
@@ -1,0 +1,5 @@
+# Routes Inventory
+
+## API Routes
+
+## Pages

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,170 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "H3 Teamy API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": ""
+    }
+  ],
+  "components": {
+    "schemas": {
+      "PasswordResetRequestBody": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": ["email"]
+      },
+      "PasswordResetRequestResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": ["ok"]
+      },
+      "PasswordResetConfirmBody": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "minLength": 1
+          },
+          "newPassword": {
+            "type": "string",
+            "minLength": 8
+          }
+        },
+        "required": ["token", "newPassword"]
+      },
+      "PasswordResetConfirmResponse": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "ok": {
+                "type": "boolean"
+              }
+            },
+            "required": ["ok"]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              }
+            },
+            "required": ["error"]
+          }
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/api/auth/password/reset-request": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                },
+                "required": ["email"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["ok"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/password/reset-confirm": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "newPassword": {
+                    "type": "string",
+                    "minLength": 8
+                  }
+                },
+                "required": ["token", "newPassword"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["ok"]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["error"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    }
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -341,6 +341,21 @@ h3 {
 .grow {
   flex: 1;
 }
+
+/* Safe-area (PWA / notches) — gebruikt door Space Invaders overlay */
+.pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+.pb-safe-bottom-bar {
+  padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+}
+.pl-safe {
+  padding-left: env(safe-area-inset-left);
+}
+.pr-safe {
+  padding-right: env(safe-area-inset-right);
+}
+
 .muted {
   color: var(--muted);
 }

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -5,6 +5,7 @@ import type { TeamEvent, RsvpStatus } from "../types";
 import GenerateReportButton from "./GenerateReportButton";
 import ReportPreview from "./ReportPreview";
 import MvpVoteButton from "./MvpVoteButton";
+import SpaceInvadersLauncher from "./spaceInvaders/SpaceInvadersLauncher";
 
 type Props = { events: TeamEvent[] };
 
@@ -366,6 +367,7 @@ export default function EventList({ events }: Props) {
           </div>
         );
       })}
+      <SpaceInvadersLauncher />
       {grouped.length === 0 ? (
         <div className="muted">No recent or upcoming matches.</div>
       ) : null}

--- a/src/components/spaceInvaders/SpaceInvadersGame.test.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { createInitialState } from "@/lib/spaceInvaders/game";
+import SpaceInvadersGame from "./SpaceInvadersGame";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("SpaceInvadersGame", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    let rafCount = 0;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (cb: FrameRequestCallback): number => {
+        rafCount += 1;
+        if (rafCount <= 12) {
+          queueMicrotask(() => cb(performance.now() + rafCount * 16));
+        }
+        return rafCount;
+      },
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const ctxStub = {
+      fillRect: vi.fn(),
+      clearRect: vi.fn(),
+      setTransform: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      createLinearGradient: vi.fn(() => ({
+        addColorStop: vi.fn(),
+      })),
+      fillStyle: "",
+      strokeStyle: "",
+      lineWidth: 0,
+      shadowBlur: 0,
+      shadowColor: "",
+      font: "",
+      textAlign: "",
+      textBaseline: "",
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      closePath: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      fillText: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+    };
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      ctxStub as unknown as CanvasRenderingContext2D,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders dialog overlay with HUD after mount", async () => {
+    const onClose = vi.fn();
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Space Invaders" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Score/)).toBeInTheDocument();
+    expect(screen.getByText("Pauze")).toBeInTheDocument();
+  });
+
+  it("toggles pause label", async () => {
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Pauze"));
+    expect(screen.getByText("Hervatten")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Hervatten"));
+    expect(screen.getByText("Pauze")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Sluiten clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={onClose}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Sluiten"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/spaceInvaders/SpaceInvadersGame.test.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom";
 import { createInitialState } from "@/lib/spaceInvaders/game";
+import * as SpaceStorage from "@/lib/spaceInvaders/storage";
 import SpaceInvadersGame from "./SpaceInvadersGame";
 
 vi.mock("@sentry/nextjs", () => ({
@@ -10,11 +11,12 @@ vi.mock("@sentry/nextjs", () => ({
 
 describe("SpaceInvadersGame", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       configurable: true,
       value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
+        matches: true,
         media: query,
         onchange: null,
         addListener: vi.fn(),
@@ -120,5 +122,68 @@ describe("SpaceInvadersGame", () => {
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Sluiten"));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={onClose}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.keyDown(document, { code: "Escape", key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls saveGameToStorage and onClose when Opslaan en sluiten", async () => {
+    const saveSpy = vi
+      .spyOn(SpaceStorage, "saveGameToStorage")
+      .mockImplementation(() => {});
+    const onClose = vi.fn();
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={onClose}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Opslaan en sluiten"));
+    expect(saveSpy).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("touch left button sets move input via pointer handlers", async () => {
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    const left = screen.getByText("← Links");
+    fireEvent.pointerDown(left);
+    fireEvent.pointerUp(left);
+  });
+
+  it("registers gameover score once via addHighScore", async () => {
+    const addSpy = vi.spyOn(SpaceStorage, "addHighScore").mockReturnValue([]);
+    const clearSpy = vi
+      .spyOn(SpaceStorage, "clearSave")
+      .mockImplementation(() => {});
+    const gameOver = {
+      ...createInitialState(),
+      status: "gameover" as const,
+      lives: 0,
+      score: 42,
+      wave: 3,
+    };
+    render(<SpaceInvadersGame initialState={gameOver} onClose={vi.fn()} />);
+    await waitFor(() => expect(addSpy).toHaveBeenCalled());
+    expect(addSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ score: 42, wave: 3 }),
+    );
+    expect(clearSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import type { CSSProperties } from "react";
 import {
   useCallback,
   useEffect,
@@ -9,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ReactPortal } from "react";
 import { createPortal } from "react-dom";
 import { GAME_H, GAME_W } from "@/lib/spaceInvaders/constants";
 import { drawGame } from "@/lib/spaceInvaders/draw";
@@ -28,27 +28,25 @@ type Props = {
   onClose: () => void;
 };
 
-/** Voorkomt tekstselectie / iOS callout bij lang indrukken op game-knoppen */
-const touchGameButtonStyle: CSSProperties = {
-  minHeight: 58,
-  touchAction: "manipulation",
-  fontSize: 18,
-  fontWeight: 600,
-  borderRadius: 10,
-  userSelect: "none",
-  WebkitUserSelect: "none",
-  WebkitTouchCallout: "none",
-};
+const touchGameButtonClass =
+  "min-h-[58px] touch-manipulation text-lg font-semibold rounded-[10px] select-none [-webkit-user-select:none] [-webkit-touch-callout:none]";
 
 const weaponLabel = (lvl: number) => {
   if (lvl <= 0) return "Basis";
   if (lvl === 1) return "Dubbel";
-  if (lvl === 2) return "Triple";
-  if (lvl === 3) return "Salvo";
+  if (lvl === 2) return "Drievoudig";
+  if (lvl === 3) return "Vijfschot";
   return "Storm";
 };
 
-export default function SpaceInvadersGame({ initialState, onClose }: Props) {
+/**
+ * Volledige Space Invaders-sessie in een modal overlay: canvas, HUD, touch- en toetsenbordbediening, opslag en highscores.
+ */
+export default function SpaceInvadersGame({
+  initialState,
+  onClose,
+}: Props): ReactPortal | null {
+  const dialogRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const stateRef = useRef<GameState>(initialState);
   const inputRef = useRef<InputRef>({
@@ -86,6 +84,11 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
   }, []);
 
   useEffect(() => {
+    if (!mounted) return;
+    dialogRef.current?.focus();
+  }, [mounted]);
+
+  useEffect(() => {
     const q = window.matchMedia("(max-width: 768px), (pointer: coarse)");
     const apply = () => setShowTouchBar(q.matches);
     apply();
@@ -97,8 +100,8 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     if (!showTouchBar) return;
     try {
       if (!localStorage.getItem(TOUCH_TIP_KEY)) setShowFirstTouchTip(true);
-    } catch {
-      /* ignore */
+    } catch (error: unknown) {
+      Sentry.captureException(error);
     }
   }, [showTouchBar]);
 
@@ -190,8 +193,8 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
         if (cur.status === "playing" || cur.status === "wave_clear") {
           try {
             stateRef.current = tick(cur, dt, inputRef.current);
-          } catch (e) {
-            Sentry.captureException(e);
+          } catch (error: unknown) {
+            Sentry.captureException(error);
           }
         }
         syncHud(stateRef.current);
@@ -208,8 +211,8 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
   const dismissTouchTip = useCallback(() => {
     try {
       localStorage.setItem(TOUCH_TIP_KEY, "1");
-    } catch {
-      /* ignore */
+    } catch (error: unknown) {
+      Sentry.captureException(error);
     }
     setShowFirstTouchTip(false);
   }, []);
@@ -296,49 +299,22 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
 
   const overlay = (
     <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 3200,
-        minHeight: "100dvh",
-        background: "#010409",
-        display: "flex",
-        flexDirection: "column",
-        paddingTop: "env(safe-area-inset-top)",
-        paddingBottom: "calc(76px + env(safe-area-inset-bottom, 0px))",
-        paddingLeft: "env(safe-area-inset-left)",
-        paddingRight: "env(safe-area-inset-right)",
-        touchAction: "none",
-      }}
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Space Invaders"
+      tabIndex={-1}
+      className="fixed inset-0 z-[3200] flex min-h-dvh flex-col touch-none bg-[#010409] pt-[env(safe-area-inset-top)] pb-[calc(76px+env(safe-area-inset-bottom,0px))] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
     >
-      <div
-        style={{
-          flexShrink: 0,
-          padding: "8px 12px",
-          display: "flex",
-          flexWrap: "wrap",
-          gap: 8,
-          alignItems: "center",
-          justifyContent: "space-between",
-          borderBottom: "1px solid #21262d",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-            gap: 10,
-            fontSize: 14,
-            color: "#c9d1d9",
-          }}
-        >
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-[#21262d] px-3 py-2">
+        <div className="flex flex-wrap gap-2.5 text-sm text-[#c9d1d9]">
           <span>Score {hud.score}</span>
           <span>Golf {hud.wave}</span>
           <span>Levens {hud.lives}</span>
           <span>Wapen {weaponLabel(hud.weaponLevel)}</span>
           <span>Schild {hud.shieldCharges}</span>
         </div>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        <div className="flex flex-wrap gap-2">
           <button
             type="button"
             onClick={pauseToggle}
@@ -360,46 +336,24 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
         </div>
       </div>
 
-      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+      <div className="relative min-h-0 flex-1">
         <canvas
           ref={canvasRef}
-          style={{
-            display: "block",
-            width: "100%",
-            height: "100%",
-            touchAction: "none",
-          }}
+          className="block h-full w-full touch-none"
           aria-label="Space Invaders speelveld"
         />
       </div>
 
       {showTouchBar && lowViewport ? (
-        <p
-          className="muted"
-          style={{
-            textAlign: "center",
-            fontSize: 11,
-            margin: "4px 8px 0",
-            flexShrink: 0,
-          }}
-        >
+        <p className="muted mx-2 mt-1 mb-0 shrink-0 text-center text-[11px]">
           Laag scherm — draai eventueel voor meer ruimte; gebruik de knoppen
           onderaan.
         </p>
       ) : null}
 
       {showTouchBar && showFirstTouchTip ? (
-        <div
-          style={{
-            flexShrink: 0,
-            margin: "8px 12px 0",
-            padding: "10px 12px",
-            borderRadius: 8,
-            background: "#21262d",
-            border: "1px solid #30363d",
-          }}
-        >
-          <p style={{ margin: "0 0 8px", fontSize: 14, color: "#c9d1d9" }}>
+        <div className="mx-3 mt-2 shrink-0 rounded-lg border border-[#30363d] bg-[#21262d] px-3 py-2.5">
+          <p className="mb-2 text-sm text-[#c9d1d9]">
             Sleepstand: gebruik de grote knoppen hieronder (boven de menubalk)
             om te bewegen en te schieten.
           </p>
@@ -410,23 +364,10 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
       ) : null}
 
       {showTouchBar ? (
-        <div
-          style={{
-            flexShrink: 0,
-            padding: "14px 14px 10px",
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr 1fr",
-            gap: 14,
-            borderTop: "1px solid #30363d",
-            background: "linear-gradient(180deg, #0d1117 0%, #010409 100%)",
-            userSelect: "none",
-            WebkitUserSelect: "none",
-            WebkitTouchCallout: "none",
-          }}
-        >
+        <div className="grid shrink-0 grid-cols-3 gap-3.5 border-t border-[#30363d] bg-gradient-to-b from-[#0d1117] to-[#010409] px-3.5 pt-3.5 pb-2.5 select-none [-webkit-user-select:none] [-webkit-touch-callout:none]">
           <button
             type="button"
-            style={touchGameButtonStyle}
+            className={touchGameButtonClass}
             onPointerDown={(e) => {
               e.preventDefault();
               setMoveLeft(true);
@@ -440,7 +381,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           </button>
           <button
             type="button"
-            style={touchGameButtonStyle}
+            className={touchGameButtonClass}
             onPointerDown={(e) => {
               e.preventDefault();
               setFire(true);
@@ -454,7 +395,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           </button>
           <button
             type="button"
-            style={touchGameButtonStyle}
+            className={touchGameButtonClass}
             onPointerDown={(e) => {
               e.preventDefault();
               setMoveRight(true);
@@ -468,14 +409,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           </button>
         </div>
       ) : null}
-      <p
-        className="muted"
-        style={{
-          textAlign: "center",
-          fontSize: 12,
-          margin: "0 8px 8px",
-        }}
-      >
+      <p className="muted mx-2 mb-2 mt-0 shrink-0 text-center text-xs">
         {showTouchBar
           ? "Ook: pijltoetsen of A/D, spatie schieten, P of Esc pauze."
           : "Toetsenbord: ← → of A D, spatie schieten, P of Esc pauze."}

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { GAME_H, GAME_W } from "@/lib/spaceInvaders/constants";
+import { drawGame } from "@/lib/spaceInvaders/draw";
+import { createInitialState, tick } from "@/lib/spaceInvaders/game";
+import {
+  addHighScore,
+  clearSave,
+  saveGameToStorage,
+} from "@/lib/spaceInvaders/storage";
+import type { GameState } from "@/lib/spaceInvaders/types";
+
+type InputRef = { moveLeft: boolean; moveRight: boolean; fire: boolean };
+
+type Props = {
+  initialState: GameState;
+  onClose: () => void;
+};
+
+const weaponLabel = (lvl: number) =>
+  lvl <= 0 ? "Basis" : lvl === 1 ? "Dubbel" : "Triple";
+
+export default function SpaceInvadersGame({ initialState, onClose }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const stateRef = useRef<GameState>(initialState);
+  const inputRef = useRef<InputRef>({
+    moveLeft: false,
+    moveRight: false,
+    fire: false,
+  });
+  const lastTsRef = useRef<number | null>(null);
+  const rafRef = useRef<number>(0);
+  const [hud, setHud] = useState({
+    score: initialState.score,
+    wave: initialState.wave,
+    lives: initialState.lives,
+    weaponLevel: initialState.weaponLevel,
+    status: initialState.status,
+  });
+  const hudSnapRef = useRef({
+    score: initialState.score,
+    wave: initialState.wave,
+    lives: initialState.lives,
+    weaponLevel: initialState.weaponLevel,
+    status: initialState.status,
+  });
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const syncHud = useCallback((s: GameState) => {
+    const prev = hudSnapRef.current;
+    if (
+      prev.score === s.score &&
+      prev.wave === s.wave &&
+      prev.lives === s.lives &&
+      prev.weaponLevel === s.weaponLevel &&
+      prev.status === s.status
+    ) {
+      return;
+    }
+    const next = {
+      score: s.score,
+      wave: s.wave,
+      lives: s.lives,
+      weaponLevel: s.weaponLevel,
+      status: s.status,
+    };
+    hudSnapRef.current = next;
+    setHud(next);
+  }, []);
+
+  const paint = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const rect = canvas.getBoundingClientRect();
+    const dpr =
+      typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+    const w = rect.width;
+    const h = rect.height;
+    if (
+      canvas.width !== Math.round(w * dpr) ||
+      canvas.height !== Math.round(h * dpr)
+    ) {
+      canvas.width = Math.round(w * dpr);
+      canvas.height = Math.round(h * dpr);
+    }
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const scale = Math.min(w / GAME_W, h / GAME_H);
+    const ox = (w - GAME_W * scale) / 2;
+    const oy = (h - GAME_H * scale) / 2;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.translate(ox, oy);
+    ctx.scale(scale, scale);
+    drawGame(ctx, stateRef.current);
+  }, []);
+
+  useLayoutEffect(() => {
+    paint();
+  }, [paint]);
+
+  useEffect(() => {
+    const onResize = () => paint();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [paint]);
+
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    const loop = (ts: number) => {
+      const last = lastTsRef.current;
+      lastTsRef.current = ts;
+      if (last != null) {
+        const dt = Math.min((ts - last) / 1000, 0.064);
+        const cur = stateRef.current;
+        if (cur.status === "playing") {
+          try {
+            stateRef.current = tick(cur, dt, inputRef.current);
+          } catch (e) {
+            Sentry.captureException(e);
+          }
+        }
+        syncHud(stateRef.current);
+      }
+      paint();
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [paint, syncHud]);
+
+  const pauseToggle = useCallback(() => {
+    const s = stateRef.current;
+    if (s.status === "gameover") return;
+    if (s.status === "playing") {
+      stateRef.current = { ...s, status: "paused" };
+    } else {
+      stateRef.current = { ...s, status: "playing" };
+    }
+    syncHud(stateRef.current);
+  }, [syncHud]);
+
+  const saveAndExit = useCallback(() => {
+    saveGameToStorage(stateRef.current);
+    onClose();
+  }, [onClose]);
+
+  const restart = useCallback(() => {
+    stateRef.current = createInitialState();
+    clearSave();
+    syncHud(stateRef.current);
+  }, [syncHud]);
+
+  const onGameOverHandled = useRef(false);
+  useEffect(() => {
+    if (hud.status === "gameover" && !onGameOverHandled.current) {
+      onGameOverHandled.current = true;
+      addHighScore({
+        score: stateRef.current.score,
+        wave: stateRef.current.wave,
+        at: new Date().toISOString(),
+      });
+      clearSave();
+    }
+    if (hud.status !== "gameover") onGameOverHandled.current = false;
+  }, [hud.status]);
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.code === "ArrowLeft" || e.code === "KeyA") {
+        inputRef.current.moveLeft = true;
+        e.preventDefault();
+      }
+      if (e.code === "ArrowRight" || e.code === "KeyD") {
+        inputRef.current.moveRight = true;
+        e.preventDefault();
+      }
+      if (e.code === "Space") {
+        inputRef.current.fire = true;
+        e.preventDefault();
+      }
+      if (e.code === "Escape" || e.code === "KeyP") {
+        pauseToggle();
+        e.preventDefault();
+      }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code === "ArrowLeft" || e.code === "KeyA")
+        inputRef.current.moveLeft = false;
+      if (e.code === "ArrowRight" || e.code === "KeyD")
+        inputRef.current.moveRight = false;
+      if (e.code === "Space") inputRef.current.fire = false;
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, [pauseToggle]);
+
+  const setMoveLeft = (v: boolean) => {
+    inputRef.current.moveLeft = v;
+  };
+  const setMoveRight = (v: boolean) => {
+    inputRef.current.moveRight = v;
+  };
+  const setFire = (v: boolean) => {
+    inputRef.current.fire = v;
+  };
+
+  const overlay = (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 200,
+        background: "#010409",
+        display: "flex",
+        flexDirection: "column",
+        paddingTop: "env(safe-area-inset-top)",
+        paddingBottom: "env(safe-area-inset-bottom)",
+        paddingLeft: "env(safe-area-inset-left)",
+        paddingRight: "env(safe-area-inset-right)",
+        touchAction: "none",
+      }}
+    >
+      <div
+        style={{
+          flexShrink: 0,
+          padding: "8px 12px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 8,
+          alignItems: "center",
+          justifyContent: "space-between",
+          borderBottom: "1px solid #21262d",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 10,
+            fontSize: 14,
+            color: "#c9d1d9",
+          }}
+        >
+          <span>Score {hud.score}</span>
+          <span>Golf {hud.wave}</span>
+          <span>Levens {hud.lives}</span>
+          <span>Wapen {weaponLabel(hud.weaponLevel)}</span>
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          <button type="button" onClick={pauseToggle}>
+            {hud.status === "paused" ? "Hervatten" : "Pauze"}
+          </button>
+          <button type="button" onClick={saveAndExit}>
+            Opslaan en sluiten
+          </button>
+          <button type="button" onClick={onClose}>
+            Sluiten
+          </button>
+          {hud.status === "gameover" ? (
+            <button type="button" onClick={restart}>
+              Opnieuw
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+        <canvas
+          ref={canvasRef}
+          style={{
+            display: "block",
+            width: "100%",
+            height: "100%",
+            touchAction: "none",
+          }}
+          aria-label="Space Invaders speelveld"
+        />
+      </div>
+
+      <div
+        style={{
+          flexShrink: 0,
+          padding: "10px 12px",
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: 10,
+          borderTop: "1px solid #21262d",
+        }}
+      >
+        <button
+          type="button"
+          style={{
+            minHeight: 48,
+            touchAction: "manipulation",
+            fontSize: 16,
+          }}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            setMoveLeft(true);
+          }}
+          onPointerUp={() => setMoveLeft(false)}
+          onPointerLeave={() => setMoveLeft(false)}
+          onPointerCancel={() => setMoveLeft(false)}
+        >
+          ← Links
+        </button>
+        <button
+          type="button"
+          style={{
+            minHeight: 48,
+            touchAction: "manipulation",
+            fontSize: 16,
+          }}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            setFire(true);
+          }}
+          onPointerUp={() => setFire(false)}
+          onPointerLeave={() => setFire(false)}
+          onPointerCancel={() => setFire(false)}
+        >
+          Vuur
+        </button>
+        <button
+          type="button"
+          style={{
+            minHeight: 48,
+            touchAction: "manipulation",
+            fontSize: 16,
+          }}
+          onPointerDown={(e) => {
+            e.preventDefault();
+            setMoveRight(true);
+          }}
+          onPointerUp={() => setMoveRight(false)}
+          onPointerLeave={() => setMoveRight(false)}
+          onPointerCancel={() => setMoveRight(false)}
+        >
+          Rechts →
+        </button>
+      </div>
+      <p
+        className="muted"
+        style={{
+          textAlign: "center",
+          fontSize: 12,
+          margin: "0 8px 8px",
+        }}
+      >
+        Toetsenbord: ← → of A D, spatie schieten, P of Esc pauze
+      </p>
+    </div>
+  );
+
+  if (!mounted) return null;
+  return createPortal(overlay, document.body);
+}

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -13,6 +13,7 @@ import { GAME_H, GAME_W } from "@/lib/spaceInvaders/constants";
 import { drawGame } from "@/lib/spaceInvaders/draw";
 import { createInitialState, tick } from "@/lib/spaceInvaders/game";
 import {
+  TOUCH_TIP_KEY,
   addHighScore,
   clearSave,
   saveGameToStorage,
@@ -54,9 +55,37 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     status: initialState.status,
   });
   const [mounted, setMounted] = useState(false);
+  /** Mobile-first: show thumb controls unless wide + fine pointer */
+  const [showTouchBar, setShowTouchBar] = useState(true);
+  const [showFirstTouchTip, setShowFirstTouchTip] = useState(false);
+  const [lowViewport, setLowViewport] = useState(false);
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const q = window.matchMedia("(max-width: 768px), (pointer: coarse)");
+    const apply = () => setShowTouchBar(q.matches);
+    apply();
+    q.addEventListener("change", apply);
+    return () => q.removeEventListener("change", apply);
+  }, []);
+
+  useEffect(() => {
+    if (!showTouchBar) return;
+    try {
+      if (!localStorage.getItem(TOUCH_TIP_KEY)) setShowFirstTouchTip(true);
+    } catch {
+      /* ignore */
+    }
+  }, [showTouchBar]);
+
+  useEffect(() => {
+    const check = () => setLowViewport(window.innerHeight < 460);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
   }, []);
 
   const syncHud = useCallback((s: GameState) => {
@@ -134,7 +163,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
       if (last != null) {
         const dt = Math.min((ts - last) / 1000, 0.064);
         const cur = stateRef.current;
-        if (cur.status === "playing") {
+        if (cur.status === "playing" || cur.status === "wave_clear") {
           try {
             stateRef.current = tick(cur, dt, inputRef.current);
           } catch (e) {
@@ -152,9 +181,18 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     };
   }, [paint, syncHud]);
 
+  const dismissTouchTip = useCallback(() => {
+    try {
+      localStorage.setItem(TOUCH_TIP_KEY, "1");
+    } catch {
+      /* ignore */
+    }
+    setShowFirstTouchTip(false);
+  }, []);
+
   const pauseToggle = useCallback(() => {
     const s = stateRef.current;
-    if (s.status === "gameover") return;
+    if (s.status === "gameover" || s.status === "wave_clear") return;
     if (s.status === "playing") {
       stateRef.current = { ...s, status: "paused" };
     } else {
@@ -238,6 +276,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
         position: "fixed",
         inset: 0,
         zIndex: 200,
+        minHeight: "100dvh",
         background: "#010409",
         display: "flex",
         flexDirection: "column",
@@ -275,7 +314,11 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           <span>Wapen {weaponLabel(hud.weaponLevel)}</span>
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-          <button type="button" onClick={pauseToggle}>
+          <button
+            type="button"
+            onClick={pauseToggle}
+            disabled={hud.status === "wave_clear"}
+          >
             {hud.status === "paused" ? "Hervatten" : "Pauze"}
           </button>
           <button type="button" onClick={saveAndExit}>
@@ -305,68 +348,106 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
         />
       </div>
 
-      <div
-        style={{
-          flexShrink: 0,
-          padding: "10px 12px",
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
-          gap: 10,
-          borderTop: "1px solid #21262d",
-        }}
-      >
-        <button
-          type="button"
+      {showTouchBar && lowViewport ? (
+        <p
+          className="muted"
           style={{
-            minHeight: 48,
-            touchAction: "manipulation",
-            fontSize: 16,
+            textAlign: "center",
+            fontSize: 11,
+            margin: "4px 8px 0",
+            flexShrink: 0,
           }}
-          onPointerDown={(e) => {
-            e.preventDefault();
-            setMoveLeft(true);
-          }}
-          onPointerUp={() => setMoveLeft(false)}
-          onPointerLeave={() => setMoveLeft(false)}
-          onPointerCancel={() => setMoveLeft(false)}
         >
-          ← Links
-        </button>
-        <button
-          type="button"
+          Laag scherm — draai eventueel voor meer ruimte; gebruik de knoppen
+          onderaan.
+        </p>
+      ) : null}
+
+      {showTouchBar && showFirstTouchTip ? (
+        <div
           style={{
-            minHeight: 48,
-            touchAction: "manipulation",
-            fontSize: 16,
+            flexShrink: 0,
+            margin: "8px 12px 0",
+            padding: "10px 12px",
+            borderRadius: 8,
+            background: "#21262d",
+            border: "1px solid #30363d",
           }}
-          onPointerDown={(e) => {
-            e.preventDefault();
-            setFire(true);
-          }}
-          onPointerUp={() => setFire(false)}
-          onPointerLeave={() => setFire(false)}
-          onPointerCancel={() => setFire(false)}
         >
-          Vuur
-        </button>
-        <button
-          type="button"
+          <p style={{ margin: "0 0 8px", fontSize: 14, color: "#c9d1d9" }}>
+            Sleepstand: gebruik de knoppen onderaan om te bewegen en te
+            schieten.
+          </p>
+          <button type="button" onClick={dismissTouchTip}>
+            OK
+          </button>
+        </div>
+      ) : null}
+
+      {showTouchBar ? (
+        <div
           style={{
-            minHeight: 48,
-            touchAction: "manipulation",
-            fontSize: 16,
+            flexShrink: 0,
+            padding: "10px 12px",
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr 1fr",
+            gap: 10,
+            borderTop: "1px solid #21262d",
           }}
-          onPointerDown={(e) => {
-            e.preventDefault();
-            setMoveRight(true);
-          }}
-          onPointerUp={() => setMoveRight(false)}
-          onPointerLeave={() => setMoveRight(false)}
-          onPointerCancel={() => setMoveRight(false)}
         >
-          Rechts →
-        </button>
-      </div>
+          <button
+            type="button"
+            style={{
+              minHeight: 48,
+              touchAction: "manipulation",
+              fontSize: 16,
+            }}
+            onPointerDown={(e) => {
+              e.preventDefault();
+              setMoveLeft(true);
+            }}
+            onPointerUp={() => setMoveLeft(false)}
+            onPointerLeave={() => setMoveLeft(false)}
+            onPointerCancel={() => setMoveLeft(false)}
+          >
+            ← Links
+          </button>
+          <button
+            type="button"
+            style={{
+              minHeight: 48,
+              touchAction: "manipulation",
+              fontSize: 16,
+            }}
+            onPointerDown={(e) => {
+              e.preventDefault();
+              setFire(true);
+            }}
+            onPointerUp={() => setFire(false)}
+            onPointerLeave={() => setFire(false)}
+            onPointerCancel={() => setFire(false)}
+          >
+            Vuur
+          </button>
+          <button
+            type="button"
+            style={{
+              minHeight: 48,
+              touchAction: "manipulation",
+              fontSize: 16,
+            }}
+            onPointerDown={(e) => {
+              e.preventDefault();
+              setMoveRight(true);
+            }}
+            onPointerUp={() => setMoveRight(false)}
+            onPointerLeave={() => setMoveRight(false)}
+            onPointerCancel={() => setMoveRight(false)}
+          >
+            Rechts →
+          </button>
+        </div>
+      ) : null}
       <p
         className="muted"
         style={{
@@ -375,7 +456,9 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           margin: "0 8px 8px",
         }}
       >
-        Toetsenbord: ← → of A D, spatie schieten, P of Esc pauze
+        {showTouchBar
+          ? "Ook: pijltoetsen of A/D, spatie schieten, P of Esc pauze."
+          : "Toetsenbord: ← → of A D, spatie schieten, P of Esc pauze."}
       </p>
     </div>
   );

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import type { CSSProperties } from "react";
 import {
   useCallback,
   useEffect,
@@ -25,6 +26,18 @@ type InputRef = { moveLeft: boolean; moveRight: boolean; fire: boolean };
 type Props = {
   initialState: GameState;
   onClose: () => void;
+};
+
+/** Voorkomt tekstselectie / iOS callout bij lang indrukken op game-knoppen */
+const touchGameButtonStyle: CSSProperties = {
+  minHeight: 58,
+  touchAction: "manipulation",
+  fontSize: 18,
+  fontWeight: 600,
+  borderRadius: 10,
+  userSelect: "none",
+  WebkitUserSelect: "none",
+  WebkitTouchCallout: "none",
 };
 
 const weaponLabel = (lvl: number) => {
@@ -406,17 +419,14 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
             gap: 14,
             borderTop: "1px solid #30363d",
             background: "linear-gradient(180deg, #0d1117 0%, #010409 100%)",
+            userSelect: "none",
+            WebkitUserSelect: "none",
+            WebkitTouchCallout: "none",
           }}
         >
           <button
             type="button"
-            style={{
-              minHeight: 58,
-              touchAction: "manipulation",
-              fontSize: 18,
-              fontWeight: 600,
-              borderRadius: 10,
-            }}
+            style={touchGameButtonStyle}
             onPointerDown={(e) => {
               e.preventDefault();
               setMoveLeft(true);
@@ -424,18 +434,13 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
             onPointerUp={() => setMoveLeft(false)}
             onPointerLeave={() => setMoveLeft(false)}
             onPointerCancel={() => setMoveLeft(false)}
+            onContextMenu={(e) => e.preventDefault()}
           >
             ← Links
           </button>
           <button
             type="button"
-            style={{
-              minHeight: 58,
-              touchAction: "manipulation",
-              fontSize: 18,
-              fontWeight: 600,
-              borderRadius: 10,
-            }}
+            style={touchGameButtonStyle}
             onPointerDown={(e) => {
               e.preventDefault();
               setFire(true);
@@ -443,18 +448,13 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
             onPointerUp={() => setFire(false)}
             onPointerLeave={() => setFire(false)}
             onPointerCancel={() => setFire(false)}
+            onContextMenu={(e) => e.preventDefault()}
           >
             Vuur
           </button>
           <button
             type="button"
-            style={{
-              minHeight: 58,
-              touchAction: "manipulation",
-              fontSize: 18,
-              fontWeight: 600,
-              borderRadius: 10,
-            }}
+            style={touchGameButtonStyle}
             onPointerDown={(e) => {
               e.preventDefault();
               setMoveRight(true);
@@ -462,6 +462,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
             onPointerUp={() => setMoveRight(false)}
             onPointerLeave={() => setMoveRight(false)}
             onPointerCancel={() => setMoveRight(false)}
+            onContextMenu={(e) => e.preventDefault()}
           >
             Rechts →
           </button>

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -27,8 +27,13 @@ type Props = {
   onClose: () => void;
 };
 
-const weaponLabel = (lvl: number) =>
-  lvl <= 0 ? "Basis" : lvl === 1 ? "Dubbel" : "Triple";
+const weaponLabel = (lvl: number) => {
+  if (lvl <= 0) return "Basis";
+  if (lvl === 1) return "Dubbel";
+  if (lvl === 2) return "Triple";
+  if (lvl === 3) return "Salvo";
+  return "Storm";
+};
 
 export default function SpaceInvadersGame({ initialState, onClose }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -45,6 +50,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     wave: initialState.wave,
     lives: initialState.lives,
     weaponLevel: initialState.weaponLevel,
+    shieldCharges: initialState.shieldCharges,
     status: initialState.status,
   });
   const hudSnapRef = useRef({
@@ -52,8 +58,10 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     wave: initialState.wave,
     lives: initialState.lives,
     weaponLevel: initialState.weaponLevel,
+    shieldCharges: initialState.shieldCharges,
     status: initialState.status,
   });
+  const drawTimeRef = useRef(0);
   const [mounted, setMounted] = useState(false);
   /** Mobile-first: show thumb controls unless wide + fine pointer */
   const [showTouchBar, setShowTouchBar] = useState(true);
@@ -95,6 +103,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
       prev.wave === s.wave &&
       prev.lives === s.lives &&
       prev.weaponLevel === s.weaponLevel &&
+      prev.shieldCharges === s.shieldCharges &&
       prev.status === s.status
     ) {
       return;
@@ -104,6 +113,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
       wave: s.wave,
       lives: s.lives,
       weaponLevel: s.weaponLevel,
+      shieldCharges: s.shieldCharges,
       status: s.status,
     };
     hudSnapRef.current = next;
@@ -135,7 +145,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.translate(ox, oy);
     ctx.scale(scale, scale);
-    drawGame(ctx, stateRef.current);
+    drawGame(ctx, stateRef.current, drawTimeRef.current);
   }, []);
 
   useLayoutEffect(() => {
@@ -160,6 +170,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
     const loop = (ts: number) => {
       const last = lastTsRef.current;
       lastTsRef.current = ts;
+      drawTimeRef.current = ts / 1000;
       if (last != null) {
         const dt = Math.min((ts - last) / 1000, 0.064);
         const cur = stateRef.current;
@@ -275,13 +286,13 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
       style={{
         position: "fixed",
         inset: 0,
-        zIndex: 200,
+        zIndex: 3200,
         minHeight: "100dvh",
         background: "#010409",
         display: "flex",
         flexDirection: "column",
         paddingTop: "env(safe-area-inset-top)",
-        paddingBottom: "env(safe-area-inset-bottom)",
+        paddingBottom: "calc(76px + env(safe-area-inset-bottom, 0px))",
         paddingLeft: "env(safe-area-inset-left)",
         paddingRight: "env(safe-area-inset-right)",
         touchAction: "none",
@@ -312,6 +323,7 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           <span>Golf {hud.wave}</span>
           <span>Levens {hud.lives}</span>
           <span>Wapen {weaponLabel(hud.weaponLevel)}</span>
+          <span>Schild {hud.shieldCharges}</span>
         </div>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
           <button
@@ -375,8 +387,8 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           }}
         >
           <p style={{ margin: "0 0 8px", fontSize: 14, color: "#c9d1d9" }}>
-            Sleepstand: gebruik de knoppen onderaan om te bewegen en te
-            schieten.
+            Sleepstand: gebruik de grote knoppen hieronder (boven de menubalk)
+            om te bewegen en te schieten.
           </p>
           <button type="button" onClick={dismissTouchTip}>
             OK
@@ -388,19 +400,22 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
         <div
           style={{
             flexShrink: 0,
-            padding: "10px 12px",
+            padding: "14px 14px 10px",
             display: "grid",
             gridTemplateColumns: "1fr 1fr 1fr",
-            gap: 10,
-            borderTop: "1px solid #21262d",
+            gap: 14,
+            borderTop: "1px solid #30363d",
+            background: "linear-gradient(180deg, #0d1117 0%, #010409 100%)",
           }}
         >
           <button
             type="button"
             style={{
-              minHeight: 48,
+              minHeight: 58,
               touchAction: "manipulation",
-              fontSize: 16,
+              fontSize: 18,
+              fontWeight: 600,
+              borderRadius: 10,
             }}
             onPointerDown={(e) => {
               e.preventDefault();
@@ -415,9 +430,11 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           <button
             type="button"
             style={{
-              minHeight: 48,
+              minHeight: 58,
               touchAction: "manipulation",
-              fontSize: 16,
+              fontSize: 18,
+              fontWeight: 600,
+              borderRadius: 10,
             }}
             onPointerDown={(e) => {
               e.preventDefault();
@@ -432,9 +449,11 @@ export default function SpaceInvadersGame({ initialState, onClose }: Props) {
           <button
             type="button"
             style={{
-              minHeight: 48,
+              minHeight: 58,
               touchAction: "manipulation",
-              fontSize: 16,
+              fontSize: 18,
+              fontWeight: 600,
+              borderRadius: 10,
             }}
             onPointerDown={(e) => {
               e.preventDefault();

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -88,6 +88,43 @@ export default function SpaceInvadersGame({
     dialogRef.current?.focus();
   }, [mounted]);
 
+  /** Focus binnen de dialog houden; Escape sluit de overlay; focus herstellen bij unmount. */
+  useEffect(() => {
+    if (!mounted) return;
+    const prevFocused = document.activeElement as HTMLElement | null;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !dialogRef.current) return;
+      const root = dialogRef.current;
+      const sel =
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+      const nodes = [...root.querySelectorAll<HTMLElement>(sel)].filter((el) =>
+        root.contains(el),
+      );
+      if (nodes.length === 0) return;
+      const first = nodes[0]!;
+      const last = nodes[nodes.length - 1]!;
+      if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      prevFocused?.focus?.();
+    };
+  }, [mounted, onClose]);
+
   useEffect(() => {
     const q = window.matchMedia("(max-width: 768px), (pointer: coarse)");
     const apply = () => setShowTouchBar(q.matches);
@@ -195,6 +232,13 @@ export default function SpaceInvadersGame({
             stateRef.current = tick(cur, dt, inputRef.current);
           } catch (error: unknown) {
             Sentry.captureException(error);
+            stateRef.current = { ...cur, status: "paused" };
+            inputRef.current = {
+              moveLeft: false,
+              moveRight: false,
+              fire: false,
+            };
+            syncHud(stateRef.current);
           }
         }
         syncHud(stateRef.current);
@@ -267,7 +311,7 @@ export default function SpaceInvadersGame({
         inputRef.current.fire = true;
         e.preventDefault();
       }
-      if (e.code === "Escape" || e.code === "KeyP") {
+      if (e.code === "KeyP") {
         pauseToggle();
         e.preventDefault();
       }
@@ -304,7 +348,7 @@ export default function SpaceInvadersGame({
       aria-modal="true"
       aria-label="Space Invaders"
       tabIndex={-1}
-      className="fixed inset-0 z-[3200] flex min-h-dvh flex-col touch-none bg-[#010409] pt-[env(safe-area-inset-top)] pb-[calc(76px+env(safe-area-inset-bottom,0px))] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
+      className="fixed inset-0 z-[3200] flex min-h-dvh flex-col touch-none bg-[#010409] pt-safe pb-safe-bottom-bar pl-safe pr-safe"
     >
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-[#21262d] px-3 py-2">
         <div className="flex flex-wrap gap-2.5 text-sm text-[#c9d1d9]">
@@ -411,8 +455,8 @@ export default function SpaceInvadersGame({
       ) : null}
       <p className="muted mx-2 mb-2 mt-0 shrink-0 text-center text-xs">
         {showTouchBar
-          ? "Ook: pijltoetsen of A/D, spatie schieten, P of Esc pauze."
-          : "Toetsenbord: ← → of A D, spatie schieten, P of Esc pauze."}
+          ? "Ook: pijltoetsen of A/D, spatie schieten, P pauze, Esc sluit."
+          : "Toetsenbord: ← → of A D, spatie schieten, P pauze, Esc sluit."}
       </p>
     </div>
   );

--- a/src/components/spaceInvaders/SpaceInvadersLauncher.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersLauncher.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createInitialState } from "@/lib/spaceInvaders/game";
+import { loadHighScores, loadSave } from "@/lib/spaceInvaders/storage";
+import SpaceInvadersGame from "./SpaceInvadersGame";
+
+export default function SpaceInvadersLauncher() {
+  const [open, setOpen] = useState(false);
+  const [bootState, setBootState] = useState<ReturnType<
+    typeof createInitialState
+  > | null>(null);
+  const [scores, setScores] = useState(loadHighScores());
+  const [hasSave, setHasSave] = useState(false);
+
+  useEffect(() => {
+    setHasSave(loadSave() != null);
+  }, [open]);
+
+  const openNew = useCallback(() => {
+    setBootState(createInitialState());
+    setOpen(true);
+  }, []);
+
+  const openResume = useCallback(() => {
+    const s = loadSave();
+    if (s) {
+      setBootState(s);
+      setOpen(true);
+    }
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setBootState(null);
+    setScores(loadHighScores());
+    setHasSave(loadSave() != null);
+  }, []);
+
+  return (
+    <>
+      <div className="card" style={{ marginTop: 16 }}>
+        <div
+          className="row"
+          style={{ flexWrap: "wrap", alignItems: "center", gap: 12 }}
+        >
+          <div className="grow">
+            <div style={{ fontWeight: 600 }}>Space Invader</div>
+            <div className="muted" style={{ fontSize: 13, marginTop: 4 }}>
+              Klassiek schietspel — golven, wapen-upgrades en topscores op dit
+              apparaat. Pauzeer, sla op en sluit wanneer je wilt.
+            </div>
+          </div>
+          <div className="row" style={{ flexWrap: "wrap", gap: 8 }}>
+            {hasSave ? (
+              <button type="button" onClick={openResume}>
+                Doorgaan
+              </button>
+            ) : null}
+            <button type="button" onClick={openNew}>
+              {hasSave ? "Nieuw spel" : "Space Invader"}
+            </button>
+          </div>
+        </div>
+        {scores.length > 0 ? (
+          <details style={{ marginTop: 12 }}>
+            <summary className="muted">Topscores (lokaal)</summary>
+            <ol style={{ marginTop: 8, marginBottom: 0, paddingLeft: 20 }}>
+              {scores.map((s, i) => (
+                <li key={`${s.at}-${i}`} style={{ fontSize: 14 }}>
+                  {s.score} punten — golf {s.wave}
+                  <span className="muted" style={{ fontSize: 12 }}>
+                    {" "}
+                    (
+                    {new Date(s.at).toLocaleString(undefined, {
+                      dateStyle: "short",
+                      timeStyle: "short",
+                    })}
+                    )
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </details>
+        ) : null}
+      </div>
+      {open && bootState ? (
+        <SpaceInvadersGame initialState={bootState} onClose={handleClose} />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/spaceInvaders/SpaceInvadersLauncher.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersLauncher.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useState } from "react";
 import { createInitialState } from "@/lib/spaceInvaders/game";
 import { loadHighScores, loadSave } from "@/lib/spaceInvaders/storage";
-import SpaceInvadersGame from "./SpaceInvadersGame";
+
+const SpaceInvadersGame = dynamic(
+  () => import("./SpaceInvadersGame").then((m) => m.default),
+  {
+    ssr: false,
+    loading: () => <p className="muted p-4 text-center">Spel laden…</p>,
+  },
+);
 
 export default function SpaceInvadersLauncher() {
   const [open, setOpen] = useState(false);

--- a/src/components/spaceInvaders/SpaceInvadersLauncher.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersLauncher.tsx
@@ -47,8 +47,9 @@ export default function SpaceInvadersLauncher() {
           <div className="grow">
             <div style={{ fontWeight: 600 }}>Space Invader</div>
             <div className="muted" style={{ fontSize: 13, marginTop: 4 }}>
-              Klassiek schietspel — golven, wapen-upgrades en topscores op dit
-              apparaat. Pauzeer, sla op en sluit wanneer je wilt.
+              Golven, willekeurige power-ups uit de lucht, schilden, explosies
+              en wapenlevels tot Storm — alles lokaal op dit apparaat. Pauzeer,
+              sla op en sluit wanneer je wilt.
             </div>
           </div>
           <div className="row" style={{ flexWrap: "wrap", gap: 8 }}>

--- a/src/lib/spaceInvaders/constants.ts
+++ b/src/lib/spaceInvaders/constants.ts
@@ -25,8 +25,20 @@ export const ALIEN_SCORE_BASE = 10;
 /** Brief pause before the next wave spawns (seconds) */
 export const WAVE_CLEAR_DURATION = 1.55;
 
-/** Seconds between player shots at weapon level 0 / 1 / 2 */
-export const FIRE_INTERVAL: [number, number, number] = [0.42, 0.32, 0.22];
+/** Max weapon tier (0 = single … 4 = wide fan) */
+export const MAX_WEAPON_LEVEL = 4;
+/** Max shield charges stackable from pickups */
+export const MAX_SHIELD_CHARGES = 4;
+/** Falling power-up speed (px/s) */
+export const LOOT_FALL_SPEED = 55;
+/** Seconds between random sky bonus drops (re-randomized after each) */
+export const LOOT_SPAWN_MIN = 4.5;
+export const LOOT_SPAWN_MAX = 11;
+
+/** Seconds between player shots per weapon level */
+export const FIRE_INTERVAL: [number, number, number, number, number] = [
+  0.44, 0.34, 0.26, 0.19, 0.14,
+];
 
 /** Base alien horizontal step (px) per move */
 export const ALIEN_STEP_X = 8;

--- a/src/lib/spaceInvaders/constants.ts
+++ b/src/lib/spaceInvaders/constants.ts
@@ -22,6 +22,9 @@ export const ALIEN_BULLET_SPEED = 140;
 export const INITIAL_LIVES = 3;
 export const ALIEN_SCORE_BASE = 10;
 
+/** Brief pause before the next wave spawns (seconds) */
+export const WAVE_CLEAR_DURATION = 1.55;
+
 /** Seconds between player shots at weapon level 0 / 1 / 2 */
 export const FIRE_INTERVAL: [number, number, number] = [0.42, 0.32, 0.22];
 

--- a/src/lib/spaceInvaders/constants.ts
+++ b/src/lib/spaceInvaders/constants.ts
@@ -1,0 +1,31 @@
+/** Logical game size (canvas scaled to fit UI). */
+export const GAME_W = 360;
+export const GAME_H = 520;
+
+export const PLAYER_W = 36;
+export const PLAYER_H = 14;
+export const PLAYER_Y = GAME_H - 48;
+export const PLAYER_SPEED = 220;
+
+export const ALIEN_COLS = 8;
+export const ALIEN_ROWS = 4;
+export const ALIEN_W = 28;
+export const ALIEN_H = 18;
+export const ALIEN_GAP_X = 10;
+export const ALIEN_GAP_Y = 8;
+
+export const BULLET_W = 4;
+export const BULLET_H = 10;
+export const PLAYER_BULLET_SPEED = 320;
+export const ALIEN_BULLET_SPEED = 140;
+
+export const INITIAL_LIVES = 3;
+export const ALIEN_SCORE_BASE = 10;
+
+/** Seconds between player shots at weapon level 0 / 1 / 2 */
+export const FIRE_INTERVAL: [number, number, number] = [0.42, 0.32, 0.22];
+
+/** Base alien horizontal step (px) per move */
+export const ALIEN_STEP_X = 8;
+/** Drop when reversing at edge */
+export const ALIEN_DROP_Y = 14;

--- a/src/lib/spaceInvaders/constants.ts
+++ b/src/lib/spaceInvaders/constants.ts
@@ -17,6 +17,7 @@ export const ALIEN_GAP_Y = 8;
 export const BULLET_W = 4;
 export const BULLET_H = 10;
 export const PLAYER_BULLET_SPEED = 320;
+/** Legacy baseline; actual speed uses `alienBulletSpeedForWave` in game.ts */
 export const ALIEN_BULLET_SPEED = 140;
 
 export const INITIAL_LIVES = 3;

--- a/src/lib/spaceInvaders/draw.ts
+++ b/src/lib/spaceInvaders/draw.ts
@@ -14,69 +14,195 @@ import {
 import { alienRect } from "./game";
 import type { GameState } from "./types";
 
+function drawStarfield(ctx: CanvasRenderingContext2D, t: number): void {
+  ctx.save();
+  for (let i = 0; i < 48; i++) {
+    const sx = ((i * 73) % GAME_W) + Math.sin(t * 0.4 + i) * 2;
+    const sy = ((i * 47) % GAME_H) + ((t * 12 + i * 17) % GAME_H);
+    const tw = 0.5 + (i % 3) * 0.35;
+    const a = 0.15 + (i % 5) * 0.08;
+    ctx.fillStyle = `rgba(200,220,255,${a})`;
+    ctx.fillRect(sx % GAME_W, sy, tw, tw);
+  }
+  ctx.restore();
+}
+
 export function drawGame(
   ctx: CanvasRenderingContext2D,
   state: GameState,
+  timeSec = 0,
 ): void {
   ctx.save();
-  ctx.fillStyle = "#0d1117";
+
+  const g = ctx.createLinearGradient(0, 0, 0, GAME_H);
+  g.addColorStop(0, "#0a1628");
+  g.addColorStop(0.45, "#0d1520");
+  g.addColorStop(1, "#050810");
+  ctx.fillStyle = g;
   ctx.fillRect(0, 0, GAME_W, GAME_H);
 
-  ctx.strokeStyle = "rgba(255,255,255,0.04)";
+  drawStarfield(ctx, timeSec);
+
+  ctx.strokeStyle = "rgba(100,180,255,0.06)";
   ctx.lineWidth = 1;
-  for (let x = 0; x < GAME_W; x += 36) {
+  for (let x = 0; x < GAME_W; x += 40) {
     ctx.beginPath();
     ctx.moveTo(x, 0);
     ctx.lineTo(x, GAME_H);
     ctx.stroke();
   }
 
+  // Loot drops (glow)
+  for (const d of state.lootDrops) {
+    const pulse = 0.65 + Math.sin(d.phase) * 0.25;
+    let hue = 48;
+    let label = "W";
+    if (d.kind === "shield") {
+      hue = 200;
+      label = "S";
+    } else if (d.kind === "burst") {
+      hue = 32;
+      label = "★";
+    }
+    ctx.shadowColor = `hsl(${hue} 90% 55%)`;
+    ctx.shadowBlur = 14 * pulse;
+    ctx.fillStyle = `hsla(${hue} 85% 52%, ${0.85 * pulse})`;
+    ctx.strokeStyle = `hsla(${hue} 100% 70%, ${0.9})`;
+    ctx.lineWidth = 2;
+    const s = 18;
+    ctx.beginPath();
+    const lx = d.x - s / 2;
+    const ly = d.y - s / 2;
+    const rad = 4;
+    ctx.moveTo(lx + rad, ly);
+    ctx.lineTo(lx + s - rad, ly);
+    ctx.quadraticCurveTo(lx + s, ly, lx + s, ly + rad);
+    ctx.lineTo(lx + s, ly + s - rad);
+    ctx.quadraticCurveTo(lx + s, ly + s, lx + s - rad, ly + s);
+    ctx.lineTo(lx + rad, ly + s);
+    ctx.quadraticCurveTo(lx, ly + s, lx, ly + s - rad);
+    ctx.lineTo(lx, ly + rad);
+    ctx.quadraticCurveTo(lx, ly, lx + rad, ly);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = "#fff";
+    ctx.font = "bold 11px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(label, d.x, d.y + 0.5);
+  }
+
   for (let r = 0; r < ALIEN_ROWS; r++) {
     for (let c = 0; c < ALIEN_COLS; c++) {
       const rect = alienRect(state, r, c);
       if (!rect) continue;
-      const hue = 100 + r * 18;
-      ctx.fillStyle = `hsl(${hue} 70% 55%)`;
+      const hue = 105 + r * 20 + Math.sin(timeSec * 2 + c) * 4;
+      ctx.shadowColor = `hsl(${hue} 80% 45%)`;
+      ctx.shadowBlur = 8;
+      const ag = ctx.createLinearGradient(
+        rect.left,
+        rect.top,
+        rect.right,
+        rect.bottom,
+      );
+      ag.addColorStop(0, `hsl(${hue} 72% 58%)`);
+      ag.addColorStop(1, `hsl(${hue} 65% 38%)`);
+      ctx.fillStyle = ag;
       ctx.fillRect(rect.left, rect.top, ALIEN_W, ALIEN_H);
-      ctx.fillStyle = "rgba(0,0,0,0.25)";
-      ctx.fillRect(rect.left + 6, rect.top + 4, 8, 6);
-      ctx.fillRect(rect.left + ALIEN_W - 14, rect.top + 4, 8, 6);
+      ctx.shadowBlur = 0;
+      ctx.fillStyle = "rgba(0,0,0,0.35)";
+      ctx.fillRect(rect.left + 5, rect.top + 3, 7, 5);
+      ctx.fillRect(rect.left + ALIEN_W - 12, rect.top + 3, 7, 5);
     }
   }
 
+  // Shield bubble
+  if (state.shieldCharges > 0) {
+    const cx = state.playerX;
+    const cy = PLAYER_Y + PLAYER_H / 2;
+    const pulse = 0.55 + Math.sin(timeSec * 6) * 0.12;
+    ctx.strokeStyle = `rgba(100,200,255,${0.35 + pulse * 0.35})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(
+      cx,
+      cy - 2,
+      26 + state.shieldCharges * 2,
+      Math.PI * 1.1,
+      Math.PI * 1.9,
+    );
+    ctx.stroke();
+    ctx.strokeStyle = `rgba(160,230,255,${0.2 + pulse * 0.2})`;
+    ctx.beginPath();
+    ctx.arc(cx, cy - 2, 22, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+
   const px = state.playerX - PLAYER_W / 2;
-  ctx.fillStyle = "#58a6ff";
+  ctx.shadowColor = "#58a6ff";
+  ctx.shadowBlur = 12;
+  const pg = ctx.createLinearGradient(
+    px,
+    PLAYER_Y,
+    px + PLAYER_W,
+    PLAYER_Y + PLAYER_H,
+  );
+  pg.addColorStop(0, "#7cb9ff");
+  pg.addColorStop(1, "#388bfd");
+  ctx.fillStyle = pg;
   ctx.beginPath();
   ctx.moveTo(state.playerX, PLAYER_Y);
   ctx.lineTo(px + PLAYER_W, PLAYER_Y + PLAYER_H);
   ctx.lineTo(px, PLAYER_Y + PLAYER_H);
   ctx.closePath();
   ctx.fill();
+  ctx.shadowBlur = 0;
 
-  ctx.fillStyle = "#3fb950";
   for (const b of state.playerBullets) {
+    ctx.shadowColor = "#3fb950";
+    ctx.shadowBlur = 6;
+    ctx.fillStyle = "#7ee787";
     ctx.fillRect(b.x - BULLET_W / 2, b.y - BULLET_H, BULLET_W, BULLET_H);
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = "rgba(180,255,200,0.45)";
+    ctx.fillRect(b.x - 1, b.y - BULLET_H - 4, 2, 5);
   }
 
-  ctx.fillStyle = "#f85149";
   for (const b of state.alienBullets) {
+    ctx.shadowColor = "#ff7b72";
+    ctx.shadowBlur = 8;
+    ctx.fillStyle = "#f85149";
     ctx.fillRect(b.x - BULLET_W / 2, b.y, BULLET_W, BULLET_H);
+    ctx.shadowBlur = 0;
+  }
+
+  for (const p of state.particles) {
+    const a = Math.min(1, p.life / p.maxLife);
+    ctx.fillStyle = `hsla(${p.hue} 90% 62%, ${a * 0.95})`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.size * a, 0, Math.PI * 2);
+    ctx.fill();
   }
 
   if (state.status === "wave_clear") {
-    ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
+    ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
     ctx.fillRect(0, 0, GAME_W, GAME_H);
     ctx.fillStyle = "#f0f6fc";
-    ctx.font = "bold 24px system-ui, sans-serif";
+    ctx.font = "bold 26px system-ui, sans-serif";
     ctx.textAlign = "center";
-    ctx.fillText(`Golf ${state.wave}`, GAME_W / 2, GAME_H / 2 - 12);
+    ctx.shadowColor = "#58a6ff";
+    ctx.shadowBlur = 18;
+    ctx.fillText(`Golf ${state.wave}`, GAME_W / 2, GAME_H / 2 - 14);
+    ctx.shadowBlur = 0;
     ctx.font = "15px system-ui, sans-serif";
     ctx.fillStyle = "#8b949e";
-    ctx.fillText("Volgende golf…", GAME_W / 2, GAME_H / 2 + 16);
+    ctx.fillText("Volgende golf…", GAME_W / 2, GAME_H / 2 + 18);
   }
 
   if (state.status === "paused") {
-    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillStyle = "rgba(0,0,0,0.6)";
     ctx.fillRect(0, 0, GAME_W, GAME_H);
     ctx.fillStyle = "#f0f6fc";
     ctx.font = "bold 22px system-ui, sans-serif";
@@ -88,18 +214,21 @@ export function drawGame(
   }
 
   if (state.status === "gameover") {
-    ctx.fillStyle = "rgba(0,0,0,0.65)";
+    ctx.fillStyle = "rgba(0,0,0,0.72)";
     ctx.fillRect(0, 0, GAME_W, GAME_H);
     ctx.fillStyle = "#f85149";
-    ctx.font = "bold 24px system-ui, sans-serif";
+    ctx.font = "bold 26px system-ui, sans-serif";
     ctx.textAlign = "center";
-    ctx.fillText("Game over", GAME_W / 2, GAME_H / 2 - 24);
+    ctx.shadowColor = "#f85149";
+    ctx.shadowBlur = 20;
+    ctx.fillText("Game over", GAME_W / 2, GAME_H / 2 - 28);
+    ctx.shadowBlur = 0;
     ctx.fillStyle = "#f0f6fc";
     ctx.font = "16px system-ui, sans-serif";
-    ctx.fillText(`Score: ${state.score}`, GAME_W / 2, GAME_H / 2 + 8);
+    ctx.fillText(`Score: ${state.score}`, GAME_W / 2, GAME_H / 2 + 6);
     ctx.fillStyle = "#8b949e";
     ctx.font = "14px system-ui, sans-serif";
-    ctx.fillText("Herstart of sluit", GAME_W / 2, GAME_H / 2 + 36);
+    ctx.fillText("Herstart of sluit", GAME_W / 2, GAME_H / 2 + 34);
   }
 
   ctx.restore();

--- a/src/lib/spaceInvaders/draw.ts
+++ b/src/lib/spaceInvaders/draw.ts
@@ -171,11 +171,54 @@ export function drawGame(
   }
 
   for (const b of state.alienBullets) {
-    ctx.shadowColor = "#ff7b72";
-    ctx.shadowBlur = 8;
-    ctx.fillStyle = "#f85149";
-    ctx.fillRect(b.x - BULLET_W / 2, b.y, BULLET_W, BULLET_H);
+    const k = b.kind;
+    let w = BULLET_W;
+    let h = BULLET_H;
+    let hue = 8;
+    let glow = 8;
+    switch (k) {
+      case "bolt":
+        w = BULLET_W;
+        h = BULLET_H;
+        hue = 8;
+        glow = 8;
+        break;
+      case "plasma":
+        w = BULLET_W * 1.5;
+        h = BULLET_H * 1.15;
+        hue = 285;
+        glow = 16;
+        break;
+      case "needle":
+        w = BULLET_W * 0.65;
+        h = BULLET_H * 1.35;
+        hue = 195;
+        glow = 6;
+        break;
+      case "heavy":
+        w = BULLET_W * 1.65;
+        h = BULLET_H * 1.4;
+        hue = 22;
+        glow = 14;
+        break;
+    }
+    ctx.shadowColor = `hsl(${hue} 90% 55%)`;
+    ctx.shadowBlur = glow;
+    const lg = ctx.createLinearGradient(b.x - w / 2, b.y, b.x + w / 2, b.y + h);
+    lg.addColorStop(0, `hsl(${hue} 95% 62%)`);
+    lg.addColorStop(1, `hsl(${hue} 80% 42%)`);
+    ctx.fillStyle = lg;
+    ctx.fillRect(b.x - w / 2, b.y, w, h);
     ctx.shadowBlur = 0;
+    if (k === "plasma") {
+      ctx.fillStyle = "rgba(255,200,255,0.35)";
+      ctx.fillRect(b.x - w * 0.15, b.y + h * 0.2, w * 0.3, h * 0.5);
+    }
+    if (k === "heavy") {
+      ctx.strokeStyle = "rgba(255,200,160,0.5)";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(b.x - w / 2 + 0.5, b.y + 0.5, w - 1, h - 1);
+    }
   }
 
   for (const p of state.particles) {

--- a/src/lib/spaceInvaders/draw.ts
+++ b/src/lib/spaceInvaders/draw.ts
@@ -264,7 +264,7 @@ export function drawGame(
     ctx.textAlign = "center";
     ctx.shadowColor = "#f85149";
     ctx.shadowBlur = 20;
-    ctx.fillText("Game over", GAME_W / 2, GAME_H / 2 - 28);
+    ctx.fillText("Spel voorbij", GAME_W / 2, GAME_H / 2 - 28);
     ctx.shadowBlur = 0;
     ctx.fillStyle = "#f0f6fc";
     ctx.font = "16px system-ui, sans-serif";

--- a/src/lib/spaceInvaders/draw.ts
+++ b/src/lib/spaceInvaders/draw.ts
@@ -1,0 +1,94 @@
+import {
+  ALIEN_COLS,
+  ALIEN_H,
+  ALIEN_ROWS,
+  ALIEN_W,
+  BULLET_H,
+  BULLET_W,
+  GAME_H,
+  GAME_W,
+  PLAYER_H,
+  PLAYER_W,
+  PLAYER_Y,
+} from "./constants";
+import { alienRect } from "./game";
+import type { GameState } from "./types";
+
+export function drawGame(
+  ctx: CanvasRenderingContext2D,
+  state: GameState,
+): void {
+  ctx.save();
+  ctx.fillStyle = "#0d1117";
+  ctx.fillRect(0, 0, GAME_W, GAME_H);
+
+  ctx.strokeStyle = "rgba(255,255,255,0.04)";
+  ctx.lineWidth = 1;
+  for (let x = 0; x < GAME_W; x += 36) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, GAME_H);
+    ctx.stroke();
+  }
+
+  for (let r = 0; r < ALIEN_ROWS; r++) {
+    for (let c = 0; c < ALIEN_COLS; c++) {
+      const rect = alienRect(state, r, c);
+      if (!rect) continue;
+      const hue = 100 + r * 18;
+      ctx.fillStyle = `hsl(${hue} 70% 55%)`;
+      ctx.fillRect(rect.left, rect.top, ALIEN_W, ALIEN_H);
+      ctx.fillStyle = "rgba(0,0,0,0.25)";
+      ctx.fillRect(rect.left + 6, rect.top + 4, 8, 6);
+      ctx.fillRect(rect.left + ALIEN_W - 14, rect.top + 4, 8, 6);
+    }
+  }
+
+  const px = state.playerX - PLAYER_W / 2;
+  ctx.fillStyle = "#58a6ff";
+  ctx.beginPath();
+  ctx.moveTo(state.playerX, PLAYER_Y);
+  ctx.lineTo(px + PLAYER_W, PLAYER_Y + PLAYER_H);
+  ctx.lineTo(px, PLAYER_Y + PLAYER_H);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#3fb950";
+  for (const b of state.playerBullets) {
+    ctx.fillRect(b.x - BULLET_W / 2, b.y - BULLET_H, BULLET_W, BULLET_H);
+  }
+
+  ctx.fillStyle = "#f85149";
+  for (const b of state.alienBullets) {
+    ctx.fillRect(b.x - BULLET_W / 2, b.y, BULLET_W, BULLET_H);
+  }
+
+  if (state.status === "paused") {
+    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillRect(0, 0, GAME_W, GAME_H);
+    ctx.fillStyle = "#f0f6fc";
+    ctx.font = "bold 22px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Pauze", GAME_W / 2, GAME_H / 2 - 8);
+    ctx.font = "14px system-ui, sans-serif";
+    ctx.fillStyle = "#8b949e";
+    ctx.fillText("Druk op hervatten of P", GAME_W / 2, GAME_H / 2 + 18);
+  }
+
+  if (state.status === "gameover") {
+    ctx.fillStyle = "rgba(0,0,0,0.65)";
+    ctx.fillRect(0, 0, GAME_W, GAME_H);
+    ctx.fillStyle = "#f85149";
+    ctx.font = "bold 24px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Game over", GAME_W / 2, GAME_H / 2 - 24);
+    ctx.fillStyle = "#f0f6fc";
+    ctx.font = "16px system-ui, sans-serif";
+    ctx.fillText(`Score: ${state.score}`, GAME_W / 2, GAME_H / 2 + 8);
+    ctx.fillStyle = "#8b949e";
+    ctx.font = "14px system-ui, sans-serif";
+    ctx.fillText("Herstart of sluit", GAME_W / 2, GAME_H / 2 + 36);
+  }
+
+  ctx.restore();
+}

--- a/src/lib/spaceInvaders/draw.ts
+++ b/src/lib/spaceInvaders/draw.ts
@@ -253,7 +253,11 @@ export function drawGame(
     ctx.fillText("Pauze", GAME_W / 2, GAME_H / 2 - 8);
     ctx.font = "14px system-ui, sans-serif";
     ctx.fillStyle = "#8b949e";
-    ctx.fillText("Druk op hervatten of P", GAME_W / 2, GAME_H / 2 + 18);
+    ctx.fillText(
+      "Druk op hervatten of P — Esc sluit",
+      GAME_W / 2,
+      GAME_H / 2 + 18,
+    );
   }
 
   if (state.status === "gameover") {
@@ -264,7 +268,7 @@ export function drawGame(
     ctx.textAlign = "center";
     ctx.shadowColor = "#f85149";
     ctx.shadowBlur = 20;
-    ctx.fillText("Spel voorbij", GAME_W / 2, GAME_H / 2 - 28);
+    ctx.fillText("Spel afgelopen", GAME_W / 2, GAME_H / 2 - 28);
     ctx.shadowBlur = 0;
     ctx.fillStyle = "#f0f6fc";
     ctx.font = "16px system-ui, sans-serif";

--- a/src/lib/spaceInvaders/draw.ts
+++ b/src/lib/spaceInvaders/draw.ts
@@ -63,6 +63,18 @@ export function drawGame(
     ctx.fillRect(b.x - BULLET_W / 2, b.y, BULLET_W, BULLET_H);
   }
 
+  if (state.status === "wave_clear") {
+    ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
+    ctx.fillRect(0, 0, GAME_W, GAME_H);
+    ctx.fillStyle = "#f0f6fc";
+    ctx.font = "bold 24px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText(`Golf ${state.wave}`, GAME_W / 2, GAME_H / 2 - 12);
+    ctx.font = "15px system-ui, sans-serif";
+    ctx.fillStyle = "#8b949e";
+    ctx.fillText("Volgende golf…", GAME_W / 2, GAME_H / 2 + 16);
+  }
+
   if (state.status === "paused") {
     ctx.fillStyle = "rgba(0,0,0,0.55)";
     ctx.fillRect(0, 0, GAME_W, GAME_H);

--- a/src/lib/spaceInvaders/game.test.ts
+++ b/src/lib/spaceInvaders/game.test.ts
@@ -3,10 +3,12 @@ import {
   alienFireEveryForWave,
   alienMoveEveryForWave,
   createInitialState,
+  spawnWave,
   tick,
   weaponLevelForWave,
 } from "./game";
-import { GAME_W } from "./constants";
+import { ALIEN_COLS, ALIEN_ROWS, GAME_W } from "./constants";
+import type { GameState } from "./types";
 
 describe("weaponLevelForWave", () => {
   it("ramps with wave", () => {
@@ -46,5 +48,41 @@ describe("tick", () => {
     }
     expect(s.playerX).toBeGreaterThan(0);
     expect(s.playerX).toBeLessThanOrEqual(GAME_W / 2);
+  });
+});
+
+describe("wave_clear interstitial", () => {
+  it("counts down and spawns next wave", () => {
+    const emptyAliens = Array.from({ length: ALIEN_ROWS }, () =>
+      Array.from({ length: ALIEN_COLS }, () => false),
+    );
+    let s: GameState = {
+      ...createInitialState(),
+      status: "wave_clear",
+      wave: 2,
+      waveClearRemaining: 0.15,
+      alienGrid: emptyAliens,
+      playerBullets: [],
+      alienBullets: [],
+    };
+    s = tick(s, 0.2, { moveLeft: false, moveRight: false, fire: false });
+    expect(s.status).toBe("playing");
+    expect(s.wave).toBe(2);
+    const alive = s.alienGrid.flat().filter(Boolean).length;
+    expect(alive).toBeGreaterThan(0);
+  });
+});
+
+describe("spawnWave", () => {
+  it("resets grid and matches weapon to wave", () => {
+    const cleared = {
+      ...createInitialState(),
+      wave: 4,
+      score: 999,
+    };
+    const next = spawnWave(cleared);
+    expect(next.wave).toBe(4);
+    expect(next.weaponLevel).toBe(weaponLevelForWave(4));
+    expect(next.alienGrid.flat().every(Boolean)).toBe(true);
   });
 });

--- a/src/lib/spaceInvaders/game.test.ts
+++ b/src/lib/spaceInvaders/game.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  alienBulletSpeedForWave,
   alienFireEveryForWave,
   alienMoveEveryForWave,
+  alienVolleyCountForWave,
   createBurst,
   createInitialState,
+  deserializeGame,
+  pickAlienWeaponKind,
   spawnWave,
   tick,
   weaponLevelForWave,
@@ -28,6 +32,74 @@ describe("difficulty curves", () => {
   });
   it("alien fire interval decreases with wave", () => {
     expect(alienFireEveryForWave(1)).toBeGreaterThan(alienFireEveryForWave(10));
+  });
+  it("alien fire interval has a low floor on late waves", () => {
+    expect(alienFireEveryForWave(1)).toBeGreaterThan(0.18);
+    expect(alienFireEveryForWave(99)).toBe(0.18);
+  });
+  it("alien bullet speed increases with wave then caps", () => {
+    expect(alienBulletSpeedForWave(2)).toBeGreaterThan(
+      alienBulletSpeedForWave(1),
+    );
+    expect(alienBulletSpeedForWave(30)).toBe(230);
+    expect(alienBulletSpeedForWave(30)).toBe(alienBulletSpeedForWave(100));
+  });
+  it("volley count steps at waves 6 and 12", () => {
+    expect(alienVolleyCountForWave(1)).toBe(1);
+    expect(alienVolleyCountForWave(5)).toBe(1);
+    expect(alienVolleyCountForWave(6)).toBe(2);
+    expect(alienVolleyCountForWave(11)).toBe(2);
+    expect(alienVolleyCountForWave(12)).toBe(3);
+  });
+});
+
+describe("pickAlienWeaponKind", () => {
+  it("wave 1 is always bolt", () => {
+    for (let row = 0; row < ALIEN_ROWS; row++) {
+      expect(pickAlienWeaponKind(1, row, 0)).toBe("bolt");
+      expect(pickAlienWeaponKind(1, row, 0.999)).toBe("bolt");
+    }
+  });
+  it("high wave + top row + low rand favors needle", () => {
+    expect(pickAlienWeaponKind(12, 0, 0)).toBe("needle");
+  });
+  it("high wave + bottom row can yield heavy after needle band", () => {
+    expect(pickAlienWeaponKind(20, ALIEN_ROWS - 1, 0.37)).toBe("heavy");
+  });
+});
+
+describe("deserializeGame alien bullets", () => {
+  it("defaults kind and velocity for legacy saves", () => {
+    const base = createInitialState();
+    const data = {
+      v: 2 as const,
+      wave: 4,
+      lives: base.lives,
+      score: base.score,
+      weaponLevel: base.weaponLevel,
+      playerX: base.playerX,
+      alienGrid: base.alienGrid,
+      alienOriginX: base.alienOriginX,
+      alienOriginY: base.alienOriginY,
+      alienDir: base.alienDir,
+      alienMoveAcc: base.alienMoveAcc,
+      alienMoveEvery: base.alienMoveEvery,
+      playerBullets: [],
+      alienBullets: [{ x: 50, y: 80 }],
+      playerFireCooldown: 0,
+      alienFireAcc: 0,
+      alienFireEvery: base.alienFireEvery,
+      status: "playing" as const,
+      shieldCharges: 0,
+      lootDrops: [],
+      lootSpawnTimer: base.lootSpawnTimer,
+    };
+    const s = deserializeGame(data);
+    expect(s.alienBullets).toHaveLength(1);
+    const b = s.alienBullets[0]!;
+    expect(b.kind).toBe("bolt");
+    expect(b.vy).toBeGreaterThan(0);
+    expect(b.vx).toBe(0);
   });
 });
 

--- a/src/lib/spaceInvaders/game.test.ts
+++ b/src/lib/spaceInvaders/game.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   alienFireEveryForWave,
   alienMoveEveryForWave,
+  createBurst,
   createInitialState,
   spawnWave,
   tick,
@@ -74,15 +75,34 @@ describe("wave_clear interstitial", () => {
 });
 
 describe("spawnWave", () => {
-  it("resets grid and matches weapon to wave", () => {
+  it("resets grid and preserves weapon above wave floor", () => {
     const cleared = {
       ...createInitialState(),
       wave: 4,
       score: 999,
+      weaponLevel: 3,
     };
     const next = spawnWave(cleared);
     expect(next.wave).toBe(4);
-    expect(next.weaponLevel).toBe(weaponLevelForWave(4));
+    expect(next.weaponLevel).toBe(3);
     expect(next.alienGrid.flat().every(Boolean)).toBe(true);
+  });
+
+  it("bumps weapon to at least wave floor when behind", () => {
+    const cleared = {
+      ...createInitialState(),
+      wave: 5,
+      weaponLevel: 0,
+    };
+    const next = spawnWave(cleared);
+    expect(next.weaponLevel).toBe(weaponLevelForWave(5));
+  });
+});
+
+describe("createBurst", () => {
+  it("returns the requested particle count", () => {
+    const p = createBurst(100, 200, 7, 120);
+    expect(p.length).toBe(7);
+    expect(p[0]!.life).toBeGreaterThan(0);
   });
 });

--- a/src/lib/spaceInvaders/game.test.ts
+++ b/src/lib/spaceInvaders/game.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  alienFireEveryForWave,
+  alienMoveEveryForWave,
+  createInitialState,
+  tick,
+  weaponLevelForWave,
+} from "./game";
+import { GAME_W } from "./constants";
+
+describe("weaponLevelForWave", () => {
+  it("ramps with wave", () => {
+    expect(weaponLevelForWave(1)).toBe(0);
+    expect(weaponLevelForWave(2)).toBe(0);
+    expect(weaponLevelForWave(3)).toBe(1);
+    expect(weaponLevelForWave(5)).toBe(1);
+    expect(weaponLevelForWave(6)).toBe(2);
+    expect(weaponLevelForWave(99)).toBe(2);
+  });
+});
+
+describe("difficulty curves", () => {
+  it("alien move interval decreases with wave", () => {
+    expect(alienMoveEveryForWave(1)).toBeGreaterThan(alienMoveEveryForWave(10));
+  });
+  it("alien fire interval decreases with wave", () => {
+    expect(alienFireEveryForWave(1)).toBeGreaterThan(alienFireEveryForWave(10));
+  });
+});
+
+describe("tick", () => {
+  it("moves player left when input.moveLeft", () => {
+    let s = createInitialState();
+    const x0 = s.playerX;
+    for (let i = 0; i < 20; i++) {
+      s = tick(s, 1 / 60, { moveLeft: true, moveRight: false, fire: false });
+    }
+    expect(s.playerX).toBeLessThan(x0);
+  });
+
+  it("clamps player to bounds", () => {
+    let s = createInitialState();
+    s = { ...s, playerX: 4 };
+    for (let i = 0; i < 200; i++) {
+      s = tick(s, 1 / 30, { moveLeft: true, moveRight: false, fire: false });
+    }
+    expect(s.playerX).toBeGreaterThan(0);
+    expect(s.playerX).toBeLessThanOrEqual(GAME_W / 2);
+  });
+});

--- a/src/lib/spaceInvaders/game.ts
+++ b/src/lib/spaceInvaders/game.ts
@@ -1,0 +1,384 @@
+import {
+  ALIEN_BULLET_SPEED,
+  ALIEN_COLS,
+  ALIEN_DROP_Y,
+  ALIEN_GAP_X,
+  ALIEN_GAP_Y,
+  ALIEN_H,
+  ALIEN_ROWS,
+  ALIEN_SCORE_BASE,
+  ALIEN_STEP_X,
+  ALIEN_W,
+  BULLET_H,
+  BULLET_W,
+  FIRE_INTERVAL,
+  GAME_H,
+  GAME_W,
+  INITIAL_LIVES,
+  PLAYER_BULLET_SPEED,
+  PLAYER_H,
+  PLAYER_SPEED,
+  PLAYER_W,
+  PLAYER_Y,
+} from "./constants";
+import type { GameInput, GameState, SerializedGameV1 } from "./types";
+
+function emptyGrid(): boolean[][] {
+  return Array.from({ length: ALIEN_ROWS }, () =>
+    Array.from({ length: ALIEN_COLS }, () => true),
+  );
+}
+
+export function weaponLevelForWave(wave: number): number {
+  if (wave >= 6) return 2;
+  if (wave >= 3) return 1;
+  return 0;
+}
+
+export function alienMoveEveryForWave(wave: number): number {
+  return Math.max(0.22, 0.55 - wave * 0.035);
+}
+
+export function alienFireEveryForWave(wave: number): number {
+  return Math.max(0.35, 1.1 - wave * 0.08);
+}
+
+export function createInitialState(): GameState {
+  const wave = 1;
+  return {
+    status: "playing",
+    wave,
+    lives: INITIAL_LIVES,
+    score: 0,
+    weaponLevel: weaponLevelForWave(wave),
+    playerX: GAME_W / 2,
+    alienGrid: emptyGrid(),
+    alienOriginX: 24,
+    alienOriginY: 56,
+    alienDir: 1,
+    alienMoveAcc: 0,
+    alienMoveEvery: alienMoveEveryForWave(wave),
+    playerBullets: [],
+    alienBullets: [],
+    playerFireCooldown: 0,
+    alienFireAcc: 0,
+    alienFireEvery: alienFireEveryForWave(wave),
+  };
+}
+
+export function spawnWave(state: GameState): GameState {
+  const wave = state.wave;
+  return {
+    ...state,
+    alienGrid: emptyGrid(),
+    alienOriginX: 24,
+    alienOriginY: 56,
+    alienDir: 1,
+    alienMoveAcc: 0,
+    alienMoveEvery: alienMoveEveryForWave(wave),
+    alienFireEvery: alienFireEveryForWave(wave),
+    weaponLevel: weaponLevelForWave(wave),
+    playerBullets: [],
+    alienBullets: [],
+    status: "playing",
+  };
+}
+
+export function alienRect(
+  state: GameState,
+  row: number,
+  col: number,
+): { left: number; top: number; right: number; bottom: number } | null {
+  if (!state.alienGrid[row]?.[col]) return null;
+  const left = state.alienOriginX + col * (ALIEN_W + ALIEN_GAP_X);
+  const top = state.alienOriginY + row * (ALIEN_H + ALIEN_GAP_Y);
+  return { left, top, right: left + ALIEN_W, bottom: top + ALIEN_H };
+}
+
+function gridBounds(state: GameState): {
+  minX: number;
+  maxX: number;
+  maxY: number;
+} | null {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let any = false;
+  for (let r = 0; r < ALIEN_ROWS; r++) {
+    for (let c = 0; c < ALIEN_COLS; c++) {
+      const rect = alienRect(state, r, c);
+      if (!rect) continue;
+      any = true;
+      minX = Math.min(minX, rect.left);
+      maxX = Math.max(maxX, rect.right);
+      maxY = Math.max(maxY, rect.bottom);
+    }
+  }
+  if (!any) return null;
+  return { minX, maxX, maxY };
+}
+
+function stepAliens(state: GameState): GameState {
+  const b = gridBounds(state);
+  if (!b) return state;
+
+  let { alienOriginX, alienOriginY, alienDir } = state;
+  const step = ALIEN_STEP_X + Math.min(state.wave, 12) * 0.4;
+
+  if (alienDir === 1 && b.maxX + step >= GAME_W - 4) {
+    alienDir = -1;
+    alienOriginY += ALIEN_DROP_Y;
+  } else if (alienDir === -1 && b.minX - step <= 4) {
+    alienDir = 1;
+    alienOriginY += ALIEN_DROP_Y;
+  } else {
+    alienOriginX += alienDir * step;
+  }
+
+  return { ...state, alienOriginX, alienOriginY, alienDir };
+}
+
+function playerRect(state: GameState) {
+  const left = state.playerX - PLAYER_W / 2;
+  return {
+    left,
+    top: PLAYER_Y,
+    right: left + PLAYER_W,
+    bottom: PLAYER_Y + PLAYER_H,
+  };
+}
+
+function overlap(
+  a: { left: number; top: number; right: number; bottom: number },
+  b: { left: number; top: number; right: number; bottom: number },
+): boolean {
+  return !(
+    a.right <= b.left ||
+    a.left >= b.right ||
+    a.bottom <= b.top ||
+    a.top >= b.bottom
+  );
+}
+
+export function tick(
+  state: GameState,
+  dt: number,
+  input: GameInput,
+): GameState {
+  if (state.status !== "playing") return state;
+
+  let next: GameState = { ...state };
+
+  // Player movement
+  if (input.moveLeft) {
+    next.playerX = Math.max(PLAYER_W / 2 + 4, next.playerX - PLAYER_SPEED * dt);
+  }
+  if (input.moveRight) {
+    next.playerX = Math.min(
+      GAME_W - PLAYER_W / 2 - 4,
+      next.playerX + PLAYER_SPEED * dt,
+    );
+  }
+
+  // Fire cooldown
+  next.playerFireCooldown = Math.max(0, next.playerFireCooldown - dt);
+
+  const fireInterval = FIRE_INTERVAL[next.weaponLevel] ?? FIRE_INTERVAL[0];
+  if (input.fire && next.playerFireCooldown <= 0) {
+    const px = next.playerX;
+    const py = PLAYER_Y - 4;
+    const lvl = next.weaponLevel;
+    if (lvl === 0) {
+      next.playerBullets = [...next.playerBullets, { x: px, y: py }];
+    } else if (lvl === 1) {
+      next.playerBullets = [
+        ...next.playerBullets,
+        { x: px - 10, y: py },
+        { x: px + 10, y: py },
+      ];
+    } else {
+      next.playerBullets = [
+        ...next.playerBullets,
+        { x: px - 14, y: py },
+        { x: px, y: py },
+        { x: px + 14, y: py },
+      ];
+    }
+    next.playerFireCooldown = fireInterval;
+  }
+
+  // Move player bullets up
+  next.playerBullets = next.playerBullets
+    .map((b) => ({ ...b, y: b.y - PLAYER_BULLET_SPEED * dt }))
+    .filter((b) => b.y > -BULLET_H);
+
+  // Alien stepping (cap steps per tick for stability on lag spikes)
+  next.alienMoveAcc += dt;
+  let steps = 0;
+  while (next.alienMoveAcc >= next.alienMoveEvery && steps < 4) {
+    next.alienMoveAcc -= next.alienMoveEvery;
+    next = stepAliens(next);
+    steps += 1;
+  }
+
+  // Alien fire (at most one shot per frame from accumulator)
+  next.alienFireAcc += dt;
+  if (next.alienFireAcc >= next.alienFireEvery) {
+    next.alienFireAcc = 0;
+    const shooters: { row: number; col: number }[] = [];
+    for (let c = 0; c < ALIEN_COLS; c++) {
+      for (let r = ALIEN_ROWS - 1; r >= 0; r--) {
+        if (next.alienGrid[r][c]) {
+          shooters.push({ row: r, col: c });
+          break;
+        }
+      }
+    }
+    if (shooters.length > 0) {
+      const pick = shooters[Math.floor(Math.random() * shooters.length)]!;
+      const rect = alienRect(next, pick.row, pick.col);
+      if (rect) {
+        next.alienBullets = [
+          ...next.alienBullets,
+          {
+            x: (rect.left + rect.right) / 2,
+            y: rect.bottom + 2,
+          },
+        ];
+      }
+    }
+  }
+
+  // Move alien bullets down
+  next.alienBullets = next.alienBullets
+    .map((b) => ({ ...b, y: b.y + ALIEN_BULLET_SPEED * dt }))
+    .filter((b) => b.y < GAME_H + 20);
+
+  // Player bullets vs aliens
+  const grid = next.alienGrid.map((row) => [...row]);
+  let score = next.score;
+  const pBullets: typeof next.playerBullets = [];
+  for (const bullet of next.playerBullets) {
+    const br = {
+      left: bullet.x - BULLET_W / 2,
+      top: bullet.y - BULLET_H,
+      right: bullet.x + BULLET_W / 2,
+      bottom: bullet.y,
+    };
+    let hit = false;
+    for (let r = 0; r < ALIEN_ROWS && !hit; r++) {
+      for (let c = 0; c < ALIEN_COLS && !hit; c++) {
+        const ar = alienRect({ ...next, alienGrid: grid }, r, c);
+        if (!ar) continue;
+        if (overlap(br, ar)) {
+          grid[r][c] = false;
+          score += ALIEN_SCORE_BASE * next.wave;
+          hit = true;
+        }
+      }
+    }
+    if (!hit) pBullets.push(bullet);
+  }
+  next = { ...next, alienGrid: grid, score, playerBullets: pBullets };
+
+  // All aliens dead -> next wave
+  const aliveCount = grid.flat().filter(Boolean).length;
+  if (aliveCount === 0) {
+    next = {
+      ...next,
+      wave: next.wave + 1,
+    };
+    next = spawnWave(next);
+    return next;
+  }
+
+  // Alien bullets vs player
+  const pr = playerRect(next);
+  const prevLives = next.lives;
+  let lives = next.lives;
+  let tookHit = false;
+  const aBullets: typeof next.alienBullets = [];
+  for (const bullet of next.alienBullets) {
+    const br = {
+      left: bullet.x - BULLET_W / 2,
+      top: bullet.y,
+      right: bullet.x + BULLET_W / 2,
+      bottom: bullet.y + BULLET_H,
+    };
+    if (!tookHit && overlap(br, pr)) {
+      lives -= 1;
+      tookHit = true;
+    } else {
+      aBullets.push(bullet);
+    }
+  }
+  next = { ...next, alienBullets: aBullets, lives };
+
+  if (lives < prevLives) {
+    // Took damage: brief respite — clear incoming shots
+    next = {
+      ...next,
+      lives,
+      alienBullets: [],
+      playerX: GAME_W / 2,
+    };
+  }
+
+  if (lives <= 0) {
+    return { ...next, status: "gameover" };
+  }
+
+  // Invaders reached player line
+  const bounds = gridBounds(next);
+  if (bounds && bounds.maxY >= PLAYER_Y - 4) {
+    return { ...next, status: "gameover", lives: 0 };
+  }
+
+  return next;
+}
+
+export function serializeGame(state: GameState): SerializedGameV1 | null {
+  if (state.status === "gameover") return null;
+  return {
+    v: 1,
+    wave: state.wave,
+    lives: state.lives,
+    score: state.score,
+    weaponLevel: state.weaponLevel,
+    playerX: state.playerX,
+    alienGrid: state.alienGrid.map((r) => [...r]),
+    alienOriginX: state.alienOriginX,
+    alienOriginY: state.alienOriginY,
+    alienDir: state.alienDir,
+    alienMoveAcc: state.alienMoveAcc,
+    alienMoveEvery: state.alienMoveEvery,
+    playerBullets: state.playerBullets.map((b) => ({ ...b })),
+    alienBullets: state.alienBullets.map((b) => ({ ...b })),
+    playerFireCooldown: state.playerFireCooldown,
+    alienFireAcc: state.alienFireAcc,
+    alienFireEvery: state.alienFireEvery,
+    status: state.status === "paused" ? "paused" : "playing",
+  };
+}
+
+export function deserializeGame(data: SerializedGameV1): GameState {
+  return {
+    status: data.status === "paused" ? "paused" : "playing",
+    wave: data.wave,
+    lives: data.lives,
+    score: data.score,
+    weaponLevel: data.weaponLevel,
+    playerX: data.playerX,
+    alienGrid: data.alienGrid.map((r) => [...r]),
+    alienOriginX: data.alienOriginX,
+    alienOriginY: data.alienOriginY,
+    alienDir: data.alienDir,
+    alienMoveAcc: data.alienMoveAcc,
+    alienMoveEvery: data.alienMoveEvery,
+    playerBullets: data.playerBullets.map((b) => ({ ...b })),
+    alienBullets: data.alienBullets.map((b) => ({ ...b })),
+    playerFireCooldown: data.playerFireCooldown,
+    alienFireAcc: data.alienFireAcc,
+    alienFireEvery: data.alienFireEvery,
+  };
+}

--- a/src/lib/spaceInvaders/game.ts
+++ b/src/lib/spaceInvaders/game.ts
@@ -15,6 +15,11 @@ import {
   GAME_H,
   GAME_W,
   INITIAL_LIVES,
+  LOOT_FALL_SPEED,
+  LOOT_SPAWN_MAX,
+  LOOT_SPAWN_MIN,
+  MAX_SHIELD_CHARGES,
+  MAX_WEAPON_LEVEL,
   WAVE_CLEAR_DURATION,
   PLAYER_BULLET_SPEED,
   PLAYER_H,
@@ -22,7 +27,15 @@ import {
   PLAYER_W,
   PLAYER_Y,
 } from "./constants";
-import type { GameInput, GameState, SerializedGameV1 } from "./types";
+import type {
+  GameInput,
+  GameState,
+  LootDrop,
+  LootKind,
+  Particle,
+  PlayerBullet,
+  SerializedGameV1,
+} from "./types";
 
 function emptyGrid(): boolean[][] {
   return Array.from({ length: ALIEN_ROWS }, () =>
@@ -44,6 +57,91 @@ export function alienFireEveryForWave(wave: number): number {
   return Math.max(0.35, 1.1 - wave * 0.08);
 }
 
+function randomBetween(a: number, b: number): number {
+  return a + Math.random() * (b - a);
+}
+
+function newLootSpawnTimer(): number {
+  return randomBetween(LOOT_SPAWN_MIN, LOOT_SPAWN_MAX);
+}
+
+export function createBurst(
+  x: number,
+  y: number,
+  count: number,
+  hueBase: number,
+  speedMin = 52,
+  speedMax = 175,
+  lifeMin = 0.26,
+  lifeMax = 0.68,
+): Particle[] {
+  const out: Particle[] = [];
+  for (let i = 0; i < count; i++) {
+    const ang = Math.random() * Math.PI * 2;
+    const sp = randomBetween(speedMin, speedMax);
+    const life = randomBetween(lifeMin, lifeMax);
+    out.push({
+      x,
+      y,
+      vx: Math.cos(ang) * sp,
+      vy: Math.sin(ang) * sp,
+      life,
+      maxLife: life,
+      hue: hueBase + randomBetween(-40, 40),
+      size: randomBetween(1.5, 4.8),
+    });
+  }
+  return out;
+}
+
+function clampWeapon(w: number): number {
+  return Math.max(0, Math.min(MAX_WEAPON_LEVEL, Math.floor(w)));
+}
+
+function pushParticles(state: GameState, burst: Particle[]): GameState {
+  const cap = 240;
+  const combined = [...state.particles, ...burst].slice(-cap);
+  return { ...state, particles: combined };
+}
+
+function tickParticles(state: GameState, dt: number): GameState {
+  const particles = state.particles
+    .map((p) => ({
+      ...p,
+      x: p.x + p.vx * dt,
+      y: p.y + p.vy * dt,
+      vy: p.vy + 28 * dt,
+      life: p.life - dt,
+    }))
+    .filter((p) => p.life > 0);
+  return { ...state, particles };
+}
+
+function randomLootKind(): LootKind {
+  const r = Math.random();
+  if (r < 0.36) return "weapon";
+  if (r < 0.68) return "shield";
+  return "burst";
+}
+
+function spawnLootDrop(x: number, y: number, kind: LootKind): LootDrop {
+  return {
+    x,
+    y,
+    vy: LOOT_FALL_SPEED + randomBetween(-8, 14),
+    kind,
+    phase: Math.random() * Math.PI * 2,
+  };
+}
+
+function rollLootOnKill(cx: number, cy: number): LootDrop | null {
+  const r = Math.random();
+  if (r < 0.12) return spawnLootDrop(cx, cy, "weapon");
+  if (r < 0.22) return spawnLootDrop(cx, cy, "shield");
+  if (r < 0.28) return spawnLootDrop(cx, cy, "burst");
+  return null;
+}
+
 export function createInitialState(): GameState {
   const wave = 1;
   return {
@@ -52,6 +150,10 @@ export function createInitialState(): GameState {
     lives: INITIAL_LIVES,
     score: 0,
     weaponLevel: weaponLevelForWave(wave),
+    shieldCharges: 0,
+    lootDrops: [],
+    particles: [],
+    lootSpawnTimer: newLootSpawnTimer(),
     playerX: GAME_W / 2,
     alienGrid: emptyGrid(),
     alienOriginX: 24,
@@ -70,21 +172,31 @@ export function createInitialState(): GameState {
 
 export function spawnWave(state: GameState): GameState {
   const wave = state.wave;
-  return {
-    ...state,
-    alienGrid: emptyGrid(),
-    alienOriginX: 24,
-    alienOriginY: 56,
-    alienDir: 1,
-    alienMoveAcc: 0,
-    alienMoveEvery: alienMoveEveryForWave(wave),
-    alienFireEvery: alienFireEveryForWave(wave),
-    weaponLevel: weaponLevelForWave(wave),
-    playerBullets: [],
-    alienBullets: [],
-    status: "playing",
-    waveClearRemaining: 0,
-  };
+  const wx = state.playerX;
+  const wy = PLAYER_Y;
+  const celebrate = createBurst(wx, wy, 28, 210, 30, 120, 0.4, 0.9);
+  return pushParticles(
+    {
+      ...state,
+      alienGrid: emptyGrid(),
+      alienOriginX: 24,
+      alienOriginY: 56,
+      alienDir: 1,
+      alienMoveAcc: 0,
+      alienMoveEvery: alienMoveEveryForWave(wave),
+      alienFireEvery: alienFireEveryForWave(wave),
+      weaponLevel: Math.max(
+        weaponLevelForWave(wave),
+        clampWeapon(state.weaponLevel),
+      ),
+      playerBullets: [],
+      alienBullets: [],
+      lootDrops: [],
+      status: "playing",
+      waveClearRemaining: 0,
+    },
+    celebrate,
+  );
 }
 
 export function alienRect(
@@ -163,6 +275,17 @@ function overlap(
   );
 }
 
+const LOOT_BOX = 20;
+
+function lootRect(d: LootDrop) {
+  return {
+    left: d.x - LOOT_BOX / 2,
+    top: d.y - LOOT_BOX / 2,
+    right: d.x + LOOT_BOX / 2,
+    bottom: d.y + LOOT_BOX / 2,
+  };
+}
+
 export function tick(
   state: GameState,
   dt: number,
@@ -170,21 +293,22 @@ export function tick(
 ): GameState {
   if (state.status === "wave_clear") {
     const t = state.waveClearRemaining - dt;
+    let next: GameState = tickParticles(state, dt);
     if (t <= 0) {
       return spawnWave({
-        ...state,
+        ...next,
         status: "playing",
         waveClearRemaining: 0,
       });
     }
-    return { ...state, waveClearRemaining: t };
+    return { ...next, waveClearRemaining: t };
   }
 
   if (state.status !== "playing") return state;
 
   let next: GameState = { ...state };
+  next = tickParticles(next, dt);
 
-  // Player movement
   if (input.moveLeft) {
     next.playerX = Math.max(PLAYER_W / 2 + 4, next.playerX - PLAYER_SPEED * dt);
   }
@@ -195,39 +319,52 @@ export function tick(
     );
   }
 
-  // Fire cooldown
   next.playerFireCooldown = Math.max(0, next.playerFireCooldown - dt);
 
-  const fireInterval = FIRE_INTERVAL[next.weaponLevel] ?? FIRE_INTERVAL[0];
+  const lvl = clampWeapon(next.weaponLevel);
+  const fireInterval = FIRE_INTERVAL[lvl] ?? FIRE_INTERVAL[0];
   if (input.fire && next.playerFireCooldown <= 0) {
     const px = next.playerX;
     const py = PLAYER_Y - 4;
-    const lvl = next.weaponLevel;
+    const burstMuzzle = createBurst(px, py + 4, 4, 145, 20, 55, 0.08, 0.16);
+    next = pushParticles(next, burstMuzzle);
+    const shots: PlayerBullet[] = [];
     if (lvl === 0) {
-      next.playerBullets = [...next.playerBullets, { x: px, y: py }];
+      shots.push({ x: px, y: py });
     } else if (lvl === 1) {
-      next.playerBullets = [
-        ...next.playerBullets,
-        { x: px - 10, y: py },
-        { x: px + 10, y: py },
-      ];
-    } else {
-      next.playerBullets = [
-        ...next.playerBullets,
+      shots.push({ x: px - 10, y: py }, { x: px + 10, y: py });
+    } else if (lvl === 2) {
+      shots.push(
         { x: px - 14, y: py },
         { x: px, y: py },
         { x: px + 14, y: py },
-      ];
+      );
+    } else if (lvl === 3) {
+      shots.push(
+        { x: px - 16, y: py },
+        { x: px - 8, y: py },
+        { x: px, y: py },
+        { x: px + 8, y: py },
+        { x: px + 16, y: py },
+      );
+    } else {
+      const spread = [-100, -52, 0, 52, 100];
+      for (const vx of spread) {
+        shots.push({ x: px, y: py, vx });
+      }
     }
+    next.playerBullets = [...next.playerBullets, ...shots];
     next.playerFireCooldown = fireInterval;
   }
 
-  // Move player bullets up
   next.playerBullets = next.playerBullets
-    .map((b) => ({ ...b, y: b.y - PLAYER_BULLET_SPEED * dt }))
-    .filter((b) => b.y > -BULLET_H);
+    .map((b) => ({
+      ...b,
+      x: b.x + (b.vx ?? 0) * dt,
+      y: b.y - (b.vy ?? PLAYER_BULLET_SPEED) * dt,
+    }))
+    .filter((b) => b.y > -BULLET_H && b.x > -12 && b.x < GAME_W + 12);
 
-  // Alien stepping (cap steps per tick for stability on lag spikes)
   next.alienMoveAcc += dt;
   let steps = 0;
   while (next.alienMoveAcc >= next.alienMoveEvery && steps < 4) {
@@ -236,7 +373,6 @@ export function tick(
     steps += 1;
   }
 
-  // Alien fire (at most one shot per frame from accumulator)
   next.alienFireAcc += dt;
   if (next.alienFireAcc >= next.alienFireEvery) {
     next.alienFireAcc = 0;
@@ -264,12 +400,30 @@ export function tick(
     }
   }
 
-  // Move alien bullets down
   next.alienBullets = next.alienBullets
     .map((b) => ({ ...b, y: b.y + ALIEN_BULLET_SPEED * dt }))
     .filter((b) => b.y < GAME_H + 20);
 
-  // Player bullets vs aliens
+  // Random bonus from the sky
+  next.lootSpawnTimer -= dt;
+  if (next.lootSpawnTimer <= 0) {
+    next.lootSpawnTimer = newLootSpawnTimer();
+    const lx = randomBetween(36, GAME_W - 36);
+    next.lootDrops = [
+      ...next.lootDrops,
+      spawnLootDrop(lx, -10, randomLootKind()),
+    ];
+    next = pushParticles(next, createBurst(lx, 8, 10, 280, 15, 45, 0.35, 0.55));
+  }
+
+  next.lootDrops = next.lootDrops
+    .map((d) => ({
+      ...d,
+      y: d.y + d.vy * dt,
+      phase: d.phase + dt * 5,
+    }))
+    .filter((d) => d.y < GAME_H + 24);
+
   const grid = next.alienGrid.map((row) => [...row]);
   let score = next.score;
   const pBullets: typeof next.playerBullets = [];
@@ -288,6 +442,27 @@ export function tick(
         if (overlap(br, ar)) {
           grid[r][c] = false;
           score += ALIEN_SCORE_BASE * next.wave;
+          const cx = (ar.left + ar.right) / 2;
+          const cy = (ar.top + ar.bottom) / 2;
+          next = pushParticles(
+            next,
+            createBurst(cx, cy, 16, 32 + r * 14, 55, 190),
+          );
+          const drop = rollLootOnKill(cx, cy);
+          if (drop) {
+            next.lootDrops = [...next.lootDrops, drop];
+            next = pushParticles(
+              next,
+              createBurst(
+                cx,
+                cy,
+                22,
+                drop.kind === "weapon" ? 48 : 175,
+                40,
+                140,
+              ),
+            );
+          }
           hit = true;
         }
       }
@@ -296,26 +471,65 @@ export function tick(
   }
   next = { ...next, alienGrid: grid, score, playerBullets: pBullets };
 
-  // All aliens dead -> next wave
   const aliveCount = grid.flat().filter(Boolean).length;
   if (aliveCount === 0) {
-    return {
-      ...next,
-      status: "wave_clear",
-      wave: next.wave + 1,
-      waveClearRemaining: WAVE_CLEAR_DURATION,
-      alienGrid: emptyGrid(),
-      playerBullets: [],
-      alienBullets: [],
-      alienMoveAcc: 0,
-      alienFireAcc: 0,
-    };
+    return pushParticles(
+      {
+        ...next,
+        status: "wave_clear",
+        wave: next.wave + 1,
+        waveClearRemaining: WAVE_CLEAR_DURATION,
+        alienGrid: emptyGrid(),
+        playerBullets: [],
+        alienBullets: [],
+        lootDrops: [],
+        alienMoveAcc: 0,
+        alienFireAcc: 0,
+      },
+      createBurst(GAME_W / 2, GAME_H * 0.35, 40, 300, 60, 200),
+    );
   }
 
-  // Alien bullets vs player
   const pr = playerRect(next);
+  const pickupPad = 6;
+  const prWide = {
+    left: pr.left - pickupPad,
+    top: pr.top - pickupPad,
+    right: pr.right + pickupPad,
+    bottom: pr.bottom + pickupPad,
+  };
+  const keptLoot: LootDrop[] = [];
+  for (const d of next.lootDrops) {
+    if (overlap(lootRect(d), prWide)) {
+      const cx = d.x;
+      const cy = d.y;
+      next = pushParticles(next, createBurst(cx, cy, 36, 52, 70, 220));
+      if (d.kind === "weapon") {
+        next.weaponLevel = clampWeapon(next.weaponLevel + 1);
+        next = pushParticles(
+          next,
+          createBurst(cx, cy, 24, 38, 80, 240, 0.2, 0.45),
+        );
+      } else if (d.kind === "shield") {
+        next.shieldCharges = Math.min(
+          MAX_SHIELD_CHARGES,
+          next.shieldCharges + 1,
+        );
+        next = pushParticles(next, createBurst(cx, cy, 20, 200, 50, 160));
+      } else {
+        score += 65 + next.wave * 8;
+        next = pushParticles(next, createBurst(cx, cy, 30, 45, 90, 260));
+      }
+      next.score = score;
+    } else {
+      keptLoot.push(d);
+    }
+  }
+  next = { ...next, lootDrops: keptLoot, score };
+
   const prevLives = next.lives;
   let lives = next.lives;
+  let shieldCharges = next.shieldCharges;
   let tookHit = false;
   const aBullets: typeof next.alienBullets = [];
   for (const bullet of next.alienBullets) {
@@ -325,33 +539,57 @@ export function tick(
       right: bullet.x + BULLET_W / 2,
       bottom: bullet.y + BULLET_H,
     };
-    if (!tookHit && overlap(br, pr)) {
-      lives -= 1;
-      tookHit = true;
+    if (overlap(br, pr)) {
+      if (shieldCharges > 0) {
+        shieldCharges -= 1;
+        next = pushParticles(
+          next,
+          createBurst(
+            (br.left + br.right) / 2,
+            (br.top + br.bottom) / 2,
+            14,
+            195,
+            30,
+            110,
+          ),
+        );
+      } else if (!tookHit) {
+        lives -= 1;
+        tookHit = true;
+      }
     } else {
       aBullets.push(bullet);
     }
   }
-  next = { ...next, alienBullets: aBullets, lives };
+  next = { ...next, alienBullets: aBullets, lives, shieldCharges };
 
   if (lives < prevLives) {
-    // Took damage: brief respite — clear incoming shots
+    next = pushParticles(
+      next,
+      createBurst(next.playerX, PLAYER_Y, 45, 0, 80, 220, 0.35, 0.75),
+    );
     next = {
       ...next,
       lives,
       alienBullets: [],
+      shieldCharges: 0,
       playerX: GAME_W / 2,
     };
   }
 
   if (lives <= 0) {
-    return { ...next, status: "gameover" };
+    return pushParticles(
+      { ...next, status: "gameover" },
+      createBurst(next.playerX, PLAYER_Y, 70, 12, 100, 280, 0.5, 1.0),
+    );
   }
 
-  // Invaders reached player line
   const bounds = gridBounds(next);
   if (bounds && bounds.maxY >= PLAYER_Y - 4) {
-    return { ...next, status: "gameover", lives: 0 };
+    return pushParticles(
+      { ...next, status: "gameover", lives: 0 },
+      createBurst(GAME_W / 2, PLAYER_Y - 40, 55, 25, 90, 260),
+    );
   }
 
   return next;
@@ -366,11 +604,11 @@ export function serializeGame(state: GameState): SerializedGameV1 | null {
         ? "wave_clear"
         : "playing";
   return {
-    v: 1,
+    v: 2,
     wave: state.wave,
     lives: state.lives,
     score: state.score,
-    weaponLevel: state.weaponLevel,
+    weaponLevel: clampWeapon(state.weaponLevel),
     playerX: state.playerX,
     alienGrid: state.alienGrid.map((r) => [...r]),
     alienOriginX: state.alienOriginX,
@@ -386,6 +624,9 @@ export function serializeGame(state: GameState): SerializedGameV1 | null {
     status,
     waveClearRemaining:
       state.status === "wave_clear" ? state.waveClearRemaining : undefined,
+    shieldCharges: state.shieldCharges,
+    lootDrops: state.lootDrops.map((d) => ({ ...d })),
+    lootSpawnTimer: state.lootSpawnTimer,
   };
 }
 
@@ -396,12 +637,13 @@ export function deserializeGame(data: SerializedGameV1): GameState {
       : data.status === "wave_clear"
         ? "wave_clear"
         : "playing";
+  const v = data.v === 2 ? 2 : 1;
   return {
     status,
     wave: data.wave,
     lives: data.lives,
     score: data.score,
-    weaponLevel: data.weaponLevel,
+    weaponLevel: clampWeapon(data.weaponLevel),
     playerX: data.playerX,
     alienGrid: data.alienGrid.map((r) => [...r]),
     alienOriginX: data.alienOriginX,
@@ -420,5 +662,24 @@ export function deserializeGame(data: SerializedGameV1): GameState {
           ? data.waveClearRemaining
           : WAVE_CLEAR_DURATION
         : 0,
+    shieldCharges:
+      v === 2 && typeof data.shieldCharges === "number"
+        ? Math.min(MAX_SHIELD_CHARGES, Math.max(0, data.shieldCharges))
+        : 0,
+    lootDrops:
+      v === 2 && Array.isArray(data.lootDrops)
+        ? data.lootDrops.map((d) => ({
+            x: d.x,
+            y: d.y,
+            vy: d.vy,
+            kind: d.kind,
+            phase: typeof d.phase === "number" ? d.phase : 0,
+          }))
+        : [],
+    particles: [],
+    lootSpawnTimer:
+      v === 2 && typeof data.lootSpawnTimer === "number"
+        ? data.lootSpawnTimer
+        : newLootSpawnTimer(),
   };
 }

--- a/src/lib/spaceInvaders/game.ts
+++ b/src/lib/spaceInvaders/game.ts
@@ -320,7 +320,9 @@ export function spawnWave(state: GameState): GameState {
       alienDir: 1,
       alienMoveAcc: 0,
       alienMoveEvery: alienMoveEveryForWave(wave),
+      alienFireAcc: 0,
       alienFireEvery: alienFireEveryForWave(wave),
+      playerFireCooldown: 0,
       weaponLevel: Math.max(
         weaponLevelForWave(wave),
         clampWeapon(state.weaponLevel),
@@ -422,41 +424,31 @@ function lootRect(d: LootDrop) {
   };
 }
 
-export function tick(
+function tickPlayerMovementFireAndBullets(
   state: GameState,
   dt: number,
   input: GameInput,
 ): GameState {
-  if (state.status === "wave_clear") {
-    const t = state.waveClearRemaining - dt;
-    let next: GameState = tickParticles(state, dt);
-    if (t <= 0) {
-      return spawnWave({
-        ...next,
-        status: "playing",
-        waveClearRemaining: 0,
-      });
-    }
-    return { ...next, waveClearRemaining: t };
-  }
-
-  if (state.status !== "playing") return state;
-
-  let next: GameState = { ...state };
-  next = tickParticles(next, dt);
-
+  let next = state;
   if (input.moveLeft) {
-    next.playerX = Math.max(PLAYER_W / 2 + 4, next.playerX - PLAYER_SPEED * dt);
+    next = {
+      ...next,
+      playerX: Math.max(PLAYER_W / 2 + 4, next.playerX - PLAYER_SPEED * dt),
+    };
   }
   if (input.moveRight) {
-    next.playerX = Math.min(
-      GAME_W - PLAYER_W / 2 - 4,
-      next.playerX + PLAYER_SPEED * dt,
-    );
+    next = {
+      ...next,
+      playerX: Math.min(
+        GAME_W - PLAYER_W / 2 - 4,
+        next.playerX + PLAYER_SPEED * dt,
+      ),
+    };
   }
-
-  next.playerFireCooldown = Math.max(0, next.playerFireCooldown - dt);
-
+  next = {
+    ...next,
+    playerFireCooldown: Math.max(0, next.playerFireCooldown - dt),
+  };
   const lvl = clampWeapon(next.weaponLevel);
   const fireInterval = FIRE_INTERVAL[lvl] ?? FIRE_INTERVAL[0];
   if (input.fire && next.playerFireCooldown <= 0) {
@@ -489,29 +481,39 @@ export function tick(
         shots.push({ x: px, y: py, vx });
       }
     }
-    next.playerBullets = [...next.playerBullets, ...shots];
-    next.playerFireCooldown = fireInterval;
+    next = {
+      ...next,
+      playerBullets: [...next.playerBullets, ...shots],
+      playerFireCooldown: fireInterval,
+    };
   }
+  return {
+    ...next,
+    playerBullets: next.playerBullets
+      .map((b) => ({
+        ...b,
+        x: b.x + (b.vx ?? 0) * dt,
+        y: b.y - (b.vy ?? PLAYER_BULLET_SPEED) * dt,
+      }))
+      .filter((b) => b.y > -BULLET_H && b.x > -12 && b.x < GAME_W + 12),
+  };
+}
 
-  next.playerBullets = next.playerBullets
-    .map((b) => ({
-      ...b,
-      x: b.x + (b.vx ?? 0) * dt,
-      y: b.y - (b.vy ?? PLAYER_BULLET_SPEED) * dt,
-    }))
-    .filter((b) => b.y > -BULLET_H && b.x > -12 && b.x < GAME_W + 12);
-
-  next.alienMoveAcc += dt;
+function tickAlienMotionFireAndAlienBullets(
+  state: GameState,
+  dt: number,
+): GameState {
+  let next = state;
+  next = { ...next, alienMoveAcc: next.alienMoveAcc + dt };
   let steps = 0;
   while (next.alienMoveAcc >= next.alienMoveEvery && steps < 4) {
-    next.alienMoveAcc -= next.alienMoveEvery;
+    next = { ...next, alienMoveAcc: next.alienMoveAcc - next.alienMoveEvery };
     next = stepAliens(next);
     steps += 1;
   }
-
-  next.alienFireAcc += dt;
+  next = { ...next, alienFireAcc: next.alienFireAcc + dt };
   if (next.alienFireAcc >= next.alienFireEvery) {
-    next.alienFireAcc = 0;
+    next = { ...next, alienFireAcc: 0 };
     const shooters: { row: number; col: number }[] = [];
     for (let c = 0; c < ALIEN_COLS; c++) {
       for (let r = ALIEN_ROWS - 1; r >= 0; r--) {
@@ -540,42 +542,51 @@ export function tick(
           );
         }
       }
-      next.alienBullets = [...next.alienBullets, ...spawned];
+      next = { ...next, alienBullets: [...next.alienBullets, ...spawned] };
     }
   }
+  return {
+    ...next,
+    alienBullets: next.alienBullets
+      .map((b) => ({
+        ...b,
+        x: b.x + b.vx * dt,
+        y: b.y + b.vy * dt,
+      }))
+      .filter((b) => b.y < GAME_H + 36 && b.x > -24 && b.x < GAME_W + 24),
+  };
+}
 
-  next.alienBullets = next.alienBullets
-    .map((b) => ({
-      ...b,
-      x: b.x + b.vx * dt,
-      y: b.y + b.vy * dt,
-    }))
-    .filter((b) => b.y < GAME_H + 36 && b.x > -24 && b.x < GAME_W + 24);
-
-  // Random bonus from the sky
-  next.lootSpawnTimer -= dt;
+function tickLootSpawnAndMove(state: GameState, dt: number): GameState {
+  let next = state;
+  next = { ...next, lootSpawnTimer: next.lootSpawnTimer - dt };
   if (next.lootSpawnTimer <= 0) {
-    next.lootSpawnTimer = newLootSpawnTimer();
+    next = { ...next, lootSpawnTimer: newLootSpawnTimer() };
     const lx = randomBetween(36, GAME_W - 36);
-    next.lootDrops = [
-      ...next.lootDrops,
-      spawnLootDrop(lx, -10, randomLootKind()),
-    ];
+    next = {
+      ...next,
+      lootDrops: [...next.lootDrops, spawnLootDrop(lx, -10, randomLootKind())],
+    };
     next = pushParticles(next, createBurst(lx, 8, 10, 280, 15, 45, 0.35, 0.55));
   }
+  return {
+    ...next,
+    lootDrops: next.lootDrops
+      .map((d) => ({
+        ...d,
+        y: d.y + d.vy * dt,
+        phase: d.phase + dt * 5,
+      }))
+      .filter((d) => d.y < GAME_H + 24),
+  };
+}
 
-  next.lootDrops = next.lootDrops
-    .map((d) => ({
-      ...d,
-      y: d.y + d.vy * dt,
-      phase: d.phase + dt * 5,
-    }))
-    .filter((d) => d.y < GAME_H + 24);
-
-  const grid = next.alienGrid.map((row) => [...row]);
-  let score = next.score;
-  const pBullets: typeof next.playerBullets = [];
-  for (const bullet of next.playerBullets) {
+function resolvePlayerBulletsVsAliens(state: GameState): GameState {
+  const grid = state.alienGrid.map((row) => [...row]);
+  let score = state.score;
+  let next = state;
+  const pBullets: PlayerBullet[] = [];
+  for (const bullet of state.playerBullets) {
     const br = {
       left: bullet.x - BULLET_W / 2,
       top: bullet.y - BULLET_H,
@@ -598,7 +609,7 @@ export function tick(
           );
           const drop = rollLootOnKill(cx, cy);
           if (drop) {
-            next.lootDrops = [...next.lootDrops, drop];
+            next = { ...next, lootDrops: [...next.lootDrops, drop] };
             next = pushParticles(
               next,
               createBurst(
@@ -617,28 +628,36 @@ export function tick(
     }
     if (!hit) pBullets.push(bullet);
   }
-  next = { ...next, alienGrid: grid, score, playerBullets: pBullets };
+  return {
+    ...next,
+    alienGrid: grid,
+    score,
+    playerBullets: pBullets,
+  };
+}
 
-  const aliveCount = grid.flat().filter(Boolean).length;
-  if (aliveCount === 0) {
-    return pushParticles(
-      {
-        ...next,
-        status: "wave_clear",
-        wave: next.wave + 1,
-        waveClearRemaining: WAVE_CLEAR_DURATION,
-        alienGrid: emptyGrid(),
-        playerBullets: [],
-        alienBullets: [],
-        lootDrops: [],
-        alienMoveAcc: 0,
-        alienFireAcc: 0,
-      },
-      createBurst(GAME_W / 2, GAME_H * 0.35, 40, 300, 60, 200),
-    );
-  }
+function waveClearIfAllAliensDead(state: GameState): GameState | null {
+  const aliveCount = state.alienGrid.flat().filter(Boolean).length;
+  if (aliveCount !== 0) return null;
+  return pushParticles(
+    {
+      ...state,
+      status: "wave_clear",
+      wave: state.wave + 1,
+      waveClearRemaining: WAVE_CLEAR_DURATION,
+      alienGrid: emptyGrid(),
+      playerBullets: [],
+      alienBullets: [],
+      lootDrops: [],
+      alienMoveAcc: 0,
+      alienFireAcc: 0,
+    },
+    createBurst(GAME_W / 2, GAME_H * 0.35, 40, 300, 60, 200),
+  );
+}
 
-  const pr = playerRect(next);
+function collectLootPickups(state: GameState): GameState {
+  const pr = playerRect(state);
   const pickupPad = 6;
   const prWide = {
     left: pr.left - pickupPad,
@@ -646,6 +665,8 @@ export function tick(
     right: pr.right + pickupPad,
     bottom: pr.bottom + pickupPad,
   };
+  let next = state;
+  let score = next.score;
   const keptLoot: LootDrop[] = [];
   for (const d of next.lootDrops) {
     if (overlap(lootRect(d), prWide)) {
@@ -653,33 +674,40 @@ export function tick(
       const cy = d.y;
       next = pushParticles(next, createBurst(cx, cy, 36, 52, 70, 220));
       if (d.kind === "weapon") {
-        next.weaponLevel = clampWeapon(next.weaponLevel + 1);
+        next = {
+          ...next,
+          weaponLevel: clampWeapon(next.weaponLevel + 1),
+        };
         next = pushParticles(
           next,
           createBurst(cx, cy, 24, 38, 80, 240, 0.2, 0.45),
         );
       } else if (d.kind === "shield") {
-        next.shieldCharges = Math.min(
-          MAX_SHIELD_CHARGES,
-          next.shieldCharges + 1,
-        );
+        next = {
+          ...next,
+          shieldCharges: Math.min(MAX_SHIELD_CHARGES, next.shieldCharges + 1),
+        };
         next = pushParticles(next, createBurst(cx, cy, 20, 200, 50, 160));
       } else {
         score += 65 + next.wave * 8;
         next = pushParticles(next, createBurst(cx, cy, 30, 45, 90, 260));
       }
-      next.score = score;
+      next = { ...next, score };
     } else {
       keptLoot.push(d);
     }
   }
-  next = { ...next, lootDrops: keptLoot, score };
+  return { ...next, lootDrops: keptLoot };
+}
 
-  const prevLives = next.lives;
+function resolveAlienBulletsAndEndgame(state: GameState): GameState {
+  const pr = playerRect(state);
+  const prevLives = state.lives;
+  let next = state;
   let lives = next.lives;
   let shieldCharges = next.shieldCharges;
   let tookHit = false;
-  const aBullets: typeof next.alienBullets = [];
+  const aBullets: AlienBullet[] = [];
   for (const bullet of next.alienBullets) {
     const br = alienBulletHitRect(bullet);
     if (overlap(br, pr)) {
@@ -735,6 +763,39 @@ export function tick(
     );
   }
 
+  return next;
+}
+
+export function tick(
+  state: GameState,
+  dt: number,
+  input: GameInput,
+): GameState {
+  if (state.status === "wave_clear") {
+    const t = state.waveClearRemaining - dt;
+    let next: GameState = tickParticles(state, dt);
+    if (t <= 0) {
+      return spawnWave({
+        ...next,
+        status: "playing",
+        waveClearRemaining: 0,
+      });
+    }
+    return { ...next, waveClearRemaining: t };
+  }
+
+  if (state.status !== "playing") return state;
+
+  let next: GameState = { ...state };
+  next = tickParticles(next, dt);
+  next = tickPlayerMovementFireAndBullets(next, dt, input);
+  next = tickAlienMotionFireAndAlienBullets(next, dt);
+  next = tickLootSpawnAndMove(next, dt);
+  next = resolvePlayerBulletsVsAliens(next);
+  const cleared = waveClearIfAllAliensDead(next);
+  if (cleared) return cleared;
+  next = collectLootPickups(next);
+  next = resolveAlienBulletsAndEndgame(next);
   return next;
 }
 

--- a/src/lib/spaceInvaders/game.ts
+++ b/src/lib/spaceInvaders/game.ts
@@ -15,6 +15,7 @@ import {
   GAME_H,
   GAME_W,
   INITIAL_LIVES,
+  WAVE_CLEAR_DURATION,
   PLAYER_BULLET_SPEED,
   PLAYER_H,
   PLAYER_SPEED,
@@ -63,6 +64,7 @@ export function createInitialState(): GameState {
     playerFireCooldown: 0,
     alienFireAcc: 0,
     alienFireEvery: alienFireEveryForWave(wave),
+    waveClearRemaining: 0,
   };
 }
 
@@ -81,6 +83,7 @@ export function spawnWave(state: GameState): GameState {
     playerBullets: [],
     alienBullets: [],
     status: "playing",
+    waveClearRemaining: 0,
   };
 }
 
@@ -165,6 +168,18 @@ export function tick(
   dt: number,
   input: GameInput,
 ): GameState {
+  if (state.status === "wave_clear") {
+    const t = state.waveClearRemaining - dt;
+    if (t <= 0) {
+      return spawnWave({
+        ...state,
+        status: "playing",
+        waveClearRemaining: 0,
+      });
+    }
+    return { ...state, waveClearRemaining: t };
+  }
+
   if (state.status !== "playing") return state;
 
   let next: GameState = { ...state };
@@ -284,12 +299,17 @@ export function tick(
   // All aliens dead -> next wave
   const aliveCount = grid.flat().filter(Boolean).length;
   if (aliveCount === 0) {
-    next = {
+    return {
       ...next,
+      status: "wave_clear",
       wave: next.wave + 1,
+      waveClearRemaining: WAVE_CLEAR_DURATION,
+      alienGrid: emptyGrid(),
+      playerBullets: [],
+      alienBullets: [],
+      alienMoveAcc: 0,
+      alienFireAcc: 0,
     };
-    next = spawnWave(next);
-    return next;
   }
 
   // Alien bullets vs player
@@ -339,6 +359,12 @@ export function tick(
 
 export function serializeGame(state: GameState): SerializedGameV1 | null {
   if (state.status === "gameover") return null;
+  const status: SerializedGameV1["status"] =
+    state.status === "paused"
+      ? "paused"
+      : state.status === "wave_clear"
+        ? "wave_clear"
+        : "playing";
   return {
     v: 1,
     wave: state.wave,
@@ -357,13 +383,21 @@ export function serializeGame(state: GameState): SerializedGameV1 | null {
     playerFireCooldown: state.playerFireCooldown,
     alienFireAcc: state.alienFireAcc,
     alienFireEvery: state.alienFireEvery,
-    status: state.status === "paused" ? "paused" : "playing",
+    status,
+    waveClearRemaining:
+      state.status === "wave_clear" ? state.waveClearRemaining : undefined,
   };
 }
 
 export function deserializeGame(data: SerializedGameV1): GameState {
+  const status: GameState["status"] =
+    data.status === "paused"
+      ? "paused"
+      : data.status === "wave_clear"
+        ? "wave_clear"
+        : "playing";
   return {
-    status: data.status === "paused" ? "paused" : "playing",
+    status,
     wave: data.wave,
     lives: data.lives,
     score: data.score,
@@ -380,5 +414,11 @@ export function deserializeGame(data: SerializedGameV1): GameState {
     playerFireCooldown: data.playerFireCooldown,
     alienFireAcc: data.alienFireAcc,
     alienFireEvery: data.alienFireEvery,
+    waveClearRemaining:
+      data.status === "wave_clear"
+        ? typeof data.waveClearRemaining === "number"
+          ? data.waveClearRemaining
+          : WAVE_CLEAR_DURATION
+        : 0,
   };
 }

--- a/src/lib/spaceInvaders/game.ts
+++ b/src/lib/spaceInvaders/game.ts
@@ -28,12 +28,15 @@ import {
   PLAYER_Y,
 } from "./constants";
 import type {
+  AlienBullet,
+  AlienWeaponKind,
   GameInput,
   GameState,
   LootDrop,
   LootKind,
   Particle,
   PlayerBullet,
+  SerializedAlienBullet,
   SerializedGameV1,
 } from "./types";
 
@@ -54,7 +57,140 @@ export function alienMoveEveryForWave(wave: number): number {
 }
 
 export function alienFireEveryForWave(wave: number): number {
-  return Math.max(0.35, 1.1 - wave * 0.08);
+  return Math.max(0.18, 1.1 - wave * 0.082);
+}
+
+/** Downward speed scale (px/s), capped for fairness */
+export function alienBulletSpeedForWave(wave: number): number {
+  return Math.min(230, ALIEN_BULLET_SPEED + wave * 7.5);
+}
+
+/** How many bottom shooters fire on the same tick (different columns when possible) */
+export function alienVolleyCountForWave(wave: number): number {
+  if (wave >= 12) return 3;
+  if (wave >= 6) return 2;
+  return 1;
+}
+
+/**
+ * Pick alien projectile type from wave, row (top → needle bias, bottom → heavy), and rng in [0,1).
+ */
+export function pickAlienWeaponKind(
+  wave: number,
+  row: number,
+  rand01: number,
+): AlienWeaponKind {
+  const fromTop = row;
+  const fromBottom = ALIEN_ROWS - 1 - row;
+  /** 0 on wave 1 → bolt-only; ramps to 1 by ~wave 6 */
+  const ramp = Math.min(1, Math.max(0, (wave - 1) / 5));
+  const needleChance =
+    ramp * Math.min(0.35, 0.05 + wave * 0.018 + fromTop * 0.04);
+  const heavyChance =
+    ramp * Math.min(0.22, Math.max(0, wave - 3) * 0.022 + fromBottom * 0.035);
+  const plasmaChance =
+    ramp * Math.min(0.28, Math.max(0, wave - 2) * 0.025 + 0.06);
+
+  let r = rand01;
+  if (r < needleChance) return "needle";
+  r -= needleChance;
+  if (r < heavyChance) return "heavy";
+  r -= heavyChance;
+  if (r < plasmaChance) return "plasma";
+  return "bolt";
+}
+
+function velocityForAlienWeapon(
+  kind: AlienWeaponKind,
+  wave: number,
+  needleVxSeed: number,
+): { vx: number; vy: number } {
+  const base = alienBulletSpeedForWave(wave);
+  switch (kind) {
+    case "bolt":
+      return { vx: 0, vy: base };
+    case "plasma":
+      return { vx: 0, vy: base * 0.82 };
+    case "needle":
+      return {
+        vx: (needleVxSeed - 0.5) * 95,
+        vy: base * 1.22,
+      };
+    case "heavy":
+      return { vx: 0, vy: base * 0.68 };
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+export function createAlienBullet(
+  x: number,
+  y: number,
+  wave: number,
+  row: number,
+  randKind: number,
+  randNeedle: number,
+): AlienBullet {
+  const kind = pickAlienWeaponKind(wave, row, randKind);
+  const { vx, vy } = velocityForAlienWeapon(kind, wave, randNeedle);
+  return { x, y, kind, vx, vy };
+}
+
+function alienBulletHitSize(kind: AlienWeaponKind): { w: number; h: number } {
+  switch (kind) {
+    case "needle":
+      return { w: BULLET_W * 0.78, h: BULLET_H * 1.05 };
+    case "plasma":
+      return { w: BULLET_W * 1.55, h: BULLET_H * 1.22 };
+    case "heavy":
+      return { w: BULLET_W * 1.72, h: BULLET_H * 1.48 };
+    case "bolt":
+      return { w: BULLET_W, h: BULLET_H };
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+}
+
+export function alienBulletHitRect(b: AlienBullet) {
+  const { w, h } = alienBulletHitSize(b.kind);
+  return {
+    left: b.x - w / 2,
+    top: b.y,
+    right: b.x + w / 2,
+    bottom: b.y + h,
+  };
+}
+
+function sampleWithoutReplacement<T>(items: T[], count: number): T[] {
+  const pool = [...items];
+  const out: T[] = [];
+  const n = Math.min(count, pool.length);
+  for (let i = 0; i < n; i++) {
+    const j = Math.floor(Math.random() * pool.length);
+    out.push(pool[j]!);
+    pool.splice(j, 1);
+  }
+  return out;
+}
+
+function normalizeAlienBullet(
+  b: SerializedAlienBullet,
+  wave: number,
+): AlienBullet {
+  const kind = b.kind ?? "bolt";
+  if (typeof b.vx === "number" && typeof b.vy === "number") {
+    return { x: b.x, y: b.y, kind, vx: b.vx, vy: b.vy };
+  }
+  return {
+    x: b.x,
+    y: b.y,
+    kind,
+    ...velocityForAlienWeapon(kind, wave, 0.5),
+  };
 }
 
 function randomBetween(a: number, b: number): number {
@@ -386,23 +522,35 @@ export function tick(
       }
     }
     if (shooters.length > 0) {
-      const pick = shooters[Math.floor(Math.random() * shooters.length)]!;
-      const rect = alienRect(next, pick.row, pick.col);
-      if (rect) {
-        next.alienBullets = [
-          ...next.alienBullets,
-          {
-            x: (rect.left + rect.right) / 2,
-            y: rect.bottom + 2,
-          },
-        ];
+      const volley = alienVolleyCountForWave(next.wave);
+      const picked = sampleWithoutReplacement(shooters, volley);
+      const spawned: AlienBullet[] = [];
+      for (const pick of picked) {
+        const rect = alienRect(next, pick.row, pick.col);
+        if (rect) {
+          spawned.push(
+            createAlienBullet(
+              (rect.left + rect.right) / 2,
+              rect.bottom + 2,
+              next.wave,
+              pick.row,
+              Math.random(),
+              Math.random(),
+            ),
+          );
+        }
       }
+      next.alienBullets = [...next.alienBullets, ...spawned];
     }
   }
 
   next.alienBullets = next.alienBullets
-    .map((b) => ({ ...b, y: b.y + ALIEN_BULLET_SPEED * dt }))
-    .filter((b) => b.y < GAME_H + 20);
+    .map((b) => ({
+      ...b,
+      x: b.x + b.vx * dt,
+      y: b.y + b.vy * dt,
+    }))
+    .filter((b) => b.y < GAME_H + 36 && b.x > -24 && b.x < GAME_W + 24);
 
   // Random bonus from the sky
   next.lootSpawnTimer -= dt;
@@ -533,12 +681,7 @@ export function tick(
   let tookHit = false;
   const aBullets: typeof next.alienBullets = [];
   for (const bullet of next.alienBullets) {
-    const br = {
-      left: bullet.x - BULLET_W / 2,
-      top: bullet.y,
-      right: bullet.x + BULLET_W / 2,
-      bottom: bullet.y + BULLET_H,
-    };
+    const br = alienBulletHitRect(bullet);
     if (overlap(br, pr)) {
       if (shieldCharges > 0) {
         shieldCharges -= 1;
@@ -652,7 +795,9 @@ export function deserializeGame(data: SerializedGameV1): GameState {
     alienMoveAcc: data.alienMoveAcc,
     alienMoveEvery: data.alienMoveEvery,
     playerBullets: data.playerBullets.map((b) => ({ ...b })),
-    alienBullets: data.alienBullets.map((b) => ({ ...b })),
+    alienBullets: data.alienBullets.map((b) =>
+      normalizeAlienBullet(b, data.wave),
+    ),
     playerFireCooldown: data.playerFireCooldown,
     alienFireAcc: data.alienFireAcc,
     alienFireEvery: data.alienFireEvery,

--- a/src/lib/spaceInvaders/schemas.ts
+++ b/src/lib/spaceInvaders/schemas.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+const playerBulletSaved = z.object({
+  x: z.number(),
+  y: z.number(),
+  vx: z.number().optional(),
+  vy: z.number().optional(),
+});
+
+const serializedAlienBulletSaved = z.object({
+  x: z.number(),
+  y: z.number(),
+  kind: z.enum(["bolt", "plasma", "needle", "heavy"]).optional(),
+  vx: z.number().optional(),
+  vy: z.number().optional(),
+});
+
+const lootDropSaved = z.object({
+  x: z.number(),
+  y: z.number(),
+  vy: z.number(),
+  kind: z.enum(["weapon", "shield", "burst"]),
+  phase: z.number(),
+});
+
+/**
+ * Runtime-validatie voor localStorage save (`SerializedGameV1`).
+ * Alleen gebruiken na `JSON.parse`; bij fout blijft loadSave `null`.
+ */
+export const SerializedGameV1Schema = z.object({
+  v: z.union([z.literal(1), z.literal(2)]),
+  wave: z.number(),
+  lives: z.number(),
+  score: z.number(),
+  weaponLevel: z.number(),
+  playerX: z.number(),
+  alienGrid: z.array(z.array(z.boolean())),
+  alienOriginX: z.number(),
+  alienOriginY: z.number(),
+  alienDir: z.union([z.literal(1), z.literal(-1)]),
+  alienMoveAcc: z.number(),
+  alienMoveEvery: z.number(),
+  playerBullets: z.array(playerBulletSaved),
+  alienBullets: z.array(serializedAlienBulletSaved),
+  playerFireCooldown: z.number(),
+  alienFireAcc: z.number(),
+  alienFireEvery: z.number(),
+  status: z.enum(["playing", "paused", "wave_clear"]),
+  waveClearRemaining: z.number().optional(),
+  shieldCharges: z.number().optional(),
+  lootDrops: z.array(lootDropSaved).optional(),
+  lootSpawnTimer: z.number().optional(),
+});
+
+/** Eén highscore-regel (`at` = ISO-8601 string, liefst UTC). */
+export const HighScoreEntrySchema = z.object({
+  score: z.number(),
+  wave: z.number(),
+  at: z.string().min(1),
+});

--- a/src/lib/spaceInvaders/storage.test.ts
+++ b/src/lib/spaceInvaders/storage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { MAX_HIGH_SCORES, mergeHighScores } from "./storage";
+import type { HighScoreEntry } from "./types";
+
+describe("mergeHighScores", () => {
+  it("sorts by score descending and caps length", () => {
+    const base: HighScoreEntry[] = [
+      { score: 50, wave: 2, at: "a" },
+      { score: 100, wave: 3, at: "b" },
+    ];
+    const merged = mergeHighScores(base, { score: 75, wave: 2, at: "c" });
+    expect(merged.map((e) => e.score)).toEqual([100, 75, 50]);
+  });
+
+  it("respects max parameter", () => {
+    const many: HighScoreEntry[] = Array.from({ length: 15 }, (_, i) => ({
+      score: i * 10,
+      wave: 1,
+      at: `t${i}`,
+    }));
+    const merged = mergeHighScores(
+      many,
+      { score: 999, wave: 9, at: "top" },
+      MAX_HIGH_SCORES,
+    );
+    expect(merged.length).toBe(MAX_HIGH_SCORES);
+    expect(merged[0]!.score).toBe(999);
+  });
+});

--- a/src/lib/spaceInvaders/storage.test.ts
+++ b/src/lib/spaceInvaders/storage.test.ts
@@ -1,29 +1,107 @@
-import { describe, expect, it } from "vitest";
-import { MAX_HIGH_SCORES, mergeHighScores } from "./storage";
-import type { HighScoreEntry } from "./types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInitialState } from "./game";
+import {
+  SAVE_KEY,
+  SCORES_KEY,
+  addHighScore,
+  clearSave,
+  loadHighScores,
+  loadSave,
+  mergeHighScores,
+  saveGameToStorage,
+} from "./storage";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
 
 describe("mergeHighScores", () => {
-  it("sorts by score descending and caps length", () => {
-    const base: HighScoreEntry[] = [
-      { score: 50, wave: 2, at: "a" },
-      { score: 100, wave: 3, at: "b" },
-    ];
-    const merged = mergeHighScores(base, { score: 75, wave: 2, at: "c" });
-    expect(merged.map((e) => e.score)).toEqual([100, 75, 50]);
+  it("merges and caps", () => {
+    const a = mergeHighScores(
+      [
+        { score: 10, wave: 1, at: "a" },
+        { score: 5, wave: 1, at: "b" },
+      ],
+      { score: 7, wave: 2, at: "c" },
+      2,
+    );
+    expect(a).toEqual([
+      { score: 10, wave: 1, at: "a" },
+      { score: 7, wave: 2, at: "c" },
+    ]);
+  });
+});
+
+describe("localStorage persistence", () => {
+  const store: Record<string, string> = {};
+
+  beforeEach(() => {
+    Object.keys(store).forEach((k) => delete store[k]);
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => (k in store ? store[k]! : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      clear: () => {
+        Object.keys(store).forEach((k) => delete store[k]);
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+      get length() {
+        return Object.keys(store).length;
+      },
+    });
   });
 
-  it("respects max parameter", () => {
-    const many: HighScoreEntry[] = Array.from({ length: 15 }, (_, i) => ({
-      score: i * 10,
-      wave: 1,
-      at: `t${i}`,
-    }));
-    const merged = mergeHighScores(
-      many,
-      { score: 999, wave: 9, at: "top" },
-      MAX_HIGH_SCORES,
-    );
-    expect(merged.length).toBe(MAX_HIGH_SCORES);
-    expect(merged[0]!.score).toBe(999);
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loadSave returns null for corrupt JSON", () => {
+    store[SAVE_KEY] = "{not json";
+    expect(loadSave()).toBeNull();
+  });
+
+  it("loadSave returns null for wrong version", () => {
+    store[SAVE_KEY] = JSON.stringify({ v: 0, wave: 1 });
+    expect(loadSave()).toBeNull();
+  });
+
+  it("saveGameToStorage and loadSave round-trip", () => {
+    const s = createInitialState();
+    saveGameToStorage(s);
+    const loaded = loadSave();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.wave).toBe(s.wave);
+    expect(loaded!.score).toBe(s.score);
+  });
+
+  it("clearSave removes key", () => {
+    store[SAVE_KEY] = "{}";
+    clearSave();
+    expect(store[SAVE_KEY]).toBeUndefined();
+  });
+
+  it("loadHighScores returns empty for invalid JSON", () => {
+    store[SCORES_KEY] = "x";
+    expect(loadHighScores()).toEqual([]);
+  });
+
+  it("loadHighScores filters bad entries", () => {
+    store[SCORES_KEY] = JSON.stringify([
+      { score: 1, wave: 1, at: "a" },
+      { score: "nope", wave: 1, at: "b" },
+      null,
+    ]);
+    expect(loadHighScores()).toEqual([{ score: 1, wave: 1, at: "a" }]);
+  });
+
+  it("addHighScore persists sorted list", () => {
+    const out = addHighScore({ score: 100, wave: 3, at: "t" });
+    expect(out[0]).toEqual({ score: 100, wave: 3, at: "t" });
+    const raw = JSON.parse(store[SCORES_KEY]!);
+    expect(raw[0].score).toBe(100);
   });
 });

--- a/src/lib/spaceInvaders/storage.test.ts
+++ b/src/lib/spaceInvaders/storage.test.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createInitialState } from "./game";
 import {
@@ -36,6 +37,7 @@ describe("localStorage persistence", () => {
   const store: Record<string, string> = {};
 
   beforeEach(() => {
+    vi.clearAllMocks();
     Object.keys(store).forEach((k) => delete store[k]);
     vi.stubGlobal("localStorage", {
       getItem: (k: string) => (k in store ? store[k]! : null),
@@ -64,8 +66,22 @@ describe("localStorage persistence", () => {
     expect(loadSave()).toBeNull();
   });
 
-  it("loadSave returns null for wrong version", () => {
+  it("loadSave returns null for wrong version (Zod)", () => {
     store[SAVE_KEY] = JSON.stringify({ v: 0, wave: 1 });
+    expect(loadSave()).toBeNull();
+  });
+
+  it("loadSave returns null when shape fails Zod", () => {
+    store[SAVE_KEY] = JSON.stringify({
+      v: 2,
+      wave: 1,
+      alienGrid: "not-a-grid",
+    });
+    expect(loadSave()).toBeNull();
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalled();
+  });
+
+  it("loadSave returns null when SAVE_KEY missing", () => {
     expect(loadSave()).toBeNull();
   });
 
@@ -78,6 +94,24 @@ describe("localStorage persistence", () => {
     expect(loaded!.score).toBe(s.score);
   });
 
+  it("saveGameToStorage removes key when serialize returns null (gameover)", () => {
+    store[SAVE_KEY] = "should-remove";
+    const dead = { ...createInitialState(), status: "gameover" as const };
+    saveGameToStorage(dead);
+    expect(store[SAVE_KEY]).toBeUndefined();
+  });
+
+  it("saveGameToStorage captures Sentry when setItem throws", () => {
+    const stub = globalThis.localStorage as {
+      setItem: (k: string, v: string) => void;
+    };
+    stub.setItem = () => {
+      throw new Error("quota");
+    };
+    saveGameToStorage(createInitialState());
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalled();
+  });
+
   it("clearSave removes key", () => {
     store[SAVE_KEY] = "{}";
     clearSave();
@@ -86,6 +120,11 @@ describe("localStorage persistence", () => {
 
   it("loadHighScores returns empty for invalid JSON", () => {
     store[SCORES_KEY] = "x";
+    expect(loadHighScores()).toEqual([]);
+  });
+
+  it("loadHighScores returns empty for non-array JSON", () => {
+    store[SCORES_KEY] = JSON.stringify({ not: "array" });
     expect(loadHighScores()).toEqual([]);
   });
 
@@ -103,5 +142,16 @@ describe("localStorage persistence", () => {
     expect(out[0]).toEqual({ score: 100, wave: 3, at: "t" });
     const raw = JSON.parse(store[SCORES_KEY]!);
     expect(raw[0].score).toBe(100);
+  });
+
+  it("addHighScore reports Sentry when setItem throws", () => {
+    const stub = globalThis.localStorage as {
+      setItem: (k: string, v: string) => void;
+    };
+    stub.setItem = () => {
+      throw new Error("quota");
+    };
+    addHighScore({ score: 1, wave: 1, at: "x" });
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalled();
   });
 });

--- a/src/lib/spaceInvaders/storage.ts
+++ b/src/lib/spaceInvaders/storage.ts
@@ -3,6 +3,8 @@ import type { GameState, HighScoreEntry, SerializedGameV1 } from "./types";
 
 export const SAVE_KEY = "h3-space-invaders-save-v1";
 export const SCORES_KEY = "h3-space-invaders-scores-v1";
+/** First-run mobile touch hint (dismiss persists) */
+export const TOUCH_TIP_KEY = "h3-space-invaders-touch-tip-v1";
 export const MAX_HIGH_SCORES = 10;
 
 export function loadSave(): GameState | null {
@@ -52,10 +54,17 @@ export function loadHighScores(): HighScoreEntry[] {
   }
 }
 
+/** Pure merge for tests and deterministic ranking */
+export function mergeHighScores(
+  existing: HighScoreEntry[],
+  entry: HighScoreEntry,
+  max = MAX_HIGH_SCORES,
+): HighScoreEntry[] {
+  return [...existing, entry].sort((a, b) => b.score - a.score).slice(0, max);
+}
+
 export function addHighScore(entry: HighScoreEntry): HighScoreEntry[] {
-  const list = [...loadHighScores(), entry]
-    .sort((a, b) => b.score - a.score)
-    .slice(0, MAX_HIGH_SCORES);
+  const list = mergeHighScores(loadHighScores(), entry);
   if (typeof window !== "undefined") {
     localStorage.setItem(SCORES_KEY, JSON.stringify(list));
   }

--- a/src/lib/spaceInvaders/storage.ts
+++ b/src/lib/spaceInvaders/storage.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { deserializeGame, serializeGame } from "./game";
+import { HighScoreEntrySchema, SerializedGameV1Schema } from "./schemas";
 import type { GameState, HighScoreEntry, SerializedGameV1 } from "./types";
 
 export const SAVE_KEY = "h3-space-invaders-save-v1";
@@ -13,9 +14,15 @@ export function loadSave(): GameState | null {
   try {
     const raw = localStorage.getItem(SAVE_KEY);
     if (!raw) return null;
-    const data = JSON.parse(raw) as SerializedGameV1;
-    if (data?.v !== 1 && data?.v !== 2) return null;
-    return deserializeGame(data);
+    const parsed: unknown = JSON.parse(raw);
+    const result = SerializedGameV1Schema.safeParse(parsed);
+    if (!result.success) {
+      Sentry.captureException(result.error, {
+        tags: { area: "space-invaders-storage", kind: "save-invalid" },
+      });
+      return null;
+    }
+    return deserializeGame(result.data as SerializedGameV1);
   } catch (error: unknown) {
     Sentry.captureException(error, {
       tags: { area: "space-invaders-storage" },
@@ -53,18 +60,14 @@ export function loadHighScores(): HighScoreEntry[] {
   try {
     const raw = localStorage.getItem(SCORES_KEY);
     if (!raw) return [];
-    const arr = JSON.parse(raw) as HighScoreEntry[];
-    if (!Array.isArray(arr)) return [];
-    return arr
-      .filter(
-        (e) =>
-          e &&
-          typeof e.score === "number" &&
-          typeof e.wave === "number" &&
-          typeof e.at === "string",
-      )
-      .sort((a, b) => b.score - a.score)
-      .slice(0, MAX_HIGH_SCORES);
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const entries: HighScoreEntry[] = [];
+    for (const item of parsed) {
+      const row = HighScoreEntrySchema.safeParse(item);
+      if (row.success) entries.push(row.data);
+    }
+    return entries.sort((a, b) => b.score - a.score).slice(0, MAX_HIGH_SCORES);
   } catch (error: unknown) {
     Sentry.captureException(error, {
       tags: { area: "space-invaders-storage" },

--- a/src/lib/spaceInvaders/storage.ts
+++ b/src/lib/spaceInvaders/storage.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { deserializeGame, serializeGame } from "./game";
 import type { GameState, HighScoreEntry, SerializedGameV1 } from "./types";
 
@@ -15,21 +16,36 @@ export function loadSave(): GameState | null {
     const data = JSON.parse(raw) as SerializedGameV1;
     if (data?.v !== 1 && data?.v !== 2) return null;
     return deserializeGame(data);
-  } catch {
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      tags: { area: "space-invaders-storage" },
+    });
     return null;
   }
 }
 
 export function saveGameToStorage(state: GameState): void {
   if (typeof window === "undefined") return;
-  const s = serializeGame(state);
-  if (s) localStorage.setItem(SAVE_KEY, JSON.stringify(s));
-  else localStorage.removeItem(SAVE_KEY);
+  try {
+    const s = serializeGame(state);
+    if (s) localStorage.setItem(SAVE_KEY, JSON.stringify(s));
+    else localStorage.removeItem(SAVE_KEY);
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      tags: { area: "space-invaders-storage" },
+    });
+  }
 }
 
 export function clearSave(): void {
   if (typeof window === "undefined") return;
-  localStorage.removeItem(SAVE_KEY);
+  try {
+    localStorage.removeItem(SAVE_KEY);
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      tags: { area: "space-invaders-storage" },
+    });
+  }
 }
 
 export function loadHighScores(): HighScoreEntry[] {
@@ -49,7 +65,10 @@ export function loadHighScores(): HighScoreEntry[] {
       )
       .sort((a, b) => b.score - a.score)
       .slice(0, MAX_HIGH_SCORES);
-  } catch {
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      tags: { area: "space-invaders-storage" },
+    });
     return [];
   }
 }
@@ -66,7 +85,13 @@ export function mergeHighScores(
 export function addHighScore(entry: HighScoreEntry): HighScoreEntry[] {
   const list = mergeHighScores(loadHighScores(), entry);
   if (typeof window !== "undefined") {
-    localStorage.setItem(SCORES_KEY, JSON.stringify(list));
+    try {
+      localStorage.setItem(SCORES_KEY, JSON.stringify(list));
+    } catch (error: unknown) {
+      Sentry.captureException(error, {
+        tags: { area: "space-invaders-storage" },
+      });
+    }
   }
   return list;
 }

--- a/src/lib/spaceInvaders/storage.ts
+++ b/src/lib/spaceInvaders/storage.ts
@@ -13,7 +13,7 @@ export function loadSave(): GameState | null {
     const raw = localStorage.getItem(SAVE_KEY);
     if (!raw) return null;
     const data = JSON.parse(raw) as SerializedGameV1;
-    if (data?.v !== 1) return null;
+    if (data?.v !== 1 && data?.v !== 2) return null;
     return deserializeGame(data);
   } catch {
     return null;

--- a/src/lib/spaceInvaders/storage.ts
+++ b/src/lib/spaceInvaders/storage.ts
@@ -1,0 +1,63 @@
+import { deserializeGame, serializeGame } from "./game";
+import type { GameState, HighScoreEntry, SerializedGameV1 } from "./types";
+
+export const SAVE_KEY = "h3-space-invaders-save-v1";
+export const SCORES_KEY = "h3-space-invaders-scores-v1";
+export const MAX_HIGH_SCORES = 10;
+
+export function loadSave(): GameState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(SAVE_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw) as SerializedGameV1;
+    if (data?.v !== 1) return null;
+    return deserializeGame(data);
+  } catch {
+    return null;
+  }
+}
+
+export function saveGameToStorage(state: GameState): void {
+  if (typeof window === "undefined") return;
+  const s = serializeGame(state);
+  if (s) localStorage.setItem(SAVE_KEY, JSON.stringify(s));
+  else localStorage.removeItem(SAVE_KEY);
+}
+
+export function clearSave(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(SAVE_KEY);
+}
+
+export function loadHighScores(): HighScoreEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(SCORES_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw) as HighScoreEntry[];
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .filter(
+        (e) =>
+          e &&
+          typeof e.score === "number" &&
+          typeof e.wave === "number" &&
+          typeof e.at === "string",
+      )
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_HIGH_SCORES);
+  } catch {
+    return [];
+  }
+}
+
+export function addHighScore(entry: HighScoreEntry): HighScoreEntry[] {
+  const list = [...loadHighScores(), entry]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_HIGH_SCORES);
+  if (typeof window !== "undefined") {
+    localStorage.setItem(SCORES_KEY, JSON.stringify(list));
+  }
+  return list;
+}

--- a/src/lib/spaceInvaders/types.ts
+++ b/src/lib/spaceInvaders/types.ts
@@ -1,0 +1,60 @@
+export type GameStatus = "playing" | "paused" | "gameover";
+
+export type PlayerBullet = { x: number; y: number };
+export type AlienBullet = { x: number; y: number };
+
+export type GameState = {
+  status: GameStatus;
+  wave: number;
+  lives: number;
+  score: number;
+  /** 0 = single, 1 = double spread, 2 = triple + faster (see FIRE_INTERVAL) */
+  weaponLevel: number;
+  playerX: number;
+  /** alive[r][c] */
+  alienGrid: boolean[][];
+  alienOriginX: number;
+  alienOriginY: number;
+  alienDir: 1 | -1;
+  /** Accumulator; when >= threshold, aliens step */
+  alienMoveAcc: number;
+  alienMoveEvery: number;
+  playerBullets: PlayerBullet[];
+  alienBullets: AlienBullet[];
+  playerFireCooldown: number;
+  alienFireAcc: number;
+  alienFireEvery: number;
+};
+
+export type GameInput = {
+  moveLeft: boolean;
+  moveRight: boolean;
+  fire: boolean;
+};
+
+export type SerializedGameV1 = {
+  v: 1;
+  wave: number;
+  lives: number;
+  score: number;
+  weaponLevel: number;
+  playerX: number;
+  alienGrid: boolean[][];
+  alienOriginX: number;
+  alienOriginY: number;
+  alienDir: 1 | -1;
+  alienMoveAcc: number;
+  alienMoveEvery: number;
+  playerBullets: PlayerBullet[];
+  alienBullets: AlienBullet[];
+  playerFireCooldown: number;
+  alienFireAcc: number;
+  alienFireEvery: number;
+  status: "playing" | "paused";
+};
+
+export type HighScoreEntry = {
+  score: number;
+  wave: number;
+  at: string;
+};

--- a/src/lib/spaceInvaders/types.ts
+++ b/src/lib/spaceInvaders/types.ts
@@ -51,7 +51,20 @@ export type Particle = {
 };
 
 /**
- * Volledige simulatiestatus voor één Space Invaders-sessie (speler, aliens, kogels, golf, timers).
+ * Volledige runtime-state van één Space Invaders-sessie.
+ *
+ * **Levenscyclus:** ontstaat bij `createInitialState` / hervatten uit save; elke frame bij `tick`;
+ * bij golf leeg → `wave_clear` → `spawnWave`; bij levens op of invasie → `gameover` (niet opgeslagen).
+ *
+ * - **status** — `playing` | `paused` | `gameover` | `wave_clear`
+ * - **wave / lives / score** — voortgang en punten
+ * - **weaponLevel** — 0 = enkel schot, hoger = meer spreiding (zie `FIRE_INTERVAL`)
+ * - **playerX** — horizontale positie schip
+ * - **alienGrid** — `alive[row][col]`
+ * - **alienOriginX/Y, alienDir** — blokpositie en richting (1 rechts, -1 links)
+ * - **alienMoveAcc / alienMoveEvery** — accumulator t.o.v. staptempo
+ * - **playerBullets / alienBullets** — actieve projectielen
+ * - **playerFireCooldown, alienFireAcc / alienFireEvery** — vuurtiming
  */
 export type GameState = {
   status: GameStatus;
@@ -84,13 +97,31 @@ export type GameState = {
   waveClearRemaining: number;
 };
 
-/** Invoer voor één `tick`: beweging en vuur (keyboard/touch wordt upstream gezet). */
+/**
+ * Spelerinvoer voor één simulatiestap (`tick`).
+ *
+ * @property moveLeft — schip naar links (keyboard / touch “links”)
+ * @property moveRight — schip naar rechts
+ * @property fire — vuur ingedrukt (continu vuren zolang `true` en cooldown 0)
+ */
 export type GameInput = {
   moveLeft: boolean;
   moveRight: boolean;
   fire: boolean;
 };
 
+/**
+ * Persistentieformaat voor localStorage (versie **1** of **2**).
+ *
+ * - **v** — schemaversie (loot/schild zit in v2)
+ * - **wave … alienFireEvery** — speltoestand zoals in `GameState` (geen particles)
+ * - **status** — nooit `gameover` in een save
+ * - **waveClearRemaining** — alleen relevant bij `wave_clear`
+ * - **shieldCharges, lootDrops, lootSpawnTimer** — optioneel / v2
+ * - **alienBullets[]** — mag ontbrekende `kind`/`vx`/`vy` hebben (legacy → default in `deserializeGame`)
+ *
+ * Runtime-validatie: `SerializedGameV1Schema` in `schemas.ts`.
+ */
 export type SerializedGameV1 = {
   v: 1 | 2;
   wave: number;
@@ -116,7 +147,13 @@ export type SerializedGameV1 = {
   lootSpawnTimer?: number;
 };
 
-/** Highscore-regel; `at` is ISO-8601 UTC (`toISOString()`). */
+/**
+ * Eén regel op het lokale scorebord.
+ *
+ * @property score — behaalde punten (getal)
+ * @property wave — hoogste bereikte golf (getal)
+ * @property at — tijdstip als **ISO-8601**-string, UTC (`new Date().toISOString()`), bv. `"2026-03-21T12:00:00.000Z"`
+ */
 export type HighScoreEntry = {
   score: number;
   wave: number;

--- a/src/lib/spaceInvaders/types.ts
+++ b/src/lib/spaceInvaders/types.ts
@@ -1,4 +1,4 @@
-export type GameStatus = "playing" | "paused" | "gameover";
+export type GameStatus = "playing" | "paused" | "gameover" | "wave_clear";
 
 export type PlayerBullet = { x: number; y: number };
 export type AlienBullet = { x: number; y: number };
@@ -24,6 +24,8 @@ export type GameState = {
   playerFireCooldown: number;
   alienFireAcc: number;
   alienFireEvery: number;
+  /** Seconds remaining for wave-clear interstitial; 0 when not active */
+  waveClearRemaining: number;
 };
 
 export type GameInput = {
@@ -50,7 +52,8 @@ export type SerializedGameV1 = {
   playerFireCooldown: number;
   alienFireAcc: number;
   alienFireEvery: number;
-  status: "playing" | "paused";
+  status: "playing" | "paused" | "wave_clear";
+  waveClearRemaining?: number;
 };
 
 export type HighScoreEntry = {

--- a/src/lib/spaceInvaders/types.ts
+++ b/src/lib/spaceInvaders/types.ts
@@ -1,15 +1,50 @@
 export type GameStatus = "playing" | "paused" | "gameover" | "wave_clear";
 
-export type PlayerBullet = { x: number; y: number };
+/** Player shots; optional vx for spread / fan fire */
+export type PlayerBullet = {
+  x: number;
+  y: number;
+  vx?: number;
+  vy?: number;
+};
 export type AlienBullet = { x: number; y: number };
+
+export type LootKind = "weapon" | "shield" | "burst";
+
+/** Falling power-up */
+export type LootDrop = {
+  x: number;
+  y: number;
+  vy: number;
+  kind: LootKind;
+  phase: number;
+};
+
+/** Short-lived visual particle */
+export type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  hue: number;
+  size: number;
+};
 
 export type GameState = {
   status: GameStatus;
   wave: number;
   lives: number;
   score: number;
-  /** 0 = single, 1 = double spread, 2 = triple + faster (see FIRE_INTERVAL) */
+  /** 0–4 — fan fire at high tiers; floor from wave + pickups (see FIRE_INTERVAL) */
   weaponLevel: number;
+  /** Extra hits absorbed (alien bullets) before life loss */
+  shieldCharges: number;
+  lootDrops: LootDrop[];
+  particles: Particle[];
+  /** Seconds until a random bonus crate may spawn from the sky */
+  lootSpawnTimer: number;
   playerX: number;
   /** alive[r][c] */
   alienGrid: boolean[][];
@@ -35,7 +70,7 @@ export type GameInput = {
 };
 
 export type SerializedGameV1 = {
-  v: 1;
+  v: 1 | 2;
   wave: number;
   lives: number;
   score: number;
@@ -54,6 +89,9 @@ export type SerializedGameV1 = {
   alienFireEvery: number;
   status: "playing" | "paused" | "wave_clear";
   waveClearRemaining?: number;
+  shieldCharges?: number;
+  lootDrops?: LootDrop[];
+  lootSpawnTimer?: number;
 };
 
 export type HighScoreEntry = {

--- a/src/lib/spaceInvaders/types.ts
+++ b/src/lib/spaceInvaders/types.ts
@@ -50,6 +50,9 @@ export type Particle = {
   size: number;
 };
 
+/**
+ * Volledige simulatiestatus voor één Space Invaders-sessie (speler, aliens, kogels, golf, timers).
+ */
 export type GameState = {
   status: GameStatus;
   wave: number;
@@ -81,6 +84,7 @@ export type GameState = {
   waveClearRemaining: number;
 };
 
+/** Invoer voor één `tick`: beweging en vuur (keyboard/touch wordt upstream gezet). */
 export type GameInput = {
   moveLeft: boolean;
   moveRight: boolean;
@@ -112,6 +116,7 @@ export type SerializedGameV1 = {
   lootSpawnTimer?: number;
 };
 
+/** Highscore-regel; `at` is ISO-8601 UTC (`toISOString()`). */
 export type HighScoreEntry = {
   score: number;
   wave: number;

--- a/src/lib/spaceInvaders/types.ts
+++ b/src/lib/spaceInvaders/types.ts
@@ -7,7 +7,25 @@ export type PlayerBullet = {
   vx?: number;
   vy?: number;
 };
-export type AlienBullet = { x: number; y: number };
+export type AlienWeaponKind = "bolt" | "plasma" | "needle" | "heavy";
+
+/** Alien projectiles — vx/vy in px/s (vy positive = downward) */
+export type AlienBullet = {
+  x: number;
+  y: number;
+  kind: AlienWeaponKind;
+  vx: number;
+  vy: number;
+};
+
+/** Persisted alien shot — optional fields for v1 / legacy saves */
+export type SerializedAlienBullet = {
+  x: number;
+  y: number;
+  kind?: AlienWeaponKind;
+  vx?: number;
+  vy?: number;
+};
 
 export type LootKind = "weapon" | "shield" | "burst";
 
@@ -83,7 +101,7 @@ export type SerializedGameV1 = {
   alienMoveAcc: number;
   alienMoveEvery: number;
   playerBullets: PlayerBullet[];
-  alienBullets: AlienBullet[];
+  alienBullets: SerializedAlienBullet[];
   playerFireCooldown: number;
   alienFireAcc: number;
   alienFireEvery: number;


### PR DESCRIPTION
## Summary
Adds a **Space Invader** card below the RSVP match list on the home page with a full-screen canvas game.

## Features
- Waves with increasing difficulty (faster aliens, more incoming fire)
- Weapon upgrades at waves 3+ and 6+ (double / triple shot + shorter cooldown)
- Lives, score, pause (P / Esc), **Opslaan en sluiten** (localStorage), **Sluiten**
- **Doorgaan** when a save exists; local **topscores** (max 10)
- Mobile: large touch targets (Links / Vuur / Rechts), safe-area padding, body scroll lock while open

## Technical
- \src/lib/spaceInvaders/*\ — game tick, draw, storage (versioned keys)
- \src/components/spaceInvaders/*\ — launcher + portal overlay game
- Vitest: \game.test.ts\ for weapon tiers, difficulty curves, tick movement

## Verify
- \
pm run lint\, \
px tsc --noEmit\, \
px vitest run\, \
pm run build\ — all green locally.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Space Invaders mini‑game in the events area: launcher card and full‑screen playable overlay with HUD, pause/resume/restart/exit, keyboard + touch controls, responsive UI, save/resume, first‑touch tip, and persistent local leaderboard. Safe‑area padding added for mobile overlays.

* **Tests**
  * New test suites covering game logic, rendering, persistence, controls, and high‑score behavior.

* **Documentation**
  * Contribution/docs guidance and automated docs generation workflow updated; CodeRabbit docstring coverage configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->