### PR TITLE
fix(report-extract): use nullable instead of optional for OpenAI strict schema

### DIFF
--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -96,8 +96,19 @@ function isRawEvent(value: unknown): value is RawEvent {
     return false;
   if (team !== "home" && team !== "away") return false;
   if (type !== "goal" && type !== "personal_foul") return false;
-  if (value.time !== undefined && typeof value.time !== "string") return false;
-  if (value.player !== undefined && typeof value.player !== "string")
+  // The extract provider now emits `null` instead of omitting fields (required
+  // by OpenAI strict structured-output mode). Treat null the same as missing.
+  if (
+    value.time !== undefined &&
+    value.time !== null &&
+    typeof value.time !== "string"
+  )
+    return false;
+  if (
+    value.player !== undefined &&
+    value.player !== null &&
+    typeof value.player !== "string"
+  )
     return false;
   return true;
 }

--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -13,6 +13,18 @@ type RawEvent = {
   player?: string;
 };
 
+// The extract provider emits `null` for absent string fields (required by
+// OpenAI strict structured-output mode). `RawEvent` keeps the strict
+// `string | undefined` shape, so we normalize at the boundary in
+// `toRawEvents` after validating with `isRawEventInput`.
+type RawEventInput = {
+  quarter: 1 | 2 | 3 | 4;
+  time?: string | null;
+  team: "home" | "away";
+  type: "goal" | "personal_foul";
+  player?: string | null;
+};
+
 type ReportBody = {
   eventId?: unknown;
   homeTeam?: unknown;
@@ -87,7 +99,7 @@ function toNumberValue(value: unknown): number | undefined {
     : undefined;
 }
 
-function isRawEvent(value: unknown): value is RawEvent {
+function isRawEventInput(value: unknown): value is RawEventInput {
   if (!isRecord(value)) return false;
   const quarter = value.quarter;
   const team = value.team;
@@ -96,8 +108,6 @@ function isRawEvent(value: unknown): value is RawEvent {
     return false;
   if (team !== "home" && team !== "away") return false;
   if (type !== "goal" && type !== "personal_foul") return false;
-  // The extract provider now emits `null` instead of omitting fields (required
-  // by OpenAI strict structured-output mode). Treat null the same as missing.
   if (
     value.time !== undefined &&
     value.time !== null &&
@@ -115,7 +125,13 @@ function isRawEvent(value: unknown): value is RawEvent {
 
 function toRawEvents(value: unknown): RawEvent[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const events = value.filter(isRawEvent);
+  const events: RawEvent[] = value.filter(isRawEventInput).map((evt) => ({
+    quarter: evt.quarter,
+    team: evt.team,
+    type: evt.type,
+    time: evt.time ?? undefined,
+    player: evt.player ?? undefined,
+  }));
   return events.length ? events : undefined;
 }
 

--- a/src/lib/reportExtractProvider.ts
+++ b/src/lib/reportExtractProvider.ts
@@ -1,21 +1,27 @@
 import * as Sentry from "@sentry/nextjs";
 import { z } from "zod";
 
+// OpenAI's structured-output (strict mode) via the Vercel AI Gateway requires
+// every property listed in `properties` to also appear in `required`. Optional
+// fields therefore have to be expressed as `.nullable()` (string | null), not
+// `.optional()` (omittable from the JSON entirely). See Sentry incident on
+// `/api/report/extract` 502 with "Invalid schema for response_format 'response'
+// ... Missing 'time'".
 const ExtractEventSchema = z.object({
   quarter: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
-  time: z.string().optional(),
+  time: z.string().nullable(),
   team: z.enum(["home", "away"]),
   type: z.enum(["goal", "personal_foul"]),
-  player: z.string().optional(),
+  player: z.string().nullable(),
 });
 
 const ExtractResultSchema = z.object({
-  homeTeam: z.string().optional(),
-  awayTeam: z.string().optional(),
-  homeScore: z.number().optional(),
-  awayScore: z.number().optional(),
-  date: z.string().optional(),
-  events: z.array(ExtractEventSchema).optional(),
+  homeTeam: z.string().nullable(),
+  awayTeam: z.string().nullable(),
+  homeScore: z.number().nullable(),
+  awayScore: z.number().nullable(),
+  date: z.string().nullable(),
+  events: z.array(ExtractEventSchema).nullable(),
 });
 
 type ExtractEvent = z.infer<typeof ExtractEventSchema>;


### PR DESCRIPTION
## Summary
Production hotfix for `/api/report/extract` 502 errors:
> GatewayInternalServerError: Invalid schema for response_format 'response': In context=('properties', 'events', 'items'), 'required' is required to be supplied and to be an array including every key in properties. Missing 'time'.

OpenAI's structured-output (strict mode) used by `generateObject` through the Vercel AI Gateway requires every property listed in \`properties\` to also appear in \`required\`. \`.optional()\` makes Zod emit a property without listing it as required, which the strict OpenAI validator rejects.

## Changes
- \`src/lib/reportExtractProvider.ts\` — switch ExtractEvent + ExtractResult schemas from \`.optional()\` to \`.nullable()\` so optional fields become \`string | null\` (always present, sometimes null) instead of being omittable.
- \`src/app/api/report/generate/route.ts\` — update \`isRawEvent\` to treat \`null\` the same as missing for \`time\` and \`player\`, since the extract provider now emits null for those instead of dropping the keys.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`vitest run\` — 296 passed, 28 skipped (preexisting)
- [x] \`eslint\` — clean on changed files
- [ ] After merge: trigger a real screenshot upload on production and verify the report generates successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Releasenotes

* **Bug Fixes**
  * Verbeterde validatie van geëxtraheerde sportgebeurtenissen door optionele velden correct af te handelen. Events kunnen nu zonder fouten worden verwerkt wanneer bepaalde velden ontbreken of null-waarden bevatten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->