### PR TITLE
feat(ui): vouw oudere wedstrijden en trainingen samen

### DIFF
--- a/e2e/post-merge/production-smoke.spec.ts
+++ b/e2e/post-merge/production-smoke.spec.ts
@@ -18,11 +18,9 @@ test.describe("Read-only deploy smoke", () => {
 
   test("homepage laadt en toont teamtitel", async ({ page }) => {
     await page.goto("/");
+    // Site title lives in the global header (not necessarily as <h1> — subpages have their own h1).
     await expect(
-      page.getByRole("heading", {
-        level: 1,
-        name: "De Rijn H3 — Waterpolo",
-      }),
+      page.locator("header").getByText("De Rijn H3 — Waterpolo", { exact: true }),
     ).toBeVisible();
   });
 

--- a/src/app/trainer/attendance/page.tsx
+++ b/src/app/trainer/attendance/page.tsx
@@ -1,12 +1,48 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { splitTrainingSessionDatesForDisplay, toYMD } from "../../../lib/training";
 
 type Session = { date: string };
+
+function SessionRow({ date }: { date: string }) {
+  return (
+    <Link
+      className="card"
+      href={`/trainer/attendance/${date}`}
+      style={{ textDecoration: "none" }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: 600 }}>{date}</div>
+          <div className="muted" style={{ fontSize: 13 }}>
+            Training op{" "}
+            {new Date(date + "T12:00:00").toLocaleDateString("nl-NL", {
+              weekday: "long",
+            })}
+          </div>
+        </div>
+        <div className="badge">Open</div>
+      </div>
+    </Link>
+  );
+}
 
 export default function TrainerAttendanceList() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [isTrainer, setIsTrainer] = useState<boolean | null>(null);
+
+  const { recentPast, olderPast, upcoming } = useMemo(() => {
+    const dates = sessions.map((s) => s.date);
+    return splitTrainingSessionDatesForDisplay(dates, toYMD(new Date()), 3);
+  }, [sessions]);
 
   useEffect(() => {
     let mounted = true;
@@ -43,41 +79,43 @@ export default function TrainerAttendanceList() {
     );
   }
 
+  const total = sessions.length;
+
   return (
     <main>
       <div className="container">
         <h1 style={{ marginBottom: 8 }}>Trainingsopkomst</h1>
 
         <div className="list">
-          {sessions.map((s) => (
-            <a
-              className="card"
-              key={s.date}
-              href={`/trainer/attendance/${s.date}`}
-              style={{ textDecoration: "none" }}
-            >
+          {recentPast.map((date) => (
+            <SessionRow key={date} date={date} />
+          ))}
+          {olderPast.length > 0 ? (
+            <details style={{ marginBottom: 4 }}>
+              <summary
+                className="muted"
+                style={{ cursor: "pointer", fontWeight: 600 }}
+              >
+                Eerdere trainingen dit seizoen ({olderPast.length})
+              </summary>
               <div
                 style={{
+                  marginTop: 12,
                   display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
+                  flexDirection: "column",
+                  gap: 12,
                 }}
               >
-                <div>
-                  <div style={{ fontWeight: 600 }}>{s.date}</div>
-                  <div className="muted" style={{ fontSize: 13 }}>
-                    Training op{" "}
-                    {new Date(s.date + "T00:00:00").toLocaleDateString(
-                      "nl-NL",
-                      { weekday: "long" },
-                    )}
-                  </div>
-                </div>
-                <div className="badge">Open</div>
+                {olderPast.map((date) => (
+                  <SessionRow key={date} date={date} />
+                ))}
               </div>
-            </a>
+            </details>
+          ) : null}
+          {upcoming.map((date) => (
+            <SessionRow key={date} date={date} />
           ))}
-          {sessions.length === 0 ? (
+          {total === 0 ? (
             <div className="muted">Nog geen sessies.</div>
           ) : null}
         </div>

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { fetchJsonOr } from "../lib/safeClientJson";
 import type { TeamEvent, RsvpStatus } from "../types";
+import { splitPastAndFutureByStart } from "../lib/listSplitPast";
 import GenerateReportButton from "./GenerateReportButton";
 import ReportPreview from "./ReportPreview";
 import MvpVoteButton from "./MvpVoteButton";
@@ -159,21 +159,152 @@ export default function EventList({ events }: Props) {
     }
   }
 
-  const grouped = useMemo(() => {
-    const now = nowTs || 0;
-    const allSorted = events
-      .slice()
-      .sort(
-        (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
-      );
-    const idx = allSorted.findIndex((e) => new Date(e.start).getTime() >= now);
-    const future = idx === -1 ? [] : allSorted.slice(idx);
-    // last two past (if available)
-    const past = (idx === -1 ? allSorted : allSorted.slice(0, idx)).slice(-2);
-    // If there are no past items at all yet (first ever match hasn't been played), just return future
-    // But once the very first match has been played, ensure at least that single past match remains visible
-    return [...past, ...future];
-  }, [events, nowTs]);
+  const { recentPast, olderPast, future } = useMemo(
+    () => splitPastAndFutureByStart(events, nowTs || 0, 3),
+    [events, nowTs],
+  );
+
+  const visibleCount =
+    recentPast.length + olderPast.length + future.length;
+
+  function renderEventCard(evt: TeamEvent) {
+    const start = new Date(evt.start);
+    const end = evt.end ? new Date(evt.end) : undefined;
+    const status = rsvpMap[evt.id] || null;
+    return (
+      <div className="card" key={evt.id}>
+        <div className="row" style={{ flexWrap: "wrap" }}>
+          <div className="grow">
+            <div className="eventTitle">{evt.title}</div>
+            <div className="eventMeta muted">
+              <span className="badge badge-date" suppressHydrationWarning>
+                {mounted ? formatEventDate(start) : ""}
+              </span>
+              <span className="badge badge-time" suppressHydrationWarning>
+                {mounted ? formatEventTime(start, end) : ""}
+              </span>
+              {evt.location ? (
+                <span className="badge">{evt.location}</span>
+              ) : null}
+              {counts[evt.id] ? (
+                <span className="badge" aria-label="RSVP-overzicht">
+                  Ja <span className="count-yes">{counts[evt.id].yes}</span>{" "}
+                  · Misschien{" "}
+                  <span className="count-maybe">
+                    {counts[evt.id].maybe}
+                  </span>{" "}
+                  · Nee{" "}
+                  <span className="count-no">{counts[evt.id].no}</span>
+                </span>
+              ) : null}
+            </div>
+          </div>
+          {loggedIn ? (
+            <div
+              className="rsvp"
+              style={{ width: "100%", justifyContent: "flex-end" }}
+            >
+              <button
+                className={status === "yes" ? "active-yes" : ""}
+                aria-pressed={status === "yes"}
+                onClick={() =>
+                  setRsvp(evt.id, status === "yes" ? null : "yes")
+                }
+              >
+                Ja
+              </button>
+              <button
+                className={status === "maybe" ? "active-maybe" : ""}
+                aria-pressed={status === "maybe"}
+                onClick={() =>
+                  setRsvp(evt.id, status === "maybe" ? null : "maybe")
+                }
+              >
+                Misschien
+              </button>
+              <button
+                className={status === "no" ? "active-no" : ""}
+                aria-pressed={status === "no"}
+                onClick={() =>
+                  setRsvp(evt.id, status === "no" ? null : "no")
+                }
+              >
+                Nee
+              </button>
+            </div>
+          ) : null}
+        </div>
+        {loggedIn ? (
+          <div
+            className="rsvp"
+            style={{
+              justifyContent: "flex-end",
+              marginTop: 8,
+              gap: 8,
+              flexWrap: "wrap",
+            }}
+          >
+            <ReportPreview eventId={evt.id} />
+            <MvpVoteButton eventId={evt.id} />
+          </div>
+        ) : null}
+        {loggedIn ? (
+          <GenerateReportButton eventId={evt.id} opponent={evt.title} />
+        ) : null}
+        {evt.description ? (
+          <div className="muted" style={{ marginTop: 8 }}>
+            {evt.description}
+          </div>
+        ) : null}
+        {loggedIn ? (
+          <details
+            style={{ marginTop: 10 }}
+            onToggle={(e) => {
+              const el = e.currentTarget as HTMLDetailsElement;
+              if (el.open) void ensureListsLoaded(evt.id);
+            }}
+          >
+            <summary className="muted">RSVP-lijst tonen</summary>
+            <div className="rsvp-columns">
+              <div>
+                <div className="badge">Ja</div>
+                <div className="muted" style={{ marginTop: 4 }}>
+                  {(lists[evt.id]?.yes || []).map((u) => (
+                    <div key={u.id}>{u.name}</div>
+                  ))}
+                  {(lists[evt.id]?.yes || []).length === 0 ? (
+                    <div>—</div>
+                  ) : null}
+                </div>
+              </div>
+              <div>
+                <div className="badge">Misschien</div>
+                <div className="muted" style={{ marginTop: 4 }}>
+                  {(lists[evt.id]?.maybe || []).map((u) => (
+                    <div key={u.id}>{u.name}</div>
+                  ))}
+                  {(lists[evt.id]?.maybe || []).length === 0 ? (
+                    <div>—</div>
+                  ) : null}
+                </div>
+              </div>
+              <div>
+                <div className="badge">Nee</div>
+                <div className="muted" style={{ marginTop: 4 }}>
+                  {(lists[evt.id]?.no || []).map((u) => (
+                    <div key={u.id}>{u.name}</div>
+                  ))}
+                  {(lists[evt.id]?.no || []).length === 0 ? (
+                    <div>—</div>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </details>
+        ) : null}
+      </div>
+    );
+  }
 
   // Niets renderen tot de auth-check klaar is
   if (!authChecked) {
@@ -215,147 +346,30 @@ export default function EventList({ events }: Props) {
           {notice}
         </div>
       ) : null}
-      {grouped.map((evt) => {
-        const start = new Date(evt.start);
-        const end = evt.end ? new Date(evt.end) : undefined;
-        const status = rsvpMap[evt.id] || null;
-        return (
-          <div className="card" key={evt.id}>
-            <div className="row" style={{ flexWrap: "wrap" }}>
-              <div className="grow">
-                <div className="eventTitle">{evt.title}</div>
-                <div className="eventMeta muted">
-                  <span className="badge badge-date" suppressHydrationWarning>
-                    {mounted ? formatEventDate(start) : ""}
-                  </span>
-                  <span className="badge badge-time" suppressHydrationWarning>
-                    {mounted ? formatEventTime(start, end) : ""}
-                  </span>
-                  {evt.location ? (
-                    <span className="badge">{evt.location}</span>
-                  ) : null}
-                  {counts[evt.id] ? (
-                    <span className="badge" aria-label="RSVP-overzicht">
-                      Ja <span className="count-yes">{counts[evt.id].yes}</span>{" "}
-                      · Misschien{" "}
-                      <span className="count-maybe">
-                        {counts[evt.id].maybe}
-                      </span>{" "}
-                      · Nee{" "}
-                      <span className="count-no">{counts[evt.id].no}</span>
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-              {loggedIn ? (
-                <div
-                  className="rsvp"
-                  style={{ width: "100%", justifyContent: "flex-end" }}
-                >
-                  <button
-                    className={status === "yes" ? "active-yes" : ""}
-                    aria-pressed={status === "yes"}
-                    onClick={() =>
-                      setRsvp(evt.id, status === "yes" ? null : "yes")
-                    }
-                  >
-                    Ja
-                  </button>
-                  <button
-                    className={status === "maybe" ? "active-maybe" : ""}
-                    aria-pressed={status === "maybe"}
-                    onClick={() =>
-                      setRsvp(evt.id, status === "maybe" ? null : "maybe")
-                    }
-                  >
-                    Misschien
-                  </button>
-                  <button
-                    className={status === "no" ? "active-no" : ""}
-                    aria-pressed={status === "no"}
-                    onClick={() =>
-                      setRsvp(evt.id, status === "no" ? null : "no")
-                    }
-                  >
-                    Nee
-                  </button>
-                </div>
-              ) : null}
-            </div>
-            {/* Match report controls (bottom-right) */}
-            {loggedIn ? (
-              <div
-                className="rsvp"
-                style={{
-                  justifyContent: "flex-end",
-                  marginTop: 8,
-                  gap: 8,
-                  flexWrap: "wrap",
-                }}
-              >
-                <ReportPreview eventId={evt.id} />
-                <MvpVoteButton eventId={evt.id} />
-              </div>
-            ) : null}
-            {loggedIn ? (
-              <GenerateReportButton eventId={evt.id} opponent={evt.title} />
-            ) : null}
-            {evt.description ? (
-              <div className="muted" style={{ marginTop: 8 }}>
-                {evt.description}
-              </div>
-            ) : null}
-            {loggedIn ? (
-              <details
-                style={{ marginTop: 10 }}
-                onToggle={(e) => {
-                  const el = e.currentTarget as HTMLDetailsElement;
-                  if (el.open) void ensureListsLoaded(evt.id);
-                }}
-              >
-                <summary className="muted">RSVP-lijst tonen</summary>
-                <div className="rsvp-columns">
-                  <div>
-                    <div className="badge">Ja</div>
-                    <div className="muted" style={{ marginTop: 4 }}>
-                      {(lists[evt.id]?.yes || []).map((u) => (
-                        <div key={u.id}>{u.name}</div>
-                      ))}
-                      {(lists[evt.id]?.yes || []).length === 0 ? (
-                        <div>—</div>
-                      ) : null}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="badge">Misschien</div>
-                    <div className="muted" style={{ marginTop: 4 }}>
-                      {(lists[evt.id]?.maybe || []).map((u) => (
-                        <div key={u.id}>{u.name}</div>
-                      ))}
-                      {(lists[evt.id]?.maybe || []).length === 0 ? (
-                        <div>—</div>
-                      ) : null}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="badge">Nee</div>
-                    <div className="muted" style={{ marginTop: 4 }}>
-                      {(lists[evt.id]?.no || []).map((u) => (
-                        <div key={u.id}>{u.name}</div>
-                      ))}
-                      {(lists[evt.id]?.no || []).length === 0 ? (
-                        <div>—</div>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </details>
-            ) : null}
+      {recentPast.map((evt) => renderEventCard(evt))}
+      {olderPast.length > 0 ? (
+        <details style={{ marginBottom: 12 }}>
+          <summary
+            className="muted"
+            style={{ cursor: "pointer", fontWeight: 600 }}
+          >
+            Vorige wedstrijden ({olderPast.length})
+          </summary>
+          <div
+            style={{
+              marginTop: 12,
+              display: "flex",
+              flexDirection: "column",
+              gap: 12,
+            }}
+          >
+            {olderPast.map((evt) => renderEventCard(evt))}
           </div>
-        );
-      })}
+        </details>
+      ) : null}
+      {future.map((evt) => renderEventCard(evt))}
       <SpaceInvadersLauncher />
-      {grouped.length === 0 ? (
+      {visibleCount === 0 ? (
         <div className="muted">Geen recente of aankomende wedstrijden.</div>
       ) : null}
     </div>

--- a/src/lib/listSplitPast.test.ts
+++ b/src/lib/listSplitPast.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { splitPastAndFutureByStart } from "./listSplitPast";
+
+describe("splitPastAndFutureByStart", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z").getTime();
+
+  it("puts all past in recent when at or below the limit", () => {
+    const items = [
+      { start: "2026-06-01T10:00:00.000Z", id: "a" },
+      { start: "2026-06-10T10:00:00.000Z", id: "b" },
+    ];
+    const { recentPast, olderPast, future } = splitPastAndFutureByStart(
+      items,
+      now,
+      3,
+    );
+    expect(recentPast.map((e) => e.id)).toEqual(["a", "b"]);
+    expect(olderPast).toHaveLength(0);
+    expect(future).toHaveLength(0);
+  });
+
+  it("keeps last 3 past and groups the rest as olderPast", () => {
+    const items = [
+      { start: "2026-05-01T10:00:00.000Z", id: "1" },
+      { start: "2026-05-08T10:00:00.000Z", id: "2" },
+      { start: "2026-06-01T10:00:00.000Z", id: "3" },
+      { start: "2026-06-10T10:00:00.000Z", id: "4" },
+      { start: "2026-06-14T10:00:00.000Z", id: "5" },
+      { start: "2026-06-20T10:00:00.000Z", id: "6" },
+    ];
+    const { recentPast, olderPast, future } = splitPastAndFutureByStart(
+      items,
+      now,
+      3,
+    );
+    expect(olderPast.map((e) => e.id)).toEqual(["1", "2"]);
+    expect(recentPast.map((e) => e.id)).toEqual(["3", "4", "5"]);
+    expect(future.map((e) => e.id)).toEqual(["6"]);
+  });
+});

--- a/src/lib/listSplitPast.ts
+++ b/src/lib/listSplitPast.ts
@@ -1,0 +1,32 @@
+/**
+ * Splits chronologically sorted events (by `start`) into recent past, older past, and future
+ * relative to `nowMs`. Used to collapse long past lists behind a disclosure.
+ *
+ * @param items - Events with ISO `start`; order is normalized ascending by start time.
+ * @param nowMs - Current time in milliseconds (e.g. `Date.now()`).
+ * @param recentPastCount - How many past items stay visible (the last N before `nowMs`).
+ * @returns `recentPast` and `olderPast` in chronological order (oldest first); `future` chronological.
+ */
+export function splitPastAndFutureByStart<T extends { start: string }>(
+  items: T[],
+  nowMs: number,
+  recentPastCount: number,
+): { recentPast: T[]; olderPast: T[]; future: T[] } {
+  const allSorted = items
+    .slice()
+    .sort(
+      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+    );
+  const idx = allSorted.findIndex((e) => new Date(e.start).getTime() >= nowMs);
+  const pastAll = idx === -1 ? allSorted : allSorted.slice(0, idx);
+  const future = idx === -1 ? [] : allSorted.slice(idx);
+  const recentPast =
+    pastAll.length <= recentPastCount
+      ? pastAll
+      : pastAll.slice(-recentPastCount);
+  const olderPast =
+    pastAll.length > recentPastCount
+      ? pastAll.slice(0, pastAll.length - recentPastCount)
+      : [];
+  return { recentPast, olderPast, future };
+}

--- a/src/lib/training.test.ts
+++ b/src/lib/training.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { defaultSeasonWindow, generateTrainingDates, toYMD } from "./training";
+import {
+  defaultSeasonWindow,
+  generateTrainingDates,
+  splitTrainingSessionDatesForDisplay,
+  toYMD,
+} from "./training";
 
 describe("toYMD", () => {
   it("formatteert datum als YYYY-MM-DD", () => {
@@ -59,5 +64,28 @@ describe("defaultSeasonWindow", () => {
     expect(w.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(w.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(w.from < w.to).toBe(true);
+  });
+});
+
+describe("splitTrainingSessionDatesForDisplay", () => {
+  it("houdt de laatste drie trainingen vóór vandaag zichtbaar en groepeert oudere", () => {
+    const today = "2026-06-15";
+    const dates = [
+      "2026-05-06",
+      "2026-05-08",
+      "2026-05-13",
+      "2026-05-15",
+      "2026-06-03",
+      "2026-06-05",
+      "2026-06-17",
+    ];
+    const { recentPast, olderPast, upcoming } = splitTrainingSessionDatesForDisplay(
+      dates,
+      today,
+      3,
+    );
+    expect(olderPast).toEqual(["2026-05-06", "2026-05-08", "2026-05-13"]);
+    expect(recentPast).toEqual(["2026-05-15", "2026-06-03", "2026-06-05"]);
+    expect(upcoming).toEqual(["2026-06-17"]);
   });
 });

--- a/src/lib/training.ts
+++ b/src/lib/training.ts
@@ -65,5 +65,33 @@ export function defaultSeasonWindow(): { from: string; to: string } {
   return { from: toYMD(seasonStart), to: toYMD(seasonEnd) };
 }
 
+/**
+ * Splits training session dates (YYYY-MM-DD) into recent past, older past, and today-or-future
+ * for compact trainer UI. Dates are compared as strings on the calendar day.
+ *
+ * @param datesYmd - Session dates, typically ascending from the API.
+ * @param todayYmd - Today's date as YYYY-MM-DD (local calendar for the team).
+ * @param recentPastCount - Past sessions to show outside the "earlier" group (default 3).
+ */
+export function splitTrainingSessionDatesForDisplay(
+  datesYmd: string[],
+  todayYmd: string,
+  recentPastCount = 3,
+): { recentPast: string[]; olderPast: string[]; upcoming: string[] } {
+  const sorted = datesYmd.slice().sort();
+  const past = sorted.filter((d) => d < todayYmd);
+  const upcoming = sorted.filter((d) => d >= todayYmd);
+  const recentPast =
+    past.length <= recentPastCount
+      ? past
+      : past.slice(-recentPastCount);
+  const olderPast =
+    past.length > recentPastCount
+      ? past.slice(0, past.length - recentPastCount)
+      : [];
+  return { recentPast, olderPast, upcoming };
+}
+
+
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Op de homepage toont `EventList` nu de **laatste drie gespeelde wedstrijden** direct; oudere verleden-wedstrijden staan in een uitklapbare sectie **"Vorige wedstrijden (N)"**, gevolgd door aankomende wedstrijden. Zo blijft de lijst kort als Sportlink veel verleden-events teruggeeft.

Op **Trainingsopkomst** voor trainers (`/trainer/attendance`) geldt hetzelfde op datumniveau: de **laatste drie trainingen vóór vandaag** staan open, **eerdere datums** onder **"Eerdere trainingen dit seizoen (N)"**, daarna trainingen vanaf vandaag. Logica staat in `splitTrainingSessionDatesForDisplay` in `src/lib/training.ts`; wedstrijden gebruiken `splitPastAndFutureByStart` in `src/lib/listSplitPast.ts`. Unit tests toegevoegd.

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s): n.v.t.
  - Functional spec section(s): n.v.t.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a33d7bc-0b03-42cb-a3f5-269fab2eb525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a33d7bc-0b03-42cb-a3f5-269fab2eb525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training sessions are now organized into recent past, older past (collapsed), and upcoming groups for improved clarity.
  * Events are similarly grouped with older matches hidden behind an expandable section showing the count of past events.
  * Enhanced layout organization reduces visual clutter while keeping historical data accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->