### PR TITLE
fix(auth): production login — session user id + redirect callback

### DIFF
--- a/src/app/api/link/complete/route.ts
+++ b/src/app/api/link/complete/route.ts
@@ -3,19 +3,20 @@ import { redeemLinkCode } from "../../../../lib/kv";
 
 export async function POST(req: NextRequest) {
   const { code } = await req.json().catch(() => ({ code: "" }));
-  if (!code) return NextResponse.json({ error: "code required" }, { status: 400 });
+  if (!code)
+    return NextResponse.json({ error: "code required" }, { status: 400 });
   const userId = await redeemLinkCode(String(code).toUpperCase());
-  if (!userId) return NextResponse.json({ error: "invalid code" }, { status: 400 });
+  if (!userId)
+    return NextResponse.json({ error: "invalid code" }, { status: 400 });
   const res = NextResponse.json({ ok: true, userId });
+  const isProd = process.env.NODE_ENV === "production";
   // Overwrite anon_id cookie with the linked userId
   res.cookies.set("anon_id", userId, {
     httpOnly: true,
     path: "/",
     sameSite: "lax",
-    secure: true,
+    secure: isProd,
     maxAge: 60 * 60 * 24 * 365,
   });
   return res;
 }
-
-

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -6,6 +6,7 @@ import * as Sentry from "@sentry/nextjs";
  */
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./lib/ensureNextAuthUrl");
     await import("../sentry.server.config");
   }
 

