### PR TITLE
chore(ops): Neon preview-branch cleanup en beleid

### DIFF
--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -1,0 +1,34 @@
+# Prunes old Neon branches when NEON_API_KEY + NEON_PROJECT_ID are set as repo secrets.
+# See docs/tech/neon-preview-branch-cleanup.md
+name: Neon branch cleanup
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: neon-cleanup-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Prune Neon branches
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+        run: |
+          if [ -z "${NEON_API_KEY:-}" ] || [ -z "${NEON_PROJECT_ID:-}" ]; then
+            echo "NEON_API_KEY or NEON_PROJECT_ID not configured — skipping (see docs/tech/neon-preview-branch-cleanup.md)."
+            exit 0
+          fi
+          node scripts/neon-cleanup-branches.mjs --max-total=12 --execute

--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -4,7 +4,7 @@ name: Neon branch cleanup
 
 on:
   schedule:
-    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+    - cron: "0 6 * * *" # Daily 06:00 UTC
   workflow_dispatch:
 
 concurrency:

--- a/docs/tech/neon-preview-branch-cleanup.md
+++ b/docs/tech/neon-preview-branch-cleanup.md
@@ -39,7 +39,7 @@ Het script verwijdert **alleen niet-primary** branches en begint bij **bladeren*
 
 ## Optioneel: geplande run in GitHub
 
-Workflow: `.github/workflows/neon-branch-cleanup.yml` (wekelijks maandag 06:00 UTC + **Actions → Neon branch cleanup → Run workflow**).
+Workflow: `.github/workflows/neon-branch-cleanup.yml` (dagelijks 06:00 UTC + **Actions → Neon branch cleanup → Run workflow**).
 
 Repository secrets (Settings → Secrets and variables → Actions):
 

--- a/docs/tech/neon-preview-branch-cleanup.md
+++ b/docs/tech/neon-preview-branch-cleanup.md
@@ -1,0 +1,53 @@
+# Neon preview branches opruimen (Vercel-integratie)
+
+Vercel kan per preview-deploy een **Neon-databasebranch** aanmaken (bijv. integratie `h3-teamy-preview-db`). Op gratis/laag betaalde plannen geldt een **maximum aantal branches**. Als dat vol is, faalt provisioning met:
+
+> Branch limit reached. Upgrade your plan or delete unused branches.
+
+Dit document is het **beleid** voor opruimen; de uitvoering is handmatig of via het script hieronder.
+
+## Beleid (team)
+
+1. **Primary branch nooit verwijderen** — dat is de vaste lijn (productie / hoofd-timeline in Neon).
+2. **Preview-branches zijn wegwerp** — zodra een PR is gemerged of duidelijk verlaten, mag de bijbehorende Neon-branch weg (data was test-only).
+3. **Maandelijks (of bij “branch limit”-fout)** iemand met Neon-toegang:
+   - Neon Console → project → **Branches**;
+   - sorteer op **laatst gebruikt / oud**;
+   - verwijder **oude preview-/feature-branches** waarvan de PR al dicht is.
+4. **Vóór massaal verwijderen**: even checken of geen open PR die branch nog nodig heeft voor een actieve preview.
+5. **Upgrade** alleen overwegen als het team structureel meer dan ~10 gelijktijdige preview-branches nodig heeft; anders is opschonen goedkoper.
+
+## Automatisch script (aanbevolen flow)
+
+Eenmalig in Neon: **Settings → API keys** een key aanmaken. **Project ID** staat op de project-settingspagina.
+
+```bash
+export NEON_API_KEY="..."
+export NEON_PROJECT_ID="autumn-disk-XXXXXX"   # jouw project-id
+
+# 1) Alleen tonen wat weg zou gaan (standaard veilig)
+npm run neon:cleanup-branches
+
+# 2) Echt verwijderen tot max. 12 branches (incl. primary)
+npm run neon:cleanup-branches -- --execute
+
+# Optioneel: andere limiet
+npm run neon:cleanup-branches -- --max-total=10 --execute
+```
+
+Het script verwijdert **alleen niet-primary** branches en begint bij **bladeren** (geen kind-branches meer), zodat de Neon-regel “eerst kinderen, dan ouder” gevolgd wordt.
+
+## Optioneel: geplande run in GitHub
+
+Workflow: `.github/workflows/neon-branch-cleanup.yml` (wekelijks maandag 06:00 UTC + **Actions → Neon branch cleanup → Run workflow**).
+
+Repository secrets (Settings → Secrets and variables → Actions):
+
+- `NEON_API_KEY`
+- `NEON_PROJECT_ID`
+
+Zonder deze variabelen slaat de job zichzelf over (groene run, geen deletes).
+
+## Gerelateerd
+
+- [Preview en productie databases](./preview-and-production-databases.md)

