### PR TITLE
chore(ci): ignore ESLint major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "eslint-config-next"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the merged dependency consolidation (#183).

Dependabot opened **ESLint 10** while `eslint-config-next@16` still targets ESLint 9. Ignore **semver-major** updates for `eslint` so we do not get recurring incompatible PRs; patch/minor updates still apply.

## After merge

- Close **#144** (ESLint 10) if still open, or leave closed with this rationale.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3daf5eb2-0581-4496-b9b9-80b2ced2b0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3daf5eb2-0581-4496-b9b9-80b2ced2b0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Opmerkingen bij de release

Deze release bevat geen wijzigingen die voor eindgebruikers zichtbaar zijn. Het betreft een interne configuratie-update voor afhankelijkheidsbeheer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->