### PR TITLE
fix(report-generate): force exact scorer counts to stop name inflation/omission

### DIFF
--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -473,7 +473,7 @@ Regels:
 - "Wij/ons" = De Rijn Heren 3, ongeacht of we thuis of uit spelen.
 - Baseer het resultaat uitsluitend op ourScore versus opponentScore. Benoem expliciet dat wij gewonnen hebben bij ourScore > opponentScore, verloren bij ourScore < opponentScore, of dat het gelijkspel was wanneer de scores gelijk zijn.
 - Gebruik alleen spelersnamen die voorkomen bij events met "team": "us". Als er geen naam staat, omschrijf de actie algemeen ("een van onze schutters") maar verzin geen namen.
-- Tel vóór het schrijven per speler hoe vaak die voorkomt in events met "type": "goal" en "team": "us". Vermeld in het verslag elke scorer minstens één keer — laat geen scorer weg — en noem geen scorer vaker dan dit aantal. Verzin geen extra goal-vermeldingen.
+- Tel vóór het schrijven per speler hoe vaak die voorkomt in events met "type": "goal" en "team": "us". Gebruik deze telling exact: noem elke scorer precies even vaak als het getelde aantal doelpunten (niet minder, niet meer). Laat geen scorer weg en verzin geen extra goal-vermeldingen.
 - Noem nooit namen van individuele tegenstanders. Je mag de teamnaam (${narrativeInput.opponentTeam}) gebruiken, maar spreek verder over "de tegenstander".
 - Meld opponent-events hooguit kort en zonder namen (bijv. "de tegenstander kwam nog even terug").
 - Schrijf energiek en sportief, maximaal 2 uitroeptekens, en blijf positief vanuit ons perspectief.

--- a/src/app/api/report/generate/route.ts
+++ b/src/app/api/report/generate/route.ts
@@ -473,6 +473,7 @@ Regels:
 - "Wij/ons" = De Rijn Heren 3, ongeacht of we thuis of uit spelen.
 - Baseer het resultaat uitsluitend op ourScore versus opponentScore. Benoem expliciet dat wij gewonnen hebben bij ourScore > opponentScore, verloren bij ourScore < opponentScore, of dat het gelijkspel was wanneer de scores gelijk zijn.
 - Gebruik alleen spelersnamen die voorkomen bij events met "team": "us". Als er geen naam staat, omschrijf de actie algemeen ("een van onze schutters") maar verzin geen namen.
+- Tel vóór het schrijven per speler hoe vaak die voorkomt in events met "type": "goal" en "team": "us". Vermeld in het verslag elke scorer minstens één keer — laat geen scorer weg — en noem geen scorer vaker dan dit aantal. Verzin geen extra goal-vermeldingen.
 - Noem nooit namen van individuele tegenstanders. Je mag de teamnaam (${narrativeInput.opponentTeam}) gebruiken, maar spreek verder over "de tegenstander".
 - Meld opponent-events hooguit kort en zonder namen (bijv. "de tegenstander kwam nog even terug").
 - Schrijf energiek en sportief, maximaal 2 uitroeptekens, en blijf positief vanuit ons perspectief.


### PR DESCRIPTION
## Summary
- Generated reports occasionally inflated popular scorers (e.g. Guido Vermeulen mentioned 5× when he scored 3) and silently dropped less-mentioned scorers (e.g. Harrie Stens missing entirely from a real DOS H1 vs De Rijn H3 report).
- Add one rule to the generation prompt that forces the model to count goals per player from the JSON before writing, mention each scorer at least once, and never more than their actual count.

## Why this should help
The previous prompt only said "use names from the JSON, don't invent." That permitted *over*-mentioning real names. The new rule turns it into an enumerate-then-narrate constraint: count first, then ensure narrative matches counts exactly. No model upgrade required — gpt-5-chat-latest can follow this with `temperature: 0.2`.

## Test plan
- [x] `vitest run` passes (314/342 with 28 skipped)
- [ ] CI verify pipeline green
- [ ] Vercel preview deploy green
- [ ] Manual: regenerate the DOS H1 vs De Rijn H3 (12-7) report after PR #268 + this PR are live; confirm Guido shows 3× (not 5×) and Harrie Stens is mentioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verbeterde nauwkeurigheid van AI-gegenereerde rapportages door zorgen dat doelpuntenmakers correct worden vermeld op basis van werkelijke wedstrijdgebeurtenissen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->