--- a/src/lib/authOptions.authorize.test.ts
+++ b/src/lib/authOptions.authorize.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@prisma/client";
+import * as Sentry from "@sentry/nextjs";
+import { prisma } from "./db";
+import { authOptions } from "./authOptions";
+
+vi.mock("./db", () => ({
+  prisma: {
+    user: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("bcryptjs", () => ({
+  default: {
+    compare: vi.fn(),
+  },
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+describe("Credentials authorize", () => {
+  const credentialsProvider = authOptions.providers.find(
+    (p) => p.id === "credentials",
+  );
+  const authorize = credentialsProvider?.options?.authorize;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null on Prisma timeout and reports to Sentry", async () => {
+    const err = new Prisma.PrismaClientKnownRequestError("timeout", {
+      code: "ETIMEDOUT",
+      clientVersion: "7",
+    });
+    vi.mocked(prisma.user.findFirst).mockRejectedValueOnce(err);
+
+    const result = await authorize?.({
+      email: "a@b.nl",
+      password: "secret",
+    });
+
+    expect(result).toBeNull();
+    expect(Sentry.captureException).toHaveBeenCalledWith(err, {
+      tags: { context: "credentials_authorize" },
+      extra: { prismaCode: "ETIMEDOUT" },
+    });
+  });
+
+  it("returns user on success", async () => {
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce({
+      id: "u1",
+      email: "a@b.nl",
+      passwordHash: "$2a$10$hashed",
+      firstName: "A",
+      lastName: "B",
+    } as never);
+
+    const bcrypt = await import("bcryptjs");
+    vi.mocked(bcrypt.default.compare).mockResolvedValueOnce(true);
+
+    const result = await authorize?.({
+      email: "a@b.nl",
+      password: "secret",
+    });
+
+    expect(result).toEqual({
+      id: "u1",
+      name: "A B",
+      email: "a@b.nl",
+    });
+  });
+});

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,3 +1,4 @@
+import "./ensureNextAuthUrl";
 import type { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,6 +1,8 @@
 import type { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";
+import * as Sentry from "@sentry/nextjs";
+import { Prisma } from "@prisma/client";
 import { prisma } from "./db";
 import bcrypt from "bcryptjs";
 
@@ -23,15 +25,27 @@ export const authOptions: NextAuthOptions = {
         const email = (creds?.email as string) || "";
         const password = (creds?.password as string) || "";
         if (!email || !password) return null;
-        const user = await prisma.user.findFirst({ where: { email } });
-        if (!user || !user.passwordHash) return null;
-        const ok = await bcrypt.compare(password, user.passwordHash);
-        if (!ok) return null;
-        return {
-          id: user.id,
-          name: `${user.firstName} ${user.lastName}`.trim(),
-          email: user.email ?? undefined,
-        };
+        try {
+          const user = await prisma.user.findFirst({ where: { email } });
+          if (!user || !user.passwordHash) return null;
+          const ok = await bcrypt.compare(password, user.passwordHash);
+          if (!ok) return null;
+          return {
+            id: user.id,
+            name: `${user.firstName} ${user.lastName}`.trim(),
+            email: user.email ?? undefined,
+          };
+        } catch (error: unknown) {
+          const code =
+            error instanceof Prisma.PrismaClientKnownRequestError
+              ? error.code
+              : undefined;
+          Sentry.captureException(error, {
+            tags: { context: "credentials_authorize" },
+            extra: { prismaCode: code },
+          });
+          return null;
+        }
       },
     }),
   ],

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -1,4 +1,3 @@
-import "./ensureNextAuthUrl";
 import type { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -70,8 +70,14 @@ export const authOptions: NextAuthOptions = {
       try {
         const u = new URL(url);
         if (u.origin === baseUrl) return url;
-      } catch {
-        // Invalid url — fall through to baseUrl
+      } catch (error: unknown) {
+        Sentry.captureException(error, {
+          extra: {
+            context: "nextauth_redirect_invalid_url",
+            url,
+            baseUrl,
+          },
+        });
       }
       return baseUrl;
     },

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -4,6 +4,9 @@ import Credentials from "next-auth/providers/credentials";
 import { prisma } from "./db";
 import bcrypt from "bcryptjs";
 
+/**
+ * NextAuth configuration: Google + credentials, JWT sessions with user id on `session.user.id`.
+ */
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
@@ -24,23 +27,39 @@ export const authOptions: NextAuthOptions = {
         if (!user || !user.passwordHash) return null;
         const ok = await bcrypt.compare(password, user.passwordHash);
         if (!ok) return null;
-        return { id: user.id, name: `${user.firstName} ${user.lastName}`.trim(), email: user.email || undefined } as any;
+        return {
+          id: user.id,
+          name: `${user.firstName} ${user.lastName}`.trim(),
+          email: user.email ?? undefined,
+        };
       },
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
   callbacks: {
-    async session({ session }) {
+    async jwt({ token, user }) {
+      if (user?.id) {
+        token.sub = user.id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token.sub) {
+        session.user.id = token.sub;
+      }
       return session;
     },
     async redirect({ url, baseUrl }) {
+      if (url.startsWith("/")) {
+        return `${baseUrl}${url}`;
+      }
       try {
         const u = new URL(url);
         if (u.origin === baseUrl) return url;
-      } catch {}
+      } catch {
+        // Invalid url — fall through to baseUrl
+      }
       return baseUrl;
     },
   },
 };
-
-

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,7 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { recordPrismaQuery, isDbMetricsEnabled } from "./dbMetrics";
+import { getPgPoolConfig, getPrismaPgAdapterOptions } from "./pgPool";
 
 declare global {
   var prisma: PrismaClient | undefined;
@@ -17,7 +18,10 @@ const prismaInstance =
     const baseOptions: Prisma.PrismaClientOptions = isDbMetricsEnabled()
       ? { log: [{ emit: "event", level: "query" as const }] }
       : {};
-    const adapter = new PrismaPg({ connectionString: url });
+    const adapter = new PrismaPg(
+      getPgPoolConfig(url) as ConstructorParameters<typeof PrismaPg>[0],
+      getPrismaPgAdapterOptions(),
+    );
     return new PrismaClient({ ...baseOptions, adapter });
   })();
 

--- a/src/lib/ensureNextAuthUrl.ts
+++ b/src/lib/ensureNextAuthUrl.ts
@@ -1,0 +1,9 @@
+/**
+ * Side-effect: sets `process.env.NEXTAUTH_URL` before NextAuth reads it (preview + Vercel fallbacks).
+ */
+import { resolveNextAuthUrl } from "./nextAuthUrl";
+
+const resolved = resolveNextAuthUrl();
+if (resolved) {
+  process.env.NEXTAUTH_URL = resolved;
+}

--- a/src/lib/nextAuthUrl.test.ts
+++ b/src/lib/nextAuthUrl.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveNextAuthUrl } from "./nextAuthUrl";
+
+describe("resolveNextAuthUrl", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses VERCEL_URL for preview when set", () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_URL", "my-app-git-branch-team.vercel.app");
+    vi.stubEnv("NEXTAUTH_URL", "https://production.example.com");
+    expect(resolveNextAuthUrl()).toBe(
+      "https://my-app-git-branch-team.vercel.app",
+    );
+  });
+
+  it("uses explicit NEXTAUTH_URL when not on Vercel preview", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("NEXTAUTH_URL", "https://app.example.com/");
+    expect(resolveNextAuthUrl()).toBe("https://app.example.com");
+  });
+
+  it("falls back to VERCEL_URL on Vercel production when NEXTAUTH_URL is unset", () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("VERCEL_URL", "my-app.vercel.app");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    expect(resolveNextAuthUrl()).toBe("https://my-app.vercel.app");
+  });
+
+  it("returns undefined when nothing is configured", () => {
+    vi.stubEnv("VERCEL", undefined);
+    vi.stubEnv("VERCEL_ENV", undefined);
+    vi.stubEnv("VERCEL_URL", undefined);
+    vi.stubEnv("NEXTAUTH_URL", undefined);
+    expect(resolveNextAuthUrl()).toBeUndefined();
+  });
+});

