### PR TITLE
fix(ical): Sportlink-wedstrijden verder in de toekomst tonen

### DIFF
--- a/src/lib/ical.test.ts
+++ b/src/lib/ical.test.ts
@@ -1,15 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Sentry from "@sentry/nextjs";
 import { fetchTeamEvents } from "./ical";
 import { kvGetJson, kvSetJson } from "./kv";
 
-// Mock dependencies
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock("./kv", () => ({
   kvGetJson: vi.fn(),
-  kvSetJson: vi.fn().mockReturnValue(Promise.resolve()),
+  kvSetJson: vi.fn().mockResolvedValue(undefined),
 }));
 
 const now = new Date();
-const futureDate = new Date(now.getTime() + 1000 * 60 * 60 * 24); // Tomorrow
+const futureDate = new Date(now.getTime() + 1000 * 60 * 60 * 24);
 const isoFuture =
   futureDate.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
 const isoEnd =
@@ -18,34 +22,38 @@ const isoEnd =
     .replace(/[-:]/g, "")
     .split(".")[0] + "Z";
 
-const mockICS = `BEGIN:VCALENDAR
+function buildMockICS(dtStart: string, dtEnd: string, summary = "Match 1") {
+  return `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Sportlink//NONSGML//NL
 BEGIN:VEVENT
 UID:12345
