### PR TITLE
feat(auth): WebAuthn-passkeys op profiel en login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@prisma/adapter-pg": "7.8.0",
         "@prisma/client": "7.8.0",
         "@sentry/nextjs": "^10.51.0",
+        "@simplewebauthn/browser": "^13.3.0",
+        "@simplewebauthn/server": "^13.3.0",
         "@tailwindcss/postcss": "^4.2.4",
         "ai": "^6.0.175",
         "bcryptjs": "^3.0.3",
@@ -1326,6 +1328,12 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "license": "MIT",
@@ -1904,6 +1912,12 @@
     },
     "node_modules/@kwsites/promise-deferred": {
       "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2581,6 +2595,174 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -4061,6 +4243,31 @@
       "license": "MIT",
       "dependencies": {
         "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -5747,6 +5954,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -10743,6 +10964,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "license": "BSD-3-Clause",
@@ -10874,6 +11113,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -12116,6 +12361,24 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "@prisma/adapter-pg": "7.8.0",
     "@prisma/client": "7.8.0",
     "@sentry/nextjs": "^10.51.0",
+    "@simplewebauthn/browser": "^13.3.0",
+    "@simplewebauthn/server": "^13.3.0",
     "@tailwindcss/postcss": "^4.2.4",
     "ai": "^6.0.175",
     "bcryptjs": "^3.0.3",

--- a/prisma/migrations/20260506120000_add_passkeys/migration.sql
+++ b/prisma/migrations/20260506120000_add_passkeys/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "Passkey" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "credentialId" TEXT NOT NULL,
+    "publicKey" BYTEA NOT NULL,
+    "counter" INTEGER NOT NULL DEFAULT 0,
+    "transports" TEXT,
+    "label" TEXT,
+
+    CONSTRAINT "Passkey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Passkey_credentialId_key" ON "Passkey"("credentialId");
+
+-- CreateIndex
+CREATE INDEX "Passkey_userId_idx" ON "Passkey"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Passkey" ADD CONSTRAINT "Passkey_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,27 @@ model User {
   identities Identity[]
   attendances Attendance[]
   feedback  Feedback[]
+  passkeys  Passkey[]
+}
+
+/** WebAuthn-passkey (Touch ID, Face ID, Windows Hello, enz.) gekoppeld aan een gebruiker. */
+model Passkey {
+  id           String   @id @default(cuid())
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  userId       String
+  /** Base64url credential-id (WebAuthn). */
+  credentialId String   @unique
+  publicKey    Bytes
+  counter      Int      @default(0)
+  /** JSON-array van transports, zoals door de browser gerapporteerd. */
+  transports   String?
+  /** Optionele korte weergavenaam voor de gebruiker. */
+  label        String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model Event {

--- a/src/app/api/auth/passkey/login-options/route.ts
+++ b/src/app/api/auth/passkey/login-options/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { startPasskeyLogin } from "../../../../../lib/services/passkeyService";
+import {
+  isDbUnavailableError,
+  jsonDatabaseUnavailable,
+} from "../../../../../lib/dbUnavailableError";
+
+/**
+ * POST — start passkey-login (biometrie / apparaatslot).
+ */
+export async function POST(): Promise<Response> {
+  try {
+    const payload = await startPasskeyLogin();
+    return NextResponse.json(payload);
+  } catch (error: unknown) {
+    if (isDbUnavailableError(error)) {
+      return jsonDatabaseUnavailable();
+    }
+    Sentry.captureException(error);
+    return NextResponse.json({ error: "Er ging iets mis" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/passkey/login-verify/route.ts
+++ b/src/app/api/auth/passkey/login-verify/route.ts
@@ -1,0 +1,66 @@
+import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
+import {
+  isDbUnavailableError,
+  jsonDatabaseUnavailable,
+} from "../../../../../lib/dbUnavailableError";
+import { createPasskeyExchangeToken } from "../../../../../lib/passkeyExchangeToken";
+import { finishPasskeyLogin } from "../../../../../lib/services/passkeyService";
+import { resolveWebAuthnExpectedOrigins } from "../../../../../lib/webAuthnRequest";
+
+const bodySchema = z.object({
+  loginSessionId: z.string().min(1),
+  credential: z.record(z.string(), z.unknown()),
+});
+
+/**
+ * POST — verifieert passkey-login en geeft een kortlevend token voor NextAuth credentials.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  try {
+    const json: unknown = await req.json().catch(() => ({}));
+    const parsed = bodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Ongeldige invoer", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const origins = resolveWebAuthnExpectedOrigins(req);
+    const credential = parsed.data
+      .credential as unknown as AuthenticationResponseJSON;
+    const result = await finishPasskeyLogin(
+      credential,
+      parsed.data.loginSessionId,
+      origins,
+    );
+    if ("error" in result) {
+      const map: Record<string, string> = {
+        challenge_missing:
+          "Sessie verlopen. Vraag opnieuw een passkey-aanmelding aan.",
+        credential_unknown: "Geen bekende passkey. Voeg eerder een passkey toe op je profiel.",
+        verification_failed: "Passkey kon niet worden geverifieerd.",
+      };
+      return NextResponse.json(
+        { error: map[result.error] ?? "Inloggen met passkey mislukt." },
+        { status: 400 },
+      );
+    }
+    const exchangeToken = createPasskeyExchangeToken(result.userId);
+    if (!exchangeToken) {
+      return NextResponse.json(
+        { error: "Serverconfiguratie ontbreekt (NEXTAUTH_SECRET)." },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json({ exchangeToken });
+  } catch (error: unknown) {
+    if (isDbUnavailableError(error)) {
+      return jsonDatabaseUnavailable();
+    }
+    Sentry.captureException(error);
+    return NextResponse.json({ error: "Er ging iets mis" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/passkey/register-options/route.ts
+++ b/src/app/api/auth/passkey/register-options/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { getActiveUser } from "../../../../../lib/activeUser";
+import {
+  isDbUnavailableError,
+  jsonDatabaseUnavailable,
+} from "../../../../../lib/dbUnavailableError";
+import { startPasskeyRegistration } from "../../../../../lib/services/passkeyService";
+
+/**
+ * POST — start WebAuthn-passkey registratie; gebruiker moet ingelogd zijn.
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  try {
+    const { userId } = await getActiveUser(req);
+    let payload;
+    try {
+      payload = await startPasskeyRegistration(userId);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.message === "user_not_found") {
+        return NextResponse.json(
+          { error: "Gebruiker niet gevonden" },
+          { status: 404 },
+        );
+      }
+      if (error instanceof Error && error.message === "user_id_too_long") {
+        return NextResponse.json(
+          { error: "Account-id niet compatibel met passkeys." },
+          { status: 400 },
+        );
+      }
+      throw error;
+    }
+    return NextResponse.json(payload);
+  } catch (error: unknown) {
+    if (isDbUnavailableError(error)) {
+      return jsonDatabaseUnavailable();
+    }
+    Sentry.captureException(error);
+    return NextResponse.json({ error: "Er ging iets mis" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/passkey/register-verify/route.ts
+++ b/src/app/api/auth/passkey/register-verify/route.ts
@@ -1,0 +1,56 @@
+import type { RegistrationResponseJSON } from "@simplewebauthn/browser";
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
+import { getActiveUser } from "../../../../../lib/activeUser";
+import {
+  isDbUnavailableError,
+  jsonDatabaseUnavailable,
+} from "../../../../../lib/dbUnavailableError";
+import { finishPasskeyRegistration } from "../../../../../lib/services/passkeyService";
+import { resolveWebAuthnExpectedOrigins } from "../../../../../lib/webAuthnRequest";
+
+const bodySchema = z.object({
+  credential: z.record(z.string(), z.unknown()),
+});
+
+/**
+ * POST — voltooit WebAuthn-passkey registratie (`startRegistration`-response).
+ */
+export async function POST(req: NextRequest): Promise<Response> {
+  try {
+    const { userId } = await getActiveUser(req);
+    const json: unknown = await req.json().catch(() => ({}));
+    const parsed = bodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Ongeldige invoer", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const origins = resolveWebAuthnExpectedOrigins(req);
+    const credential = parsed.data
+      .credential as unknown as RegistrationResponseJSON;
+    const result = await finishPasskeyRegistration(userId, credential, origins);
+    if (!result.ok) {
+      const map: Record<string, string> = {
+        challenge_missing:
+          "Sessie verlopen. Probeer opnieuw een passkey toe te voegen.",
+        verification_failed: "Passkey kon niet worden geverifieerd.",
+        duplicate_or_db:
+          "Deze passkey is al geregistreerd of opslaan is mislukt.",
+      };
+      return NextResponse.json(
+        { error: map[result.error] ?? "Passkey registreren mislukt." },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error: unknown) {
+    if (isDbUnavailableError(error)) {
+      return jsonDatabaseUnavailable();
+    }
+    Sentry.captureException(error);
+    return NextResponse.json({ error: "Er ging iets mis" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/passkeys/route.ts
+++ b/src/app/api/auth/passkeys/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { getActiveUser } from "../../../../lib/activeUser";
+import {
+  isDbUnavailableError,
+  jsonDatabaseUnavailable,
+} from "../../../../lib/dbUnavailableError";
+import {
+  deletePasskeyForUser,
+  listPasskeysForUser,
+} from "../../../../lib/services/passkeyService";
+
+/**
+ * GET — lijst passkeys voor het actieve account (profiel).
+ */
+export async function GET(req: NextRequest): Promise<Response> {
+  try {
+    const { userId } = await getActiveUser(req);
+    const passkeys = await listPasskeysForUser(userId);
+    return NextResponse.json({
+      passkeys: passkeys.map((p) => ({
+        id: p.id,
+        createdAt: p.createdAt.toISOString(),
+        label: p.label,
+      })),
+    });
+  } catch (error: unknown) {
+    if (isDbUnavailableError(error)) {
+      return jsonDatabaseUnavailable();
+    }
+    Sentry.captureException(error);
+    return NextResponse.json({ error: "Er ging iets mis" }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE — verwijdert een passkey (`?id=`).
+ */
+export async function DELETE(req: NextRequest): Promise<Response> {
+  try {
+    const { userId } = await getActiveUser(req);
+    const id = req.nextUrl.searchParams.get("id")?.trim();
+    if (!id) {
+      return NextResponse.json({ error: "Ontbrekende id" }, { status: 400 });
+    }
+    const removed = await deletePasskeyForUser(userId, id);
+    if (!removed) {
+      return NextResponse.json({ error: "Passkey niet gevonden" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error: unknown) {
+    if (isDbUnavailableError(error)) {
+      return jsonDatabaseUnavailable();
+    }
+    Sentry.captureException(error);
+    return NextResponse.json({ error: "Er ging iets mis" }, { status: 500 });
+  }
+}

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
+import type { PublicKeyCredentialRequestOptionsJSON } from "@simplewebauthn/browser";
+import { startAuthentication } from "@simplewebauthn/browser";
+import { browserSupportsWebAuthn } from "@simplewebauthn/browser";
 import { signIn } from "next-auth/react";
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import { Button, Card, Input, Stack } from "../../components/ui";
 
 type LoginFormProps = {
@@ -30,6 +33,14 @@ export default function LoginForm({
   const [notice, setNotice] = useState<Notice>(null);
   const [signingIn, setSigningIn] = useState(false);
   const [registering, setRegistering] = useState(false);
+  const [passkeyLoading, setPasskeyLoading] = useState(false);
+  const [webAuthnUsable, setWebAuthnUsable] = useState(false);
+
+  useEffect(() => {
+    setWebAuthnUsable(
+      typeof window !== "undefined" && browserSupportsWebAuthn(),
+    );
+  }, []);
 
   async function register(): Promise<void> {
     setNotice(null);
@@ -97,6 +108,77 @@ export default function LoginForm({
     }
   }
 
+  async function loginPasskey(): Promise<void> {
+    if (passkeyLoading) return;
+    setNotice(null);
+    setPasskeyLoading(true);
+    try {
+      const optRes = await fetch("/api/auth/passkey/login-options", {
+        method: "POST",
+      });
+      if (!optRes.ok) {
+        setNotice({
+          tone: "error",
+          text: "Passkey-inloggen is nu niet beschikbaar. Probeer opnieuw of kies e-mail of Google.",
+        });
+        return;
+      }
+      const { optionsJSON, loginSessionId } = (await optRes.json()) as {
+        optionsJSON: PublicKeyCredentialRequestOptionsJSON;
+        loginSessionId: string;
+      };
+      const credential = await startAuthentication({ optionsJSON });
+      const verRes = await fetch("/api/auth/passkey/login-verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ loginSessionId, credential }),
+      });
+      const data = (await verRes.json().catch(() => ({}))) as {
+        error?: string;
+        exchangeToken?: string;
+      };
+      if (!verRes.ok) {
+        setNotice({
+          tone: "error",
+          text:
+            typeof data.error === "string"
+              ? data.error
+              : "Inloggen met passkey mislukt.",
+        });
+        return;
+      }
+      const exchangeToken = data.exchangeToken;
+      if (!exchangeToken) {
+        setNotice({
+          tone: "error",
+          text: "Passkey-respons onvolledig. Probeer opnieuw.",
+        });
+        return;
+      }
+      const result = await signIn("credentials", {
+        passkeyExchange: exchangeToken,
+        redirect: false,
+        callbackUrl,
+      });
+      if (result?.error) {
+        setNotice({
+          tone: "error",
+          text: "Inloggen met passkey mislukt. Probeer opnieuw of gebruik e-mail of Google.",
+        });
+        return;
+      }
+      window.location.assign(result?.url || callbackUrl);
+    } catch (error: unknown) {
+      Sentry.captureException(error, { tags: { flow: "login-passkey" } });
+      setNotice({
+        tone: "error",
+        text: "Passkey-inloggen onderbroken of niet ondersteund op dit apparaat.",
+      });
+    } finally {
+      setPasskeyLoading(false);
+    }
+  }
+
   async function loginGoogle(): Promise<void> {
     setNotice(null);
     try {
@@ -128,6 +210,25 @@ export default function LoginForm({
             Inloggen met Google
           </Button>
         </Card>
+
+        {webAuthnUsable ? (
+          <Card style={{ marginTop: 12 }}>
+            <h3 style={{ marginTop: 0 }}>Snel inloggen</h3>
+            <p className="muted" style={{ marginTop: 0 }}>
+              Gebruik Touch ID, Face ID of een vergelijkbare passkey als je die
+              op je profiel hebt toegevoegd.
+            </p>
+            <Button
+              variant="secondary"
+              isFullWidth
+              onClick={() => void loginPasskey()}
+              loading={passkeyLoading}
+              loadingLabel="Passkey…"
+            >
+              Inloggen met passkey
+            </Button>
+          </Card>
+        ) : null}
 
         <Card style={{ marginTop: 12 }}>
           <h3 style={{ marginTop: 0 }}>Met e-mail</h3>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,4 +1,10 @@
 "use client";
+import * as Sentry from "@sentry/nextjs";
+import {
+  browserSupportsWebAuthn,
+  startRegistration,
+  type PublicKeyCredentialCreationOptionsJSON,
+} from "@simplewebauthn/browser";
 import { useEffect, useState } from "react";
 import { getBadgeForAttendance, type AttendanceBadge } from "../../lib/badges";
 import { APP_VERSION } from "../../lib/version";
@@ -10,6 +16,7 @@ type Profile = {
   lastName: string;
   email: string;
 } | null;
+type PasskeyRow = { id: string; createdAt: string; label: string | null };
 type Roles = { admin: boolean; trainer: boolean; player: boolean };
 
 export default function ProfilePage() {
@@ -33,9 +40,12 @@ export default function ProfilePage() {
   } | null>(null);
   const [attendanceBadge, setAttendanceBadge] =
     useState<AttendanceBadge | null>(null);
+  const [passkeys, setPasskeys] = useState<PasskeyRow[]>([]);
+  const [passkeyAdding, setPasskeyAdding] = useState(false);
+  const [passkeySupported, setPasskeySupported] = useState(false);
 
   async function load() {
-    const [p, s, a, t, season] = await Promise.all([
+    const [p, s, a, t, season, pkRes] = await Promise.all([
       fetch("/api/profile", { cache: "no-store" }).then((r) => r.json()),
       fetch("/api/identity/status", { cache: "no-store" }).then((r) =>
         r.json(),
@@ -49,6 +59,9 @@ export default function ProfilePage() {
       fetch("/api/training/overview", { cache: "no-store" })
         .then((r) => r.json())
         .catch(() => ({ list: [], total: 0 })),
+      fetch("/api/auth/passkeys", { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : { passkeys: [] }))
+        .catch(() => ({ passkeys: [] })),
     ]);
     setProfile(p.user);
     if (p.user) {
@@ -83,7 +96,18 @@ export default function ProfilePage() {
       setAttendanceStats(null);
       setAttendanceBadge(null);
     }
+
+    const pkParsed = pkRes as { passkeys?: PasskeyRow[] };
+    setPasskeys(
+      Array.isArray(pkParsed.passkeys) ? pkParsed.passkeys : [],
+    );
   }
+
+  useEffect(() => {
+    setPasskeySupported(
+      typeof window !== "undefined" && browserSupportsWebAuthn(),
+    );
+  }, []);
 
   useEffect(() => {
     load();
@@ -124,6 +148,77 @@ export default function ProfilePage() {
       showToast(e?.message || "Kon niet importeren", "error");
     } finally {
       setAdopting(false);
+    }
+  }
+
+  async function addPasskey(): Promise<void> {
+    if (!browserSupportsWebAuthn()) {
+      showToast(
+        "Passkeys worden niet ondersteund in deze browser.",
+        "error",
+      );
+      return;
+    }
+    setPasskeyAdding(true);
+    try {
+      const optRes = await fetch("/api/auth/passkey/register-options", {
+        method: "POST",
+      });
+      if (!optRes.ok) {
+        showToast(
+          "Passkey starten mislukt. Probeer het later opnieuw.",
+          "error",
+        );
+        return;
+      }
+      const { optionsJSON } = (await optRes.json()) as {
+        optionsJSON: PublicKeyCredentialCreationOptionsJSON;
+      };
+      const credential = await startRegistration({ optionsJSON });
+      const verRes = await fetch("/api/auth/passkey/register-verify", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ credential }),
+      });
+      const errBody = (await verRes.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      if (!verRes.ok) {
+        showToast(
+          typeof errBody.error === "string"
+            ? errBody.error
+            : "Passkey toevoegen mislukt.",
+          "error",
+        );
+        return;
+      }
+      showToast("Passkey toegevoegd", "success");
+      await load();
+    } catch (error: unknown) {
+      Sentry.captureException(error, { tags: { flow: "profile-passkey-add" } });
+      showToast("Passkey toevoegen onderbroken.", "error");
+    } finally {
+      setPasskeyAdding(false);
+    }
+  }
+
+  async function removePasskey(id: string): Promise<void> {
+    try {
+      const res = await fetch(
+        `/api/auth/passkeys?id=${encodeURIComponent(id)}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        showToast("Passkey verwijderen mislukt.", "error");
+        return;
+      }
+      showToast("Passkey verwijderd", "success");
+      await load();
+    } catch (error: unknown) {
+      Sentry.captureException(error, {
+        tags: { flow: "profile-passkey-remove" },
+      });
+      showToast("Kon passkey niet verwijderen.", "error");
     }
   }
 
@@ -232,19 +327,65 @@ export default function ProfilePage() {
           </Stack>
         </Card>
 
+        {passkeySupported ? (
+          <Card style={{ maxWidth: 520, marginTop: 12 }}>
+            <Stack gap="3">
+              <div>
+                <h3 style={{ marginTop: 0 }}>Snel inloggen</h3>
+                <p className="muted" style={{ marginTop: 6 }}>
+                  Voeg een passkey toe voor dit apparaat (Touch ID, Face ID,
+                  Windows Hello of vergelijkbaar). Je blijft ook gewoon met
+                  Google of e-mail kunnen inloggen.
+                </p>
+              </div>
+              <Button
+                variant="secondary"
+                onClick={() => void addPasskey()}
+                loading={passkeyAdding}
+                loadingLabel="Bezig…"
+              >
+                Passkey op dit apparaat toevoegen
+              </Button>
+              {passkeys.length > 0 ? (
+                <Stack gap="2">
+                  <span className="muted">Geregistreerde passkeys</span>
+                  <ul style={{ margin: 0, paddingLeft: 18 }}>
+                    {passkeys.map((pk) => (
+                      <li key={pk.id} style={{ marginBottom: 8 }}>
+                        <Stack
+                          direction="row"
+                          justify="between"
+                          align="center"
+                          gap="2"
+                        >
+                          <span>
+                            {pk.label ??
+                              `Passkey · ${new Date(pk.createdAt).toLocaleDateString("nl-NL")}`}
+                          </span>
+                          <Button
+                            variant="ghost"
+                            onClick={() => void removePasskey(pk.id)}
+                          >
+                            Verwijderen
+                          </Button>
+                        </Stack>
+                      </li>
+                    ))}
+                  </ul>
+                </Stack>
+              ) : (
+                <span className="muted">Nog geen passkeys.</span>
+              )}
+            </Stack>
+          </Card>
+        ) : null}
+
         <div
           data-tour="profile-version"
           className="muted"
           style={{ marginTop: 16, fontSize: 12, textAlign: "center" }}
         >
           App-versie {APP_VERSION}
-        </div>
-        <div
-          data-tour="profile-version"
-          className="muted"
-          style={{ marginTop: 16, fontSize: 12, textAlign: "center" }}
-        >
-          App version {APP_VERSION}
         </div>
       </div>
     </main>

--- a/src/lib/authOptions.authorize.test.ts
+++ b/src/lib/authOptions.authorize.test.ts
@@ -1,14 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Prisma } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";
 import { prisma } from "./db";
 import { authOptions } from "./authOptions";
+import { createPasskeyExchangeToken } from "./passkeyExchangeToken";
 import { USER_CORE_SELECT, type UserCoreRow } from "./userPrismaSelect";
 
 vi.mock("./db", () => ({
   prisma: {
     user: {
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
     },
   },
 }));
@@ -101,6 +103,74 @@ describe("Credentials authorize", () => {
     expect(Sentry.captureException).toHaveBeenCalledWith(err, {
       tags: { context: "credentials_authorize" },
       extra: { prismaCode: "P2022" },
+    });
+  });
+
+  describe("passkeyExchange credentials", () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("returns user when passkey exchange token is valid", async () => {
+      vi.stubEnv("NEXTAUTH_SECRET", "unit-test-secret-passkey");
+      const token = createPasskeyExchangeToken("u-pass");
+      const row: UserCoreRow = {
+        id: "u-pass",
+        email: "p@b.nl",
+        passwordHash: null,
+        firstName: "P",
+        lastName: "Q",
+      };
+      vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(row);
+
+      const result = await authorize?.({
+        passkeyExchange: token,
+        email: "",
+        password: "",
+      });
+
+      expect(result).toEqual({
+        id: "u-pass",
+        name: "P Q",
+        email: "p@b.nl",
+      });
+      expect(prisma.user.findUnique).toHaveBeenCalledWith({
+        where: { id: "u-pass" },
+        select: USER_CORE_SELECT,
+      });
+    });
+
+    it("returns null when passkey exchange token is invalid", async () => {
+      vi.stubEnv("NEXTAUTH_SECRET", "unit-test-secret-passkey");
+      const result = await authorize?.({
+        passkeyExchange: "not-a-valid-token",
+        email: "",
+        password: "",
+      });
+      expect(result).toBeNull();
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("returns null on Prisma error during passkey login and reports to Sentry", async () => {
+      vi.stubEnv("NEXTAUTH_SECRET", "unit-test-secret-passkey");
+      const token = createPasskeyExchangeToken("u-pass");
+      const err = new Prisma.PrismaClientKnownRequestError("boom", {
+        code: "P2002",
+        clientVersion: "7",
+      });
+      vi.mocked(prisma.user.findUnique).mockRejectedValueOnce(err);
+
+      const result = await authorize?.({
+        passkeyExchange: token,
+        email: "",
+        password: "",
+      });
+
+      expect(result).toBeNull();
+      expect(Sentry.captureException).toHaveBeenCalledWith(err, {
+        tags: { context: "credentials_authorize_passkey" },
+        extra: { prismaCode: "P2002" },
+      });
     });
   });
 });

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -3,8 +3,9 @@ import GoogleProvider from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";
 import * as Sentry from "@sentry/nextjs";
 import { Prisma } from "@prisma/client";
-import { prisma } from "./db";
 import bcrypt from "bcryptjs";
+import { prisma } from "./db";
+import { verifyPasskeyExchangeToken } from "./passkeyExchangeToken";
 import { USER_CORE_SELECT } from "./userPrismaSelect";
 
 /**
@@ -21,8 +22,39 @@ export const authOptions: NextAuthOptions = {
       credentials: {
         email: { label: "Email", type: "text" },
         password: { label: "Password", type: "password" },
+        passkeyExchange: { label: "Passkey", type: "text" },
       },
       async authorize(creds) {
+        const exchangeRaw = creds?.passkeyExchange;
+        const exchange =
+          typeof exchangeRaw === "string" ? exchangeRaw.trim() : "";
+        if (exchange) {
+          const userId = verifyPasskeyExchangeToken(exchange);
+          if (!userId) return null;
+          try {
+            const user = await prisma.user.findUnique({
+              where: { id: userId },
+              select: USER_CORE_SELECT,
+            });
+            if (!user) return null;
+            return {
+              id: user.id,
+              name: `${user.firstName} ${user.lastName}`.trim(),
+              email: user.email ?? undefined,
+            };
+          } catch (error: unknown) {
+            const code =
+              error instanceof Prisma.PrismaClientKnownRequestError
+                ? error.code
+                : undefined;
+            Sentry.captureException(error, {
+              tags: { context: "credentials_authorize_passkey" },
+              extra: { prismaCode: code },
+            });
+            return null;
+          }
+        }
+
         const email = (creds?.email as string) || "";
         const password = (creds?.password as string) || "";
         if (!email || !password) return null;

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -253,6 +253,70 @@ export async function kvDelete(key: string): Promise<void> {
   memoryTtl.delete(key);
 }
 
+const WEBAUTHN_CHALLENGE_TTL_SEC = 5 * 60;
+
+/**
+ * Bewaar een tijdelijke WebAuthn-challenge (registratie of login), Redis-first met TTL.
+ * Bij ontbrekende Redis: geheugenfallback met expiry (zoals wachtwoord-reset tokens).
+ *
+ * @param kind - Registratie onder ingelogde gebruiker of anonieme authenticatie-flow.
+ * @param sessionKey - Unieke sleutel (`userId` bij registratie, willekeurige sessie-id bij login).
+ * @param challenge - Base64url challenge-string uit SimpleWebAuthn.
+ */
+export async function webAuthnStoreChallenge(
+  kind: "registration" | "authentication",
+  sessionKey: string,
+  challenge: string,
+): Promise<void> {
+  const key = `webauthn:${kind}:${sessionKey}`;
+  const redis = await getRedis();
+  if (redis) {
+    await redis.set(key, challenge, "EX", WEBAUTHN_CHALLENGE_TTL_SEC);
+    return;
+  }
+  memoryJson.set(key, JSON.stringify({ challenge }));
+  memoryTtl.set(key, Date.now() + WEBAUTHN_CHALLENGE_TTL_SEC * 1000);
+}
+
+/**
+ * Haalt een challenge op en verwijdert deze (eenmalig gebruik).
+ *
+ * @param kind - Zelfde scope als bij {@link webAuthnStoreChallenge}.
+ * @param sessionKey - Zelfde sleutel als bij opslag.
+ * @returns De challenge-string of `null` bij ontbreken of expiry.
+ */
+export async function webAuthnConsumeChallenge(
+  kind: "registration" | "authentication",
+  sessionKey: string,
+): Promise<string | null> {
+  const key = `webauthn:${kind}:${sessionKey}`;
+  const redis = await getRedis();
+  if (redis) {
+    const pipeline = redis.pipeline();
+    pipeline.get(key);
+    pipeline.del(key);
+    const results = await pipeline.exec();
+    const raw = results?.[0]?.[1];
+    return typeof raw === "string" ? raw : null;
+  }
+  const exp = memoryTtl.get(key);
+  if (typeof exp === "number" && Date.now() > exp) {
+    memoryJson.delete(key);
+    memoryTtl.delete(key);
+    return null;
+  }
+  const val = memoryJson.get(key);
+  memoryJson.delete(key);
+  memoryTtl.delete(key);
+  if (!val) return null;
+  try {
+    const parsed = JSON.parse(val) as { challenge?: string };
+    return typeof parsed.challenge === "string" ? parsed.challenge : null;
+  } catch {
+    return null;
+  }
+}
+
 function makeToken(): string {
   // short code for dev; can switch to uuid if preferred
   return Math.random().toString(36).slice(2, 10).toUpperCase();

--- a/src/lib/passkeyExchangeToken.test.ts
+++ b/src/lib/passkeyExchangeToken.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPasskeyExchangeToken,
+  verifyPasskeyExchangeToken,
+} from "./passkeyExchangeToken";
+
+describe("passkeyExchangeToken", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXTAUTH_SECRET", "test-secret-key-for-hmac-only");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("round-trips a valid user id", () => {
+    const token = createPasskeyExchangeToken("user-abc");
+    expect(verifyPasskeyExchangeToken(token)).toBe("user-abc");
+  });
+
+  it("returns null when secret is missing", () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("NEXTAUTH_SECRET", "");
+    expect(createPasskeyExchangeToken("u")).toBe("");
+    expect(verifyPasskeyExchangeToken("x.y")).toBeNull();
+  });
+
+  it("returns null on tampered payload", () => {
+    const token = createPasskeyExchangeToken("user-abc");
+    const tampered = token.replace(/^./, "Z");
+    expect(verifyPasskeyExchangeToken(tampered)).toBeNull();
+  });
+
+  it("returns null on malformed token", () => {
+    expect(verifyPasskeyExchangeToken("no-dot")).toBeNull();
+    expect(verifyPasskeyExchangeToken("")).toBeNull();
+  });
+});

--- a/src/lib/passkeyExchangeToken.ts
+++ b/src/lib/passkeyExchangeToken.ts
@@ -1,0 +1,57 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const TTL_MS = 90_000;
+
+/**
+ * Maakt een kortlevend HMAC-token om na geslaagde WebAuthn-login een NextAuth credentials-sessie te starten.
+ *
+ * @param userId - Interne gebruikers-id (Prisma `User.id`).
+ * @returns Getekende base64url-string; leeg secret → lege string (alleen test/misconfig).
+ */
+export function createPasskeyExchangeToken(userId: string): string {
+  const secret = process.env.NEXTAUTH_SECRET ?? "";
+  if (!secret) return "";
+  const exp = Date.now() + TTL_MS;
+  const payload = Buffer.from(
+    JSON.stringify({ uid: userId, exp }),
+    "utf8",
+  ).toString("base64url");
+  const sig = createHmac("sha256", secret).update(payload).digest();
+  return `${payload}.${sig.toString("base64url")}`;
+}
+
+/**
+ * Valideert {@link createPasskeyExchangeToken} en retourneert het user-id bij geldige handtekening en expiry.
+ *
+ * @param token - Ruwe token van de login-verify-route.
+ * @returns `userId` of `null` bij ongeldige/expired token.
+ */
+export function verifyPasskeyExchangeToken(token: string): string | null {
+  const secret = process.env.NEXTAUTH_SECRET ?? "";
+  if (!secret || !token) return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+  const payload = token.slice(0, dot);
+  const sigB64 = token.slice(dot + 1);
+  let sigBuf: Buffer;
+  try {
+    sigBuf = Buffer.from(sigB64, "base64url");
+  } catch {
+    return null;
+  }
+  const expectedSig = createHmac("sha256", secret).update(payload).digest();
+  if (sigBuf.length !== expectedSig.length) return null;
+  if (!timingSafeEqual(sigBuf, expectedSig)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const uid = (parsed as { uid?: unknown }).uid;
+  const exp = (parsed as { exp?: unknown }).exp;
+  if (typeof uid !== "string" || typeof exp !== "number") return null;
+  if (Date.now() > exp) return null;
+  return uid;
+}

--- a/src/lib/services/passkeyService.ts
+++ b/src/lib/services/passkeyService.ts
@@ -1,0 +1,270 @@
+import type {
+  AuthenticatorTransportFuture,
+  AuthenticationResponseJSON,
+  RegistrationResponseJSON,
+} from "@simplewebauthn/browser";
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from "@simplewebauthn/server";
+import { isoUint8Array } from "@simplewebauthn/server/helpers";
+import { randomBytes } from "crypto";
+import { prisma } from "../db";
+import { webAuthnConsumeChallenge, webAuthnStoreChallenge } from "../kv";
+import { getWebAuthnRpConfig } from "../webAuthnEnv";
+
+/**
+ * Start WebAuthn-registratie voor een ingelogde gebruiker; slaat de challenge op onder `userId`.
+ *
+ * @param userId - Actieve gebruiker (sessie).
+ * @throws Error `user_not_found` als de gebruiker niet bestaat.
+ */
+export async function startPasskeyRegistration(userId: string): Promise<{
+  optionsJSON: Awaited<ReturnType<typeof generateRegistrationOptions>>;
+}> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, firstName: true, lastName: true },
+  });
+  if (!user) {
+    throw new Error("user_not_found");
+  }
+
+  const existing = await prisma.passkey.findMany({
+    where: { userId },
+    select: { credentialId: true, transports: true },
+  });
+
+  const { rpID, rpName } = getWebAuthnRpConfig();
+  const userName = user.email ?? user.id;
+  const userDisplayName =
+    `${user.firstName} ${user.lastName}`.trim() || userName;
+
+  const excludeCredentials = existing.map((row) => {
+    let transports: AuthenticatorTransportFuture[] | undefined;
+    if (row.transports) {
+      try {
+        transports = JSON.parse(row.transports) as AuthenticatorTransportFuture[];
+      } catch {
+        transports = undefined;
+      }
+    }
+    return {
+      id: row.credentialId,
+      ...(transports ? { transports } : {}),
+    };
+  });
+
+  const userID = isoUint8Array.fromUTF8String(user.id);
+  if (userID.byteLength > 64) {
+    throw new Error("user_id_too_long");
+  }
+
+  const options = await generateRegistrationOptions({
+    rpName,
+    rpID,
+    userName,
+    userDisplayName,
+    userID,
+    excludeCredentials,
+    authenticatorSelection: {
+      residentKey: "preferred",
+      userVerification: "preferred",
+    },
+  });
+
+  await webAuthnStoreChallenge("registration", userId, options.challenge);
+
+  return { optionsJSON: options };
+}
+
+/**
+ * Voltooit registratie en slaat de publieke sleutel op.
+ *
+ * @param userId - Dezelfde gebruiker als bij {@link startPasskeyRegistration}.
+ * @param response - Ruwe browser-response (`startRegistration`).
+ * @param expectedOrigins - Toegestane origins voor clientDataJSON (zie {@link ../webAuthnEnv.getWebAuthnAllowedOrigins}).
+ */
+export async function finishPasskeyRegistration(
+  userId: string,
+  response: RegistrationResponseJSON,
+  expectedOrigins: string[],
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const expectedChallenge = await webAuthnConsumeChallenge(
+    "registration",
+    userId,
+  );
+  if (!expectedChallenge) {
+    return { ok: false, error: "challenge_missing" };
+  }
+
+  const { rpID } = getWebAuthnRpConfig();
+
+  let verification;
+  try {
+    verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: expectedOrigins,
+      expectedRPID: rpID,
+      requireUserVerification: false,
+    });
+  } catch {
+    return { ok: false, error: "verification_failed" };
+  }
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return { ok: false, error: "verification_failed" };
+  }
+
+  const { credential } = verification.registrationInfo;
+  const transportsJson =
+    credential.transports && credential.transports.length > 0
+      ? JSON.stringify(credential.transports)
+      : null;
+
+  try {
+    await prisma.passkey.create({
+      data: {
+        userId,
+        credentialId: credential.id,
+        publicKey: Buffer.from(credential.publicKey),
+        counter: credential.counter,
+        transports: transportsJson,
+      },
+    });
+  } catch {
+    return { ok: false, error: "duplicate_or_db" };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Start passkey-login (discoverable credentials); retourneert een aparte `loginSessionId` voor challenge-lookup.
+ */
+export async function startPasskeyLogin(): Promise<{
+  optionsJSON: Awaited<ReturnType<typeof generateAuthenticationOptions>>;
+  loginSessionId: string;
+}> {
+  const { rpID } = getWebAuthnRpConfig();
+  const loginSessionId = randomBytes(24).toString("base64url");
+  const options = await generateAuthenticationOptions({
+    rpID,
+    userVerification: "preferred",
+    timeout: 60000,
+  });
+
+  await webAuthnStoreChallenge(
+    "authentication",
+    loginSessionId,
+    options.challenge,
+  );
+
+  return { optionsJSON: options, loginSessionId };
+}
+
+/**
+ * Verifieert een login-response en werkt de teller bij.
+ *
+ * @param response - Ruwe browser-response (`startAuthentication`).
+ * @param loginSessionId - Id uit {@link startPasskeyLogin}.
+ * @param expectedOrigins - Zie {@link finishPasskeyRegistration}.
+ */
+export async function finishPasskeyLogin(
+  response: AuthenticationResponseJSON,
+  loginSessionId: string,
+  expectedOrigins: string[],
+): Promise<{ userId: string } | { error: string }> {
+  const expectedChallenge = await webAuthnConsumeChallenge(
+    "authentication",
+    loginSessionId,
+  );
+  if (!expectedChallenge) {
+    return { error: "challenge_missing" };
+  }
+
+  const credentialId = response.id;
+  const passkey = await prisma.passkey.findUnique({
+    where: { credentialId },
+    select: {
+      userId: true,
+      credentialId: true,
+      publicKey: true,
+      counter: true,
+    },
+  });
+  if (!passkey) {
+    return { error: "credential_unknown" };
+  }
+
+  const { rpID } = getWebAuthnRpConfig();
+
+  let verification;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: expectedOrigins,
+      expectedRPID: rpID,
+      credential: {
+        id: passkey.credentialId,
+        publicKey: Buffer.from(passkey.publicKey),
+        counter: passkey.counter,
+      },
+      requireUserVerification: false,
+    });
+  } catch {
+    return { error: "verification_failed" };
+  }
+
+  if (!verification.verified) {
+    return { error: "verification_failed" };
+  }
+
+  const newCounter = verification.authenticationInfo.newCounter;
+  await prisma.passkey.update({
+    where: { credentialId: passkey.credentialId },
+    data: { counter: newCounter },
+  });
+
+  return { userId: passkey.userId };
+}
+
+export type PasskeyListItem = {
+  id: string;
+  createdAt: Date;
+  label: string | null;
+};
+
+/**
+ * Lijst passkeys voor profielbeheer (geen gevoelige velden).
+ *
+ * @param userId - Gebruiker waarvan passkeys worden opgevraagd.
+ */
+export async function listPasskeysForUser(
+  userId: string,
+): Promise<PasskeyListItem[]> {
+  return prisma.passkey.findMany({
+    where: { userId },
+    select: { id: true, createdAt: true, label: true },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+/**
+ * Verwijdert een passkey als die aan `userId` toebehoort.
+ *
+ * @returns `true` als er een rij is verwijderd.
+ */
+export async function deletePasskeyForUser(
+  userId: string,
+  passkeyId: string,
+): Promise<boolean> {
+  const res = await prisma.passkey.deleteMany({
+    where: { id: passkeyId, userId },
+  });
+  return res.count > 0;
+}

--- a/src/lib/webAuthnEnv.ts
+++ b/src/lib/webAuthnEnv.ts
@@ -1,0 +1,67 @@
+import { resolveNextAuthUrl } from "./nextAuthUrl";
+
+export type WebAuthnRpConfig = {
+  rpID: string;
+  rpName: string;
+};
+
+/**
+ * Leest RP-ID en weergavenaam voor WebAuthn.
+ * `WEBAUTHN_RP_ID` overrult; anders hostname van `NEXTAUTH_URL` / `VERCEL_URL`, anders `localhost`.
+ *
+ * @returns Configuratie voor SimpleWebAuthn `rpID` / `rpName`.
+ */
+export function getWebAuthnRpConfig(): WebAuthnRpConfig {
+  const rpName = process.env.WEBAUTHN_RP_NAME ?? "H3 Teamy";
+  const explicit = process.env.WEBAUTHN_RP_ID?.trim();
+  if (explicit) {
+    return { rpID: explicit, rpName };
+  }
+  const resolved = resolveNextAuthUrl();
+  if (resolved) {
+    try {
+      const host = new URL(resolved).hostname;
+      if (host) return { rpID: host, rpName };
+    } catch {
+      /* fall through */
+    }
+  }
+  const vercel = process.env.VERCEL_URL?.trim();
+  if (vercel) {
+    try {
+      const host = new URL(
+        vercel.startsWith("http") ? vercel : `https://${vercel}`,
+      ).hostname;
+      if (host) return { rpID: host, rpName };
+    } catch {
+      /* fall through */
+    }
+  }
+  return { rpID: "localhost", rpName };
+}
+
+/**
+ * Toegestane `Origin`-waarden voor WebAuthn-verificatie (clientDataJSON.origin).
+ * Combineert `NEXTAUTH_URL`, optioneel `WEBAUTHN_ALLOWED_ORIGINS` (komma-gescheiden volledige origins).
+ *
+ * @returns Lijst unieke origin-strings inclusief protocol en poort.
+ */
+export function getWebAuthnAllowedOrigins(): string[] {
+  const out = new Set<string>();
+  const resolved = resolveNextAuthUrl();
+  if (resolved) {
+    try {
+      out.add(new URL(resolved).origin);
+    } catch {
+      /* skip */
+    }
+  }
+  const extra = process.env.WEBAUTHN_ALLOWED_ORIGINS;
+  if (extra) {
+    for (const part of extra.split(",")) {
+      const o = part.trim();
+      if (o) out.add(o);
+    }
+  }
+  return [...out];
+}

--- a/src/lib/webAuthnRequest.test.ts
+++ b/src/lib/webAuthnRequest.test.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveWebAuthnExpectedOrigins } from "./webAuthnRequest";
+
+describe("resolveWebAuthnExpectedOrigins", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("includes NEXTAUTH_URL origin when configured", () => {
+    vi.stubEnv("NEXTAUTH_URL", "https://team.example.org");
+    const req = new NextRequest("https://team.example.org/api/x", {
+      headers: { origin: "https://team.example.org" },
+    });
+    expect(resolveWebAuthnExpectedOrigins(req)).toContain(
+      "https://team.example.org",
+    );
+  });
+
+  it("falls back to Origin header when NEXTAUTH_URL unset", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("VERCEL_URL", "");
+    const req = new NextRequest("http://localhost:3000/api/x", {
+      headers: { origin: "http://localhost:3000" },
+    });
+    expect(resolveWebAuthnExpectedOrigins(req)).toEqual([
+      "http://localhost:3000",
+    ]);
+  });
+});

--- a/src/lib/webAuthnRequest.ts
+++ b/src/lib/webAuthnRequest.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from "next/server";
+import { getWebAuthnAllowedOrigins } from "./webAuthnEnv";
+
+/**
+ * Bepaalt welke `expectedOrigin`-waarden SimpleWebAuthn mag accepteren voor dit verzoek.
+ * Prefereert geconfigureerde origins; valt terug op de `Origin`-header als er niets geconfigureerd is (lokaal).
+ *
+ * @param req - Inkomend API-verzoek met optionele `Origin`-header.
+ */
+export function resolveWebAuthnExpectedOrigins(req: NextRequest): string[] {
+  const allowed = getWebAuthnAllowedOrigins();
+  const origin = req.headers.get("origin");
+  if (origin && allowed.includes(origin)) {
+    return allowed;
+  }
+  if (allowed.length > 0) {
+    return allowed;
+  }
+  return origin ? [origin] : [];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

- Gebruikers kunnen op **Mijn profiel** een passkey registreren (Touch ID, Face ID, Windows Hello of vergelijkbaar) als **gemak**, naast Google en e-mail/wachtwoord.
- Op **Inloggen** is er een extra kaart **Inloggen met passkey** wanneer de browser WebAuthn ondersteunt.
- Technisch: `@simplewebauthn/server` + `@simplewebauthn/browser`, nieuw Prisma-model `Passkey`, tijdelijke challenges in Redis (anders geheugenfallback), en een kortlevend HMAC-token om na succesvolle WebAuthn-verificatie een normale NextAuth-credentials-sessie te starten.

## Migratie

Na merge: `prisma migrate deploy` op preview/productie. Optionele env: `WEBAUTHN_RP_ID`, `WEBAUTHN_RP_NAME`, `WEBAUTHN_ALLOWED_ORIGINS` (komma-gescheiden origins); default RP-ID komt uit `NEXTAUTH_URL`.

## Getest

- `npx vitest run` (alle tests groen)
- `npm run lint`
- `npm run build` (met placeholder `DATABASE_URL` / `NEXTAUTH_SECRET`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9e5f56e-7cec-4e5c-8fd5-c0381d89ab2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9e5f56e-7cec-4e5c-8fd5-c0381d89ab2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added passkey authentication support for login - users can now sign in faster using their device's biometric or security key via the new "Snel inloggen" option
  * Added passkey management in the profile page, allowing users to register, list, and remove passkeys for streamlined authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->