--- a/docs/tech/preview-and-production-databases.md
+++ b/docs/tech/preview-and-production-databases.md
@@ -84,6 +84,11 @@ DB gedeeld hebben kunnen.
 3. `npm run db:migrate:preview` — schema bijgewerkt?
 4. `npm run db:seed:preview` — dummy data aanwezig?
 
+## Neon preview branches (limiet / Vercel-provisioning)
+
+Als Vercel faalt met **“Branch limit reached”** bij de preview-database: zie
+[Neon preview branch cleanup](./neon-preview-branch-cleanup.md) voor beleid en `npm run neon:cleanup-branches`.
+
 ## Veiligheidsregels
 
 - `prisma/seed.ts` weigert te draaien tegen production-achtige URLs (env-check)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:migrate:preview": "dotenv -e .env.preview.local -- prisma migrate deploy",
     "db:migrate:production": "dotenv -e .env.production.local -- prisma migrate deploy",
     "db:migrate:both": "npm run db:migrate:preview && npm run db:migrate:production",
+    "neon:cleanup-branches": "node scripts/neon-cleanup-branches.mjs",
     "db:seed": "tsx prisma/seed.ts",
     "db:seed:preview": "dotenv -e .env.preview.local -- tsx prisma/seed.ts",
     "build": "next build",

--- a/scripts/neon-cleanup-branches.mjs
+++ b/scripts/neon-cleanup-branches.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Prunes Neon database branches created for Vercel preview deploys when the
+ * account hits the branch limit. Never deletes the project's primary branch.
+ *
+ * Env:
+ *   NEON_API_KEY   — Personal API key from Neon Console (Settings → API keys)
+ *   NEON_PROJECT_ID — Project ID from Neon project settings (e.g. autumn-disk-484331)
+ *
+ * Usage:
+ *   node scripts/neon-cleanup-branches.mjs              # dry-run: list only
+ *   node scripts/neon-cleanup-branches.mjs --execute    # perform deletes
+ *   node scripts/neon-cleanup-branches.mjs --max-total=12 --execute
+ *
+ * @see docs/tech/neon-preview-branch-cleanup.md
+ */
+
+const BASE = "https://console.neon.tech/api/v2";
+
+function parseArgs(argv) {
+  const execute = argv.includes("--execute");
+  let maxTotal = 12;
+  for (const a of argv) {
+    if (a.startsWith("--max-total=")) {
+      maxTotal = Math.max(2, Number.parseInt(a.slice("--max-total=".length), 10) || 12);
+    }
+  }
+  return { execute, maxTotal };
+}
+
+async function neonFetch(path, { method = "GET", apiKey } = {}) {
+  const url = `${BASE}${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text };
+  }
+  if (!res.ok) {
+    const msg = body?.message || body?.error || res.statusText;
+    throw new Error(`${method} ${path} → ${res.status}: ${msg}`);
+  }
+  return body;
+}
+
+async function listAllBranches(projectId, apiKey) {
+  const branches = [];
+  let cursor = null;
+  for (;;) {
+    const qs = new URLSearchParams({ limit: "100", sort_by: "updated_at", sort_order: "asc" });
+    if (cursor) qs.set("cursor", cursor);
+    const data = await neonFetch(`/projects/${projectId}/branches?${qs}`, { apiKey });
+    const batch = data.branches || [];
+    branches.push(...batch);
+    cursor = data.pagination?.next || data.pagination?.cursor || null;
+    if (!cursor || batch.length === 0) break;
+  }
+  return branches;
+}
+
+function getPrimaryBranch(branches) {
+  const primary = branches.find((b) => b.primary === true);
+  if (primary) return primary;
+  const noParent = branches.find((b) => !b.parent_id);
+  if (noParent) return noParent;
+  return branches.find((b) => b.name === "main") || branches[0];
+}
+
+/** Branches that are not parent of any other branch in the set (safe delete order bottom-up). */
+function leafNonPrimaryIds(branches, primaryId) {
+  const ids = new Set(branches.map((b) => b.id));
+  const isParent = new Set();
+  for (const b of branches) {
+    if (b.parent_id && ids.has(b.parent_id)) {
+      isParent.add(b.parent_id);
+    }
+  }
+  return branches
+    .filter((b) => b.id !== primaryId && !isParent.has(b.id))
+    .sort((a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime())
+    .map((b) => b.id);
+}
+
+async function main() {
+  const { execute, maxTotal } = parseArgs(process.argv.slice(2));
+  const apiKey = process.env.NEON_API_KEY;
+  const projectId = process.env.NEON_PROJECT_ID;
+
+  if (!apiKey || !projectId) {
+    console.error(
+      "Set NEON_API_KEY and NEON_PROJECT_ID (see docs/tech/neon-preview-branch-cleanup.md).",
+    );
+    process.exit(1);
+  }
+
+  let branches = await listAllBranches(projectId, apiKey);
+  const primary = getPrimaryBranch(branches);
+  if (!primary) {
+    console.error("No branches returned; check NEON_PROJECT_ID.");
+    process.exit(1);
+  }
+
+  console.log(`Project ${projectId}: ${branches.length} branch(es), primary = ${primary.id} (${primary.name || "unnamed"})`);
+  console.log(`Target: at most ${maxTotal} branches total. Mode: ${execute ? "DELETE" : "dry-run"}.`);
+
+  if (branches.length <= maxTotal) {
+    console.log("Nothing to prune.");
+    return;
+  }
+
+  while (branches.length > maxTotal) {
+    const leaves = leafNonPrimaryIds(branches, primary.id);
+    const victimId = leaves[0];
+    if (!victimId) {
+      console.error(
+        "No deletable leaf branch found (Neon requires deleting children before parents). Prune manually in Neon Console.",
+      );
+      process.exit(2);
+    }
+    const victim = branches.find((b) => b.id === victimId);
+    console.log(
+      `${execute ? "Deleting" : "Would delete"} ${victimId} (${victim?.name || "unnamed"}, updated ${victim?.updated_at})`,
+    );
+    if (execute) {
+      await neonFetch(`/projects/${projectId}/branches/${victimId}`, {
+        method: "DELETE",
+        apiKey,
+      });
+    }
+    branches = branches.filter((b) => b.id !== victimId);
+  }
+
+  if (!execute) {
+    console.log("\nRe-run with --execute to apply deletes.");
+  } else {
+    console.log(`Done. ${branches.length} branch(es) remain.`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vercel preview deploys can fail with **Neon branch limit reached** when too many preview DB branches exist. This PR adds:

- **`docs/tech/neon-preview-branch-cleanup.md`** — team policy (when/how to delete, never touch primary) and runbook.
- **`scripts/neon-cleanup-branches.mjs`** — lists or deletes oldest **leaf** non-primary branches until the project is at or below `--max-total` (default 12). Dry-run by default; `--execute` applies deletes.
- **`npm run neon:cleanup-branches`** in `package.json`.
- **`.github/workflows/neon-branch-cleanup.yml`** — weekly + manual dispatch; skips if `NEON_API_KEY` / `NEON_PROJECT_ID` secrets are unset.
- Link from **`docs/tech/preview-and-production-databases.md`**.

The agent cannot delete branches in your Neon account without credentials; configure secrets and run the script or workflow, or delete branches in the Neon Console per the doc.

## Docs

- [x] Added `docs/tech/neon-preview-branch-cleanup.md`
- [ ] `npm run docs:generate` (not required for ops-only doc)
- Links:
  - Feature doc(s): `docs/tech/neon-preview-branch-cleanup.md`
  - Functional spec section(s): n.v.t.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a33d7bc-0b03-42cb-a3f5-269fab2eb525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a33d7bc-0b03-42cb-a3f5-269fab2eb525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Toegevoegd documentatie voor het beheren en opschonen van Neon preview database branches.

* **Chores**
  * Geïmplementeerd geautomatiseerde dagelijkse opschoning van ongebruikte Neon branches via GitHub Actions workflow.
  * Toegevoegd `npm run neon:cleanup-branches` commando voor handmatige opschoning van preview branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->