### PR TITLE
fix: prevent mobile copy popup in Space Invaders controls

### DIFF
--- a/src/components/spaceInvaders/SpaceInvadersGame.test.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.test.tsx
@@ -167,6 +167,23 @@ describe("SpaceInvadersGame", () => {
     fireEvent.pointerUp(left);
   });
 
+  it("prevents context menu on the game overlay root", async () => {
+    render(
+      <SpaceInvadersGame
+        initialState={createInitialState()}
+        onClose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    const dialog = screen.getByRole("dialog", { name: "Space Invaders" });
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    dialog.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it("registers gameover score once via addHighScore", async () => {
     const addSpy = vi.spyOn(SpaceStorage, "addHighScore").mockReturnValue([]);
     const clearSpy = vi

--- a/src/components/spaceInvaders/SpaceInvadersGame.tsx
+++ b/src/components/spaceInvaders/SpaceInvadersGame.tsx
@@ -341,7 +341,8 @@ export default function SpaceInvadersGame({
       aria-modal="true"
       aria-label="Space Invaders"
       tabIndex={-1}
-      className="fixed inset-0 z-[3200] flex min-h-dvh flex-col touch-none bg-[#010409] pt-safe pb-safe-bottom-bar pl-safe pr-safe"
+      className="fixed inset-0 z-[3200] flex min-h-dvh flex-col touch-none select-none bg-[#010409] pt-safe pb-safe-bottom-bar pl-safe pr-safe [-webkit-user-select:none] [-webkit-touch-callout:none]"
+      onContextMenu={(e) => e.preventDefault()}
     >
       <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-[#21262d] px-3 py-2">
         <div className="flex flex-wrap gap-2.5 text-sm text-[#c9d1d9]">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Voorkomt mobiele copy/select-popups tijdens het spelen van Space Invaders door de volledige game-overlay `select-none`, `-webkit-user-select: none`, `-webkit-touch-callout: none` en `contextmenu`-preventie te geven.
- Voegt een regressietest toe die verifieert dat de dialog-root `contextmenu` standaardgedrag blokkeert.

## Testing

- `npm test -- src/components/spaceInvaders/SpaceInvadersGame.test.tsx`
- `npm run build`
- `npx tsc --noEmit`
- `npm run lint`
- `npm test`
- Handmatige mobiele viewport-test (long-press op onderbalk knoppen + hulpetekst)

[space_invaders_mobile_no_copy_popup_controls.mp4](https://cursor.com/agents/bc-104a61be-8ca3-4e84-b3fd-4c3ab7fee69c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspace_invaders_mobile_no_copy_popup_controls.mp4)
[Space Invaders mobiele controls geladen](https://cursor.com/agents/bc-104a61be-8ca3-4e84-b3fd-4c3ab7fee69c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspace_invaders_controls_mobile_loaded.webp)
[Geen copy popup bij long press](https://cursor.com/agents/bc-104a61be-8ca3-4e84-b3fd-4c3ab7fee69c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspace_invaders_controls_mobile_no_popup.webp)

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s):
  - Functional spec section(s):
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-104a61be-8ca3-4e84-b3fd-4c3ab7fee69c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-104a61be-8ca3-4e84-b3fd-4c3ab7fee69c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Releaseopmerkingen

* **Verbeteringen**
  * De Space Invaders-speloverlaygeluidscherm voorkomt nu het verschijnen van het contextmenu en ongewenste tekstselectie-interacties.

* **Tests**
  * Testdekking toegevoegd voor verificatie van gedrag bij context-menupreventie op de speloverlaygeluidscherm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->