### PR TITLE
fix: keep RSVP list entries for unnamed players

### DIFF
--- a/src/app/api/rsvp/list/route.test.ts
+++ b/src/app/api/rsvp/list/route.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { GET } from "./route";
+import {
+  getUserProfiles,
+  getUserRsvpStats,
+  listEventRsvps,
+} from "../../../../lib/kv";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("../../../../lib/kv", () => ({
+  getUserProfiles: vi.fn(),
+  getUserRsvpStats: vi.fn(),
+  listEventRsvps: vi.fn(),
+}));
+
+vi.mock("../../../../lib/badges", () => ({
+  getBadgeForAttendance: vi.fn(() => ({ label: "test" })),
+}));
+
+vi.mock("../../../../lib/dbMetrics", () => ({
+  withDbRequestMetrics: vi.fn(async (_endpoint: string, fn: () => Promise<unknown>) =>
+    fn(),
+  ),
+}));
+
+describe("GET /api/rsvp/list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns counts without loading profile data when countsOnly is enabled", async () => {
+    vi.mocked(listEventRsvps).mockResolvedValue([
+      { userId: "u1", status: "yes" },
+      { userId: "u2", status: "no" },
+      { userId: "u3", status: "maybe" },
+      { userId: "u4", status: null },
+    ]);
+
+    const req = new Request(
+      "http://localhost/api/rsvp/list?eventId=wedstrijd-1&countsOnly=1",
+    );
+    const response = await GET(req as NextRequest);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      counts: { yes: 1, no: 1, maybe: 1 },
+      lists: { yes: [], no: [], maybe: [] },
+    });
+    expect(vi.mocked(getUserProfiles)).not.toHaveBeenCalled();
+    expect(vi.mocked(getUserRsvpStats)).not.toHaveBeenCalled();
+  });
+
+  it("keeps RSVP entries visible when a player profile has no display name", async () => {
+    vi.mocked(listEventRsvps).mockResolvedValue([
+      { userId: "u1", status: "yes" },
+      { userId: "u2", status: "maybe" },
+    ]);
+    vi.mocked(getUserProfiles).mockResolvedValue({
+      u1: { firstName: "", lastName: "", email: null },
+      u2: { firstName: "Jan", lastName: "Jansen", email: null },
+    });
+    vi.mocked(getUserRsvpStats).mockResolvedValue({
+      u1: { total: 0, yes: 0 },
+      u2: { total: 3, yes: 2 },
+    });
+
+    const req = new Request("http://localhost/api/rsvp/list?eventId=wedstrijd-2");
+    const response = await GET(req as NextRequest);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      counts: { yes: 1, no: 0, maybe: 1 },
+      lists: {
+        yes: [{ id: "u1", name: "Onbekende speler" }],
+        no: [],
+        maybe: [{ id: "u2", name: "Jan Jansen" }],
+      },
+    });
+  });
+
+  it("returns a 500 response and reports Sentry when listing RSVPs fails", async () => {
+    const error = new Error("db stuk");
+    vi.mocked(listEventRsvps).mockRejectedValue(error);
+
+    const req = new Request("http://localhost/api/rsvp/list?eventId=wedstrijd-3");
+    const response = await GET(req as NextRequest);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "list_failed",
+      message: "db stuk",
+    });
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/app/api/rsvp/list/route.test.ts
+++ b/src/app/api/rsvp/list/route.test.ts
@@ -33,6 +33,10 @@ describe("GET /api/rsvp/list", () => {
     vi.clearAllMocks();
   });
 
+  function makeRequest(url: string): NextRequest {
+    return new NextRequest(new Request(url));
+  }
+
   it("returns counts without loading profile data when countsOnly is enabled", async () => {
     vi.mocked(listEventRsvps).mockResolvedValue([
       { userId: "u1", status: "yes" },
@@ -41,10 +45,9 @@ describe("GET /api/rsvp/list", () => {
       { userId: "u4", status: null },
     ]);
 
-    const req = new Request(
-      "http://localhost/api/rsvp/list?eventId=wedstrijd-1&countsOnly=1",
+    const response = await GET(
+      makeRequest("http://localhost/api/rsvp/list?eventId=wedstrijd-1&countsOnly=1"),
     );
-    const response = await GET(req as NextRequest);
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -69,8 +72,9 @@ describe("GET /api/rsvp/list", () => {
       u2: { total: 3, yes: 2 },
     });
 
-    const req = new Request("http://localhost/api/rsvp/list?eventId=wedstrijd-2");
-    const response = await GET(req as NextRequest);
+    const response = await GET(
+      makeRequest("http://localhost/api/rsvp/list?eventId=wedstrijd-2"),
+    );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -87,8 +91,9 @@ describe("GET /api/rsvp/list", () => {
     const error = new Error("db stuk");
     vi.mocked(listEventRsvps).mockRejectedValue(error);
 
-    const req = new Request("http://localhost/api/rsvp/list?eventId=wedstrijd-3");
-    const response = await GET(req as NextRequest);
+    const response = await GET(
+      makeRequest("http://localhost/api/rsvp/list?eventId=wedstrijd-3"),
+    );
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({

--- a/src/app/api/rsvp/list/route.ts
+++ b/src/app/api/rsvp/list/route.ts
@@ -7,7 +7,16 @@ import {
 } from "../../../../lib/kv";
 import { getBadgeForAttendance } from "../../../../lib/badges";
 import { withDbRequestMetrics } from "../../../../lib/dbMetrics";
+import { displayName } from "../../../../lib/userUtils";
 
+const UNKNOWN_RSVP_NAME = "Onbekende speler";
+
+/**
+ * Returns RSVP counts and, when requested, the named RSVP lists for an event.
+ *
+ * @param req - Incoming request containing the event identifier and optional countsOnly flag.
+ * @returns JSON response with RSVP counts and grouped attendee lists.
+ */
 export async function GET(req: NextRequest) {
   return withDbRequestMetrics("api/rsvp/list.GET", async () => {
     const eventId = req.nextUrl.searchParams.get("eventId");
@@ -41,13 +50,7 @@ export async function GET(req: NextRequest) {
         continue;
       }
       const profile = profilesById[userId];
-      const first = (profile?.firstName || "").trim();
-      const last = (profile?.lastName || "").trim();
-      const name = `${first} ${last}`.trim();
-      const displayName = name || (profile?.email || "").trim();
-      if (!displayName) {
-        continue;
-      }
+      const resolvedDisplayName = displayName(profile ?? {}) || UNKNOWN_RSVP_NAME;
       // Compute simple attendance percentage as Yes/(Yes+No+Maybe) across all events (kept for potential future use)
       try {
         const stats = statsById[userId] || { total: 0, yes: 0 };
@@ -57,10 +60,11 @@ export async function GET(req: NextRequest) {
       } catch (error: unknown) {
         Sentry.captureException(error);
       }
-      if (status === "yes") yes.push({ id: userId, name: displayName });
-      else if (status === "no") no.push({ id: userId, name: displayName });
+      if (status === "yes") yes.push({ id: userId, name: resolvedDisplayName });
+      else if (status === "no")
+        no.push({ id: userId, name: resolvedDisplayName });
       else if (status === "maybe")
-        maybe.push({ id: userId, name: displayName });
+        maybe.push({ id: userId, name: resolvedDisplayName });
     }
     return NextResponse.json({
       counts,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- keep RSVP list entries visible when a player record has no display name in production
- reuse the shared `displayName` helper and fall back to `Onbekende speler`
- add focused route tests for counts-only, unnamed players, and the Sentry error path

## Testing

- `npx vitest run src/app/api/rsvp/list/route.test.ts`
- `npm run lint`
- `npm test`
- `npm run build` *(currently blocked by an existing Prisma config type issue)*
- `npx tsc --noEmit` *(currently blocked by an existing Prisma config type issue)*

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s):
  - Functional spec section(s):
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9f2c028-67e9-4dc6-b175-34cf11ad074b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9f2c028-67e9-4dc6-b175-34cf11ad074b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for the RSVP list endpoint, including behavior validation for aggregated counts and error handling scenarios.

* **Bug Fixes**
  * Improved attendee name display with consistent fallback naming when participant information is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->