### PR TITLE
fix(report-extract): resize tall screenshots before VLM call (Claude 8000px limit)

### DIFF
--- a/src/lib/reportExtractProvider.ts
+++ b/src/lib/reportExtractProvider.ts
@@ -302,13 +302,56 @@ async function callAiTextNormalization(args: {
   }
 }
 
+/**
+ * Anthropic vision models reject images where any dimension exceeds 8000 px.
+ * `sharp` downscales the longest side to fit so a single stitched screenshot
+ * (often very tall) doesn't break extraction with Claude/Sonnet, while gpt-4o
+ * keeps working unchanged. PNG is preserved so text rendering stays sharp.
+ */
+async function fitImageForVisionLimits(
+  buffer: Buffer,
+  mimeType: string,
+): Promise<{ buffer: Buffer; mimeType: string }> {
+  const MAX_DIMENSION = 7800;
+  try {
+    const sharpModule = await import("sharp");
+    const sharp = sharpModule.default;
+    const meta = await sharp(buffer).metadata();
+    const width = meta.width ?? 0;
+    const height = meta.height ?? 0;
+    if (!width || !height) return { buffer, mimeType };
+    if (width <= MAX_DIMENSION && height <= MAX_DIMENSION) {
+      return { buffer, mimeType };
+    }
+    const resized = await sharp(buffer)
+      .resize({
+        width: width >= height ? MAX_DIMENSION : undefined,
+        height: height > width ? MAX_DIMENSION : undefined,
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .png()
+      .toBuffer();
+    return { buffer: resized, mimeType: "image/png" };
+  } catch {
+    // sharp could not read the buffer (e.g. unrecognized format in tests).
+    // Fall through with the original payload — the VLM call will surface any
+    // real client/provider error.
+    return { buffer, mimeType };
+  }
+}
+
 async function callAiVisionExtraction(args: {
   model: string;
   file: File;
 }): Promise<ExtractResult> {
   const { generateObject } = await import("./ai/client");
-  const buffer = Buffer.from(await args.file.arrayBuffer());
-  const mimeType = args.file.type || "image/png";
+  const rawBuffer = Buffer.from(await args.file.arrayBuffer());
+  const rawMimeType = args.file.type || "image/png";
+  const { buffer, mimeType } = await fitImageForVisionLimits(
+    rawBuffer,
+    rawMimeType,
+  );
   try {
     const { object } = await generateObject({
       model: gatewayModelString(args.model),


### PR DESCRIPTION
## Summary
- Switching `REPORT_EXTRACT_OPENAI_MODEL` to `anthropic/claude-sonnet-4-6` blew up extraction with `image dimensions exceed max allowed size: 8000 pixels`. Stitched match-report screenshots are routinely much taller than 8000 px.
- Add a `sharp`-based downscale that fits the longest dimension to 7800 px before sending to the VLM. Preserves PNG to keep text crisp.
- gpt-4o was unaffected (it auto-handles oversized images server-side), so this only kicks in when the dimension threshold is actually crossed — no perf cost on small screenshots.
- Sharp errors (e.g. unrecognized buffer in unit-test mocks) fall through with the original buffer so existing tests pass and a sharp hiccup never blocks a real extraction.

## Test plan
- [x] `vitest run src/lib/reportExtractProvider.test.ts` — 14/14 pass
- [x] Full `vitest run` — 314/342 pass (28 skipped pre-existing)
- [x] `tsc --noEmit` clean
- [ ] CI verify pipeline green
- [ ] Vercel preview deploy green
- [ ] Manual: redo the admin proefdraai with the multi-pane screenshot; confirm Sonnet extraction now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)