### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,31 @@
 - Cache (ioredis) failures must never propagate to the caller — wrap in try/catch, log with Sentry, continue.
 - Pre-commit hooks run Prettier, ESLint, `tsc --noEmit`, and `vitest run`.
 - The `.cursor/rules/` directory contains agent-agnostic coding rules adapted from ECC (everything-claude-code) covering: security, API design, frontend/backend patterns, database migrations, verification loops, search-first workflow, code review, and de-slop cleanup.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+- **Next.js dev server**: `npm run dev` (port 3000). Uses Turbopack.
+- **PostgreSQL**: required. In Cloud Agent VMs, start via Docker: `docker run --name pg -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=h3teamy -p 5432:5432 -d postgres:16`. The Docker daemon must be running first (`dockerd &`). After starting Postgres, run `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/h3teamy npx prisma migrate deploy` to apply migrations.
+- **Redis**: optional. The app falls back to an in-memory `Map` when `REDIS_URL` is unset. No Redis needed for basic dev.
+
+### Environment
+
+- Create `.env.local` with at minimum: `DATABASE_URL`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL=http://localhost:3000`.
+- `prisma.config.ts` reads `DATABASE_URL` via `dotenv/config` (loads `.env`, not `.env.local`), so pass `DATABASE_URL=...` as an env var prefix when running Prisma CLI commands directly.
+- Seeded test account: `trainer@example.test` / `preview123` (admin/trainer role).
+
+### Commands (see `package.json` scripts)
+
+- Lint: `npm run lint`
+- Typecheck: `npx tsc --noEmit`
+- Test: `npx vitest run` (314 tests, ~14s)
+- Build: `npm run build`
+- Seed DB: `DATABASE_URL=... npm run db:seed`
+
+### Gotchas
+
+- The `postinstall` script runs `prisma generate`, which needs a valid `prisma.config.ts`. If no database is reachable, generation still succeeds (it only needs the schema, not a live DB).
+- Pre-commit hooks (`husky`) run Prettier, ESLint, `tsc --noEmit`, and `vitest run`. For Cloud Agent commits, use `--no-verify` only when explicitly instructed; otherwise let hooks run.
+- Docker in the Cloud Agent VM requires `fuse-overlayfs`, `iptables-legacy`, and the `"storage-driver": "fuse-overlayfs"` daemon config. The update script handles Node.js and npm deps only; Docker + Postgres must be started manually per session.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable setup/run guidance for future Cloud Agent sessions. Covers:

- PostgreSQL (Docker) and Next.js dev server startup
- Required `.env.local` variables and Prisma CLI env var gotcha (`dotenv/config` loads `.env`, not `.env.local`)
- Seeded test account credentials
- Standard commands (lint, typecheck, test, build, seed)
- Docker-in-VM configuration notes (fuse-overlayfs, iptables-legacy)

## Docs

- [x] Updated relevant feature docs under `docs/tech/...` — N/A (AGENTS.md only)
- [x] `npm run docs:generate` succeeds locally — N/A (no doc changes)
- Links:
  - Feature doc(s): N/A
  - Functional spec section(s): N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d16c2fb-e8d4-4938-afe8-01b91b739024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d16c2fb-e8d4-4938-afe8-01b91b739024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

