### PR TITLE
ci: dependabot auto-merge + coderabbit major gate

### DIFF
--- a/.github/workflows/coderabbit-major-gate.yml
+++ b/.github/workflows/coderabbit-major-gate.yml
@@ -1,0 +1,132 @@
+name: CodeRabbit Major Gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+concurrency:
+  group: coderabbit-major-gate-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  major_gate:
+    name: CodeRabbit major opmerkingen opgelost
+    runs-on: ubuntu-latest
+    steps:
+      - name: Controleer openstaande CodeRabbit major comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request?.number ?? context.payload.issue?.number;
+
+            if (!prNumber) {
+              core.info("Geen pull request context, check wordt overgeslagen.");
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.draft) {
+              core.info(`PR #${prNumber} is draft, major gate niet afdwingen.`);
+              return;
+            }
+
+            const isCoderabbit = (login) =>
+              typeof login === "string" && login.toLowerCase().startsWith("coderabbitai");
+
+            const isMajorOrCritical = (body) => {
+              if (typeof body !== "string" || body.length === 0) return false;
+              const firstLine = body.split("\n")[0] ?? "";
+              return /(?:🟠\s*major|🔴\s*critical)/i.test(firstLine);
+            };
+
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewThreads(first: 100, after: $cursor) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        isResolved
+                        comments(first: 20) {
+                          nodes {
+                            author {
+                              login
+                            }
+                            body
+                            url
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const unresolvedMajorComments = [];
+            let cursor = null;
+
+            while (true) {
+              const result = await github.graphql(query, {
+                owner,
+                repo,
+                number: prNumber,
+                cursor,
+              });
+
+              const threads = result.repository.pullRequest.reviewThreads;
+              for (const thread of threads.nodes) {
+                if (thread.isResolved) {
+                  continue;
+                }
+
+                const matchingComment = thread.comments.nodes.find(
+                  (comment) => isCoderabbit(comment.author?.login) && isMajorOrCritical(comment.body),
+                );
+
+                if (matchingComment) {
+                  unresolvedMajorComments.push(matchingComment);
+                }
+              }
+
+              if (!threads.pageInfo.hasNextPage) {
+                break;
+              }
+
+              cursor = threads.pageInfo.endCursor;
+            }
+
+            if (unresolvedMajorComments.length === 0) {
+              core.info(`Geen openstaande CodeRabbit major/critical opmerkingen op PR #${prNumber}.`);
+              return;
+            }
+
+            const commentLinks = unresolvedMajorComments
+              .slice(0, 10)
+              .map((comment) => `- ${comment.url}`)
+              .join("\n");
+
+            core.setFailed(
+              `${unresolvedMajorComments.length} openstaande CodeRabbit major/critical opmerking(en) gevonden.\n` +
+                `Los deze eerst op voordat je merge't.\n${commentLinks}`,
+            );

--- a/.github/workflows/coderabbit-major-gate.yml
+++ b/.github/workflows/coderabbit-major-gate.yml
@@ -47,6 +47,19 @@ jobs:
               return;
             }
 
+            const authorLogin = (pr.user?.login ?? "").toLowerCase();
+            const isDependabotPr =
+              authorLogin === "dependabot[bot]" ||
+              authorLogin === "app/dependabot" ||
+              authorLogin.includes("dependabot");
+
+            if (!isDependabotPr) {
+              core.info(
+                `PR #${prNumber} is niet door Dependabot aangemaakt (${pr.user?.login ?? "unknown"}), gate niet afdwingen.`,
+              );
+              return;
+            }
+
             const isCoderabbit = (login) =>
               typeof login === "string" && login.toLowerCase().startsWith("coderabbitai");
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,198 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  process:
+    name: Sluit superseded en merge groene Dependabot PRs
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verwerk open Dependabot PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const dependencyTitlePattern =
+              /^build\(deps(?:-dev)?\): bump (.+?) from .+ to .+(?: in .+)?$/i;
+
+            const parseDependencyName = (title) => {
+              const match = title.match(dependencyTitlePattern);
+              return match ? match[1].trim().toLowerCase() : null;
+            };
+
+            const openPrs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const dependabotPrs = openPrs
+              .filter((pr) => pr.user?.login === "dependabot[bot]" && !pr.draft)
+              .sort((a, b) => a.number - b.number);
+
+            if (dependabotPrs.length === 0) {
+              core.info("Geen open, niet-draft Dependabot PRs gevonden.");
+              return;
+            }
+
+            core.info(`Open Dependabot PRs: ${dependabotPrs.map((pr) => `#${pr.number}`).join(", ")}`);
+
+            const groupedByDependency = new Map();
+            for (const pr of dependabotPrs) {
+              const dependencyName = parseDependencyName(pr.title);
+              if (!dependencyName) {
+                continue;
+              }
+
+              if (!groupedByDependency.has(dependencyName)) {
+                groupedByDependency.set(dependencyName, []);
+              }
+
+              groupedByDependency.get(dependencyName).push(pr);
+            }
+
+            const closedPrNumbers = new Set();
+            for (const [dependencyName, prs] of groupedByDependency.entries()) {
+              if (prs.length < 2) {
+                continue;
+              }
+
+              const sortedNewestFirst = [...prs].sort((a, b) => b.number - a.number);
+              const newestPr = sortedNewestFirst[0];
+              const supersededPrs = sortedNewestFirst.slice(1);
+
+              for (const supersededPr of supersededPrs) {
+                core.info(
+                  `Sluit superseded PR #${supersededPr.number} voor "${dependencyName}" ten gunste van #${newestPr.number}.`,
+                );
+
+                try {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: supersededPr.number,
+                    body: `Automatisch gesloten: er staat al een nieuwere Dependabot update open voor \`${dependencyName}\` (#${newestPr.number}).`,
+                  });
+                } catch (error) {
+                  core.warning(
+                    `Kon geen comment plaatsen op #${supersededPr.number}: ${error.message}`,
+                  );
+                }
+
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: supersededPr.number,
+                  state: "closed",
+                });
+
+                closedPrNumbers.add(supersededPr.number);
+              }
+            }
+
+            const repoInfo = await github.rest.repos.get({ owner, repo });
+            const mergeMethodPreference = [
+              repoInfo.data.allow_merge_commit ? "merge" : null,
+              repoInfo.data.allow_squash_merge ? "squash" : null,
+              repoInfo.data.allow_rebase_merge ? "rebase" : null,
+            ].filter(Boolean);
+
+            if (mergeMethodPreference.length === 0) {
+              core.warning("Geen toegestane merge methodes geconfigureerd op deze repository.");
+              return;
+            }
+
+            const mergeMethod = mergeMethodPreference[0];
+            core.info(`Geselecteerde merge methode: ${mergeMethod}`);
+
+            const statusQuery = `
+              query PullRequestStatus($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    number
+                    title
+                    reviewDecision
+                    mergeable
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup {
+                            state
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const candidatePrs = dependabotPrs.filter((pr) => !closedPrNumbers.has(pr.number));
+            for (const pr of candidatePrs) {
+              const statusResult = await github.graphql(statusQuery, {
+                owner,
+                repo,
+                number: pr.number,
+              });
+
+              const pullRequest = statusResult.repository.pullRequest;
+              const checkState =
+                pullRequest?.commits?.nodes?.[0]?.commit?.statusCheckRollup?.state ?? "PENDING";
+
+              if (checkState !== "SUCCESS") {
+                core.info(
+                  `PR #${pr.number} nog niet merge-klaar: statusCheckRollup=${checkState}.`,
+                );
+                continue;
+              }
+
+              if (pullRequest.mergeable === "CONFLICTING") {
+                core.info(`PR #${pr.number} heeft merge-conflicts, overslaan.`);
+                continue;
+              }
+
+              if (pullRequest.reviewDecision !== "APPROVED") {
+                try {
+                  await github.rest.pulls.createReview({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                    event: "APPROVE",
+                    body: "Automatische goedkeuring voor Dependabot PR nadat checks geslaagd zijn.",
+                  });
+                } catch (error) {
+                  core.warning(`Auto-approval mislukt voor #${pr.number}: ${error.message}`);
+                }
+              }
+
+              try {
+                await github.rest.pulls.merge({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  merge_method: mergeMethod,
+                });
+                core.info(`PR #${pr.number} succesvol gemerged.`);
+              } catch (error) {
+                core.warning(`Auto-merge mislukt voor #${pr.number}: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Voegt een GitHub Action toe die open Dependabot PR's periodiek verwerkt: superseded PR's voor dezelfde dependency automatisch sluit en niet-draft Dependabot PR's automatisch merge't zodra alle checks geslaagd zijn.

Voegt een tweede GitHub Action toe die de PR-check laat falen wanneer er onopgeloste CodeRabbit **Major/Critical** reviewthreads openstaan.

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s): n.v.t.
  - Functional spec section(s): n.v.t.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13893d08-4ef8-4987-94fe-96c25710cd07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13893d08-4ef8-4987-94fe-96c25710cd07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