--- a/src/lib/nextAuthUrl.test.ts
+++ b/src/lib/nextAuthUrl.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Sentry from "@sentry/nextjs";
 import { resolveNextAuthUrl } from "./nextAuthUrl";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
 
 describe("resolveNextAuthUrl", () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -39,5 +45,18 @@ describe("resolveNextAuthUrl", () => {
     vi.stubEnv("VERCEL_URL", undefined);
     vi.stubEnv("NEXTAUTH_URL", undefined);
     expect(resolveNextAuthUrl()).toBeUndefined();
+  });
+
+  it("returns undefined for invalid NEXTAUTH_URL and logs parse errors to Sentry", () => {
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("VERCEL_URL", "");
+    vi.stubEnv("NEXTAUTH_URL", ":");
+    expect(resolveNextAuthUrl()).toBeUndefined();
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(TypeError),
+      expect.objectContaining({
+        extra: expect.objectContaining({ context: "nextauth_url_toOrigin" }),
+      }),
+    );
   });
 });

--- a/src/lib/nextAuthUrl.ts
+++ b/src/lib/nextAuthUrl.ts
@@ -1,0 +1,39 @@
+/**
+ * Normalizes a host or URL string to an origin (no trailing slash).
+ *
+ * @param value - Hostname or full URL.
+ * @returns Parsed origin, or `undefined` if invalid.
+ */
+function toOrigin(value: string): string | undefined {
+  const withScheme = value.startsWith("http") ? value : `https://${value}`;
+  try {
+    return new URL(withScheme).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves the canonical site URL for NextAuth on Vercel.
+ * Preview deployments often inherit Production `NEXTAUTH_URL`, which breaks CSRF and OAuth redirects.
+ *
+ * @returns Origin without trailing slash, or `undefined` if nothing to apply.
+ */
+export function resolveNextAuthUrl(): string | undefined {
+  const vercelEnv = process.env.VERCEL_ENV;
+  const vercelUrl = process.env.VERCEL_URL?.trim();
+  if (vercelUrl && (vercelEnv === "preview" || vercelEnv === "development")) {
+    return toOrigin(vercelUrl);
+  }
+
+  const explicit = process.env.NEXTAUTH_URL?.trim();
+  if (explicit) {
+    return toOrigin(explicit);
+  }
+
+  if (vercelUrl && process.env.VERCEL === "1") {
+    return toOrigin(vercelUrl);
+  }
+
+  return undefined;
+}

--- a/src/lib/nextAuthUrl.ts
+++ b/src/lib/nextAuthUrl.ts
@@ -1,14 +1,31 @@
+import * as Sentry from "@sentry/nextjs";
+
 /**
  * Normalizes a host or URL string to an origin (no trailing slash).
+ * Alleen `http:` en `https:` zijn toegestaan (geen `httpx:` of andere schema’s).
  *
- * @param value - Hostname or full URL.
- * @returns Parsed origin, or `undefined` if invalid.
+ * @param value - Hostname of volledige URL.
+ * @returns Geparsede origin, of `undefined` bij ongeldige invoer.
  */
 function toOrigin(value: string): string | undefined {
-  const withScheme = value.startsWith("http") ? value : `https://${value}`;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const hasHttpOrHttps = /^(https?):\/\//i.test(trimmed);
+  const withScheme = hasHttpOrHttps ? trimmed : `https://${trimmed}`;
+
   try {
-    return new URL(withScheme).origin;
-  } catch {
+    const parsed = new URL(withScheme);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    const origin = parsed.origin;
+    if (origin === "null") return undefined;
+    return origin;
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      extra: { context: "nextauth_url_toOrigin", input: value },
+    });
     return undefined;
   }
 }

