### PR TITLE
fix(report-generate): repopulate roster cache so player names match

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ const config = [
       ".next/**",
       "node_modules/**",
       ".cursor/**",
+      ".claude/**",
       "ecc-reference/**",
       "e2e/**",
     ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ const config = [
       ".next/**",
       "node_modules/**",
       ".cursor/**",
-      ".claude/**",
+      ".claude/worktrees/**",
       "ecc-reference/**",
       "e2e/**",
     ],

--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/nextjs";
 import { getReport, setReport, kvGetJson } from "../../../../lib/kv";
 import { MVP_PLACEHOLDER } from "../../../../lib/mvpNarrative";
 import { sendMatchReportToWhatsAppGroup } from "../../../../lib/services/waapiService";
+import { getActiveUsers } from "../../../../lib/services/userService";
 import type { TeamEvent } from "../../../../types";
 
 type RawEvent = {
@@ -182,13 +183,14 @@ function similarity(a: string, b: string): number {
 
 async function getRosterNames(): Promise<string[]> {
   try {
-    const cached =
-      await kvGetJson<{ id: string; name: string }[]>("users:roster:v2");
-    if (Array.isArray(cached) && cached.length) {
-      return cached.map((u) => u.name).filter(Boolean);
-    }
-  } catch {}
-  return [];
+    const users = await getActiveUsers();
+    return users.map((u) => u.name).filter(Boolean);
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      tags: { module: "report_generate", operation: "getRosterNames" },
+    });
+    return [];
+  }
 }
 
 function canonicalizePlayer(

--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -358,8 +358,23 @@ function prepareNarrativeInput(
   };
 }
 
-// Simplified generation: consume provided JSON and let the model write the report.
-
+/**
+ * Genereert een Nederlandstalig wedstrijdverslag uit de geleverde JSON en
+ * verstuurt een notificatie naar de WhatsApp-groep.
+ *
+ * Verwacht een `ReportBody` met `eventId`, scores en events. Spelersnamen in
+ * "us"-events worden gematcht tegen de actuele roster (fuzzy via Levenshtein,
+ * drempel 0.72); bij een onmatchbare naam vervalt deze, zodat het AI-prompt
+ * algemene formuleringen gebruikt. Een geslaagde generatie cachet het verslag
+ * via `setReport` en vuurt `sendMatchReportToWhatsAppGroup`.
+ *
+ * @param req - Next.js request met JSON-body (`ReportBody`).
+ * @returns 200 met `{ ok, report, whatsappNotification }`,
+ *   400 bij ongeldige JSON of ontbrekende `eventId`,
+ *   422 wanneer scores of events ontbreken,
+ *   502 wanneer het AI-model faalt,
+ *   500 bij een onverwachte fout.
+ */
 export async function POST(req: NextRequest) {
   try {
     let body: ReportBody;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       "e2e/**",
       "evals/**",
       "**/.opencode/**",
-      ".claude/**",
+      ".claude/worktrees/**",
     ],
     alias: {
       "@": resolve(__dirname, "./src"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "e2e/**",
       "evals/**",
       "**/.opencode/**",
+      ".claude/**",
     ],
     alias: {
       "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- `getRosterNames()` in the match-report route only read the `users:roster:v2` KV cache and silently returned `[]` on miss. After `PUT /api/admin/users` invalidates the cache (or on cold start), every "us" event got `player: undefined`, the AI prompt had no names, and reports came out anonymous — observed in the latest run.
- Delegate to `getActiveUsers()` which already handles cache → Prisma → repopulate, and surface failures via Sentry instead of swallowing them.
- Also exclude `.claude/worktrees/**` from vitest and ESLint so worktree artifacts (e.g. Playwright specs from another branch) don't break the pre-commit hook.

## Test plan
- [x] `npx vitest run src/app/api/report/generate/route.waapi-e2e.test.ts` — 4/4 pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-commit hook (prettier + lint + tsc + vitest) green on both commits
- [ ] CI verify pipeline green
- [ ] Vercel preview deploy green
- [ ] Manual: trigger a match report after clearing `users:roster:v2` and confirm player names appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Verbeterde foutafhandeling in rapportgeneratie met betere logging
* Aangevulde configuratie voor ontwikkelings- en testomgeving

<!-- end of auto-generated comment: release notes by coderabbit.ai -->