### PR TITLE
chore: Cursor Agent dependency setup script

### DIFF
--- a/scripts/cursor-agent-setup.sh
+++ b/scripts/cursor-agent-setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Non-interactive shells (zoals Cursor Agents) laden vaak geen nvm/fnm; dan ontbreekt npm op PATH.
+if [[ -z "${NVM_DIR:-}" && -d "${HOME}/.nvm" ]]; then
+  export NVM_DIR="${HOME}/.nvm"
+fi
+if [[ -n "${NVM_DIR:-}" && -s "${NVM_DIR}/nvm.sh" ]]; then
+  # shellcheck source=/dev/null
+  . "${NVM_DIR}/nvm.sh"
+fi
+if command -v fnm >/dev/null 2>&1; then
+  eval "$(fnm env)"
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "cursor-agent-setup: npm niet gevonden. Installeer Node.js 22 (engines in package.json) of zet npm op PATH." >&2
+  exit 1
+fi
+
+npm ci --legacy-peer-deps --ignore-scripts \
+  || npm install --legacy-peer-deps --ignore-scripts
+
+npm run prisma:generate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Voegt `scripts/cursor-agent-setup.sh` toe als robuuste vervanging voor een losse update-script met alleen `npm`/`npx`-regels.

**Probleem met het oude fragment**
- `npx prisma generate` draaide ook als zowel `npm ci` als `npm install` faalden.
- Geen `nvm`/`fnm` in niet-interactieve shells → `npm: command not found`.

**Script-gedrag**
- Laadt nvm/fnm indien aanwezig.
- Stopt met duidelijke fout (NL) als `npm` ontbreekt.
- `npm ci … || npm install …` met `set -e` zodat bij dubbele fout het script stopt voordat Prisma draait.
- `npm run prisma:generate` i.p.v. `npx prisma generate` (zelfde als `package.json`).

**Cursor-instelling:** update script kan worden gezet op `bash scripts/cursor-agent-setup.sh`, of als één regel:

`(npm ci --legacy-peer-deps --ignore-scripts || npm install --legacy-peer-deps --ignore-scripts) && npm run prisma:generate`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a56a470b-f9fd-4747-8fdd-29af8af88c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a56a470b-f9fd-4747-8fdd-29af8af88c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