-DTSTART:${isoFuture}
-DTEND:${isoEnd}
-SUMMARY:Match 1
+DTSTART:${dtStart}
+DTEND:${dtEnd}
+SUMMARY:${summary}
 LOCATION:Pool A
 END:VEVENT
 END:VCALENDAR`;
+}
 
 describe("fetchTeamEvents", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.SPORTLINK_ICAL_URL = "http://example.com/calendar.ics";
+    vi.stubEnv("SPORTLINK_ICAL_URL", "http://example.com/calendar.ics");
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(buildMockICS(isoFuture, isoEnd)),
+    } as Response);
+  });
 
-    // Mock fetch
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        text: () => Promise.resolve(mockICS),
-      } as Response),
-    );
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it("fetches and parses ical data", async () => {
-    (kvGetJson as any).mockResolvedValue([]);
+    vi.mocked(kvGetJson).mockResolvedValue([]);
 
     const events = await fetchTeamEvents();
 
@@ -56,11 +64,9 @@ describe("fetchTeamEvents", () => {
   });
 
   it("falls back to cache if fetch fails", async () => {
-    // Mock fetch failure
-    global.fetch = vi.fn(() => Promise.reject("Network error"));
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("Network error"));
 
-    // Mock cache hit
-    (kvGetJson as any).mockResolvedValue([
+    vi.mocked(kvGetJson).mockResolvedValue([
       {
         id: "cached-1",
         title: "Cached Match",
@@ -72,51 +78,93 @@ describe("fetchTeamEvents", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0].title).toBe("Cached Match");
-    // Should NOT update cache if fetch failed
     expect(kvSetJson).not.toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("reports to Sentry when HTTP response is not ok", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve(""),
+    } as Response);
+    vi.mocked(kvGetJson).mockResolvedValue([
+      {
+        id: "cached-1",
+        title: "Cached Match",
+        start: new Date().toISOString(),
+      },
+    ]);
+
+    const events = await fetchTeamEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe("Cached Match");
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it("merges new data with cache", async () => {
     const pastDate = new Date(Date.now() - 100000).toISOString();
-    const futureDate = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(); // Tomorrow (same as mockICS)
+    const futureDateIso = new Date(
+      Date.now() + 1000 * 60 * 60 * 24,
+    ).toISOString();
 
-    // Need to match the ID generation logic: YYYYMMDD--slug
-    const d = new Date(futureDate);
+    const d = new Date(futureDateIso);
     const y = d.getFullYear();
     const m = String(d.getMonth() + 1).padStart(2, "0");
     const day = String(d.getDate()).padStart(2, "0");
     const id = `${y}${m}${day}--match-1`;
 
-    // Cache has one old event and one that will be updated
-    (kvGetJson as any).mockResolvedValue([
+    vi.mocked(kvGetJson).mockResolvedValue([
       { id: "old-1", title: "Old Match", start: pastDate },
-      { id: id, title: "Match 1 (Old)", start: futureDate }, // ID matches the one from mockICS
+      { id, title: "Match 1 (Old)", start: futureDateIso },
     ]);
 
     const events = await fetchTeamEvents();
 
-    // Should have 2 events: Old Match (preserved) and Match 1 (updated from ICS)
     expect(events).toHaveLength(2);
 
     const updatedMatch = events.find((e) => e.title === "Match 1");
     expect(updatedMatch).toBeDefined();
 
-    // Verify sorting (oldest first)
     expect(events[0].title).toBe("Old Match");
   });
 
   it("handles invalid ical data gracefully", async () => {
-    // Mock fetch with bad data
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        text: () => Promise.resolve("INVALID ICAL DATA"),
-      } as Response),
-    );
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve("INVALID ICAL DATA"),
+    } as Response);
 
-    // Should return empty array or cache if parsing fails
-    (kvGetJson as any).mockResolvedValue([]);
+    vi.mocked(kvGetJson).mockResolvedValue([]);
     const events = await fetchTeamEvents();
     expect(events).toHaveLength(0);
+  });
+
+  it("keeps matches more than 365 days in the future (Sportlink season feed)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-26T12:00:00.000Z"));
+    const farFuture = new Date("2027-08-15T14:00:00.000Z");
+    const isoFar =
+      farFuture.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+    const isoFarEnd =
+      new Date(farFuture.getTime() + 3600000)
+        .toISOString()
+        .replace(/[-:]/g, "")
+        .split(".")[0] + "Z";
+
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(buildMockICS(isoFar, isoFarEnd, "Away game")),
+    } as Response);
+    vi.mocked(kvGetJson).mockResolvedValue([]);
+
+    const events = await fetchTeamEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].title).toBe("Away game");
+    vi.useRealTimers();
   });
 });

--- a/src/lib/ical.ts
+++ b/src/lib/ical.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { TeamEvent } from "../types";
 import { canonicalEventId } from "./eventId";
 import { kvGetJson, kvSetJson } from "./kv";
@@ -12,9 +13,20 @@ type ParsedVEvent = {
   description?: string;
 };
 
+/** Past events kept for RSVP/history (Sportlink + buffer). */
+const PRUNE_PAST_MS = 400 * 24 * 60 * 60 * 1000;
+/** Future events kept — Sportlink feeds often list the next full season (>365 days). */
+const PRUNE_FUTURE_MS = 540 * 24 * 60 * 60 * 1000;
+
+function icalDateToIso(value: Date | string | number): string {
+  const d = value instanceof Date ? value : new Date(value);
+  return d.toISOString();
+}
+
 /**
  * Fetches, parses, and caches team events from the external iCal feed.
  * Merges new data with existing cached data to preserve history.
+ * Events outside a bounded window (roughly 400 days past through 540 days future) are dropped when updating the cache.
  *
  * @returns A list of {@link TeamEvent} objects sorted by date.
  */
@@ -35,27 +47,26 @@ export async function fetchTeamEvents(): Promise<TeamEvent[]> {
         .filter((c): c is ParsedVEvent => c?.type === "VEVENT")
         .map((evt) => {
           const title = (evt.summary || "Match").toString();
-          const startIso =
-            evt.start instanceof Date
-              ? evt.start.toISOString()
-              : new Date(evt.start as any).toISOString();
+          if (evt.start === undefined) {
+            throw new Error("VEVENT without DTSTART");
+          }
+          const startIso = icalDateToIso(evt.start);
           const id = canonicalEventId(title, startIso);
           return {
             id,
             uid: evt.uid?.toString(),
             title,
             start: startIso,
-            end: evt.end
-              ? evt.end instanceof Date
-                ? evt.end.toISOString()
-                : new Date(evt.end as any).toISOString()
-              : undefined,
+            end:
+              evt.end !== undefined ? icalDateToIso(evt.end) : undefined,
             location: evt.location?.toString(),
             description: evt.description?.toString(),
           } satisfies TeamEvent;
         });
-    } catch {
-      // Ignore; we'll fall back to cache below
+    } catch (err: unknown) {
+      Sentry.captureException(
+        err instanceof Error ? err : new Error(String(err)),
+      );
     }
   }
 
@@ -71,16 +82,20 @@ export async function fetchTeamEvents(): Promise<TeamEvent[]> {
     (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
   );
 
-  // Prune to a reasonable window (keep one year back and one year ahead) to avoid unbounded growth
+  // Prune to a bounded window so Redis does not grow without limit (asymmetric: feeds can list far-future matches).
   const now = Date.now();
-  const windowMs = 365 * 24 * 60 * 60 * 1000;
-  merged = merged.filter(
-    (e) => Math.abs(new Date(e.start).getTime() - now) <= windowMs,
-  );
+  merged = merged.filter((e) => {
+    const t = new Date(e.start).getTime();
+    return t >= now - PRUNE_PAST_MS && t <= now + PRUNE_FUTURE_MS;
+  });
 
   // Update cache if we had a successful parse; otherwise return cached as-is
   if (parsed) {
-    await kvSetJson(cacheKey, merged).catch(() => {});
+    await kvSetJson(cacheKey, merged).catch((error: unknown) => {
+      Sentry.captureException(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    });
   } else if (cached.length) {
     merged = cached;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

De kalender merge in `fetchTeamEvents` snoeide events met een symmetrisch venster van ±365 dagen om de Redis-cache begrensd te houden. Sportlink-iCal feeds bevatten vaak het volledige seizoen ver vooruit (>365 dagen), waardoor alle aankomende wedstrijden uit de response vielen en de UI leek.

Deze wijziging gebruikt een asymmetrisch venster (ongeveer 400 dagen terug, 540 dagen vooruit), logt fetch/parse- en KV-schrijffouten naar Sentry in plaats van ze te slikken, en vervangt `as any` bij datumconversie door een kleine helper. De unit tests zijn opgeschoond (`vi.mocked`, `vi.stubEnv`, Sentry-mock) en er is een regressietest toegevoegd voor een wedstrijd meer dan 365 dagen in de toekomst.

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s): n.v.t.
  - Functional spec section(s): n.v.t.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a33d7bc-0b03-42cb-a3f5-269fab2eb525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a33d7bc-0b03-42cb-a3f5-269fab2eb525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