--- a/src/lib/pgPool.test.ts
+++ b/src/lib/pgPool.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getPgPoolConfig } from "./pgPool";
+
+describe("getPgPoolConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses max 5 on Vercel when PG_POOL_MAX is unset", () => {
+    vi.stubEnv("VERCEL", "1");
+    const cfg = getPgPoolConfig("postgresql://u:p@localhost/db");
+    expect(cfg.max).toBe(5);
+    expect(cfg.connectionTimeoutMillis).toBe(15_000);
+    expect(cfg.allowExitOnIdle).toBe(true);
+  });
+
+  it("respects PG_POOL_MAX when set", () => {
+    vi.stubEnv("VERCEL", "1");
+    vi.stubEnv("PG_POOL_MAX", "12");
+    const cfg = getPgPoolConfig("postgresql://u:p@localhost/db");
+    expect(cfg.max).toBe(12);
+  });
+
+  it("uses a higher default max when not on Vercel", () => {
+    vi.stubEnv("VERCEL", undefined);
+    const cfg = getPgPoolConfig("postgresql://u:p@localhost/db");
+    expect(cfg.max).toBe(20);
+    expect(cfg.allowExitOnIdle).toBe(false);
+  });
+});

--- a/src/lib/pgPool.ts
+++ b/src/lib/pgPool.ts
@@ -1,0 +1,51 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Parses a positive integer from an env value, or returns `fallback`.
+ * @param value - Raw string (e.g. from `process.env.PG_POOL_MAX`).
+ * @param fallback - Used when missing, NaN, or non-positive.
+ */
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const n = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * Builds `pg.Pool` options for Prisma’s driver adapter.
+ * Uses a modest `max` on Vercel to avoid opening one TCP connection per request (which can exhaust Postgres or stall with `ETIMEDOUT`).
+ *
+ * @param connectionString - Postgres URL (`DATABASE_URL` / `PRISMA_DATABASE_URL`).
+ * @returns Pool configuration passed to `@prisma/adapter-pg` (internally builds a `pg.Pool`).
+ */
+export function getPgPoolConfig(connectionString: string): {
+  connectionString: string;
+  max: number;
+  min: number;
+  idleTimeoutMillis: number;
+  connectionTimeoutMillis: number;
+  allowExitOnIdle: boolean;
+} {
+  const onVercel = process.env.VERCEL === "1";
+  const max = parsePositiveInt(process.env.PG_POOL_MAX, onVercel ? 5 : 20);
+  return {
+    connectionString,
+    max,
+    min: 0,
+    idleTimeoutMillis: 10_000,
+    connectionTimeoutMillis: 15_000,
+    allowExitOnIdle: onVercel,
+  };
+}
+
+/**
+ * Options for `@prisma/adapter-pg`: log pool errors without relying on a raw `pg.Pool` instance (avoids duplicate `@types/pg` clashes with the adapter bundle).
+ */
+export function getPrismaPgAdapterOptions(): {
+  onPoolError: (err: Error) => void;
+} {
+  return {
+    onPoolError: (err: Error) => {
+      Sentry.captureException(err, { tags: { component: "pg-pool" } });
+    },
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,18 +1,21 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Assign an anonymous user id cookie if missing
+/**
+ * Ensures each visitor has an `anon_id` cookie for anonymous identity flows.
+ */
 export function middleware(request: NextRequest) {
   const response = NextResponse.next();
   const cookieName = "anon_id";
   const existing = request.cookies.get(cookieName)?.value;
   if (!existing) {
     const id = crypto.randomUUID();
+    const isProd = process.env.NODE_ENV === "production";
     response.cookies.set(cookieName, id, {
       httpOnly: true,
       path: "/",
       sameSite: "lax",
-      secure: true,
+      secure: isProd,
       maxAge: 60 * 60 * 24 * 365, // 1 year
     });
   }
@@ -22,5 +25,3 @@ export function middleware(request: NextRequest) {
 export const config = {
   matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };
-
-

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import type { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  /**
+   * Session shape including stable user id for app identity resolution.
+   */
+  interface Session {
+    user: {
+      /** Prisma user id, from JWT `sub` after sign-in. */
+      id?: string;
+    } & DefaultSession["user"];
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Loganalyse (CSV)

De export toont vooral **Prisma `ETIMEDOUT`** op `prisma.identity.findUnique()` (via `getActiveUser` → `/api/me`) en eerdere **`prisma.user.findFirst()`** in credentials-login (NextAuth error-URL). `/api/rsvp/list` geeft 500 met **`queryCount: 0`** — typisch **geen query uitgevoerd** omdat de verbinding/time-out faalde vóór de query.

Dat wijst op **databaseconnectiviteit / pool-gedrag op Vercel**, niet op een fout in de NextAuth-redirect of JWT-alleen flow.

## Aanpassingen in deze commit

1. **`@prisma/adapter-pg` met begrensde pool** (`src/lib/pgPool.ts` + `src/lib/db.ts`): op Vercel standaard **max 5** connecties (`PG_POOL_MAX` overschrijfbaar), `connectionTimeoutMillis` 15s, `allowExitOnIdle` op Vercel. Doel: minder “één connectie per request” en minder uitputting van Postgres / timeouts.
2. **Credentials `authorize`**: bij DB-fouten (o.a. `ETIMEDOUT`) → `null` + **Sentry**, geen ruwe Prisma-string meer in `/api/auth/error`.

## Wat jij nog kunt controleren (infra)

- **Prisma Postgres / provider**: region vs Vercel-region, connection limits, eventueel **PgBouncer / connection pooling** in de connection string.
- **`DATABASE_URL`**: direct vs pooled URL op Vercel.

Tests: `vitest` + `next build` groen op deze branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa18f207-51bc-4b8e-95f8-8a5ca15417be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa18f207-51bc-4b8e-95f8-8a5ca15417be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatische detectie en instelling van de juiste applicatie‑URL op basis van de omgeving.
  * Betere database‑poolconfiguratie voor productieomgevingen.

* **Bug Fixes**
  * Verbeterde foutafhandeling bij aanmeldingen en omleidingen; relatieve URL's worden correct geprefixt en ongeldige URL's expliciet afgehandeld.

* **Refactor**
  * Persistente gebruikers‑id wordt betrouwbaarder meegenomen in sessies.
  * Cookie‑beheer aangepast om de secure‑flag op basis van de omgeving te zetten.

* **Tests**
  * Nieuwe tests voor URL‑resolutie, database‑poolconfiguratie en authenticatie‑flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->