### PR TITLE
Passkeys: request-aware RP-ID, changelog 0.2.1, tour target

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,13 @@
 
 Describe the change.
 
+## User-facing release (“Wat is nieuw”)
+
+De tour opent alleen als `package.json`-versie een bijpassende sleutel in `src/lib/changelog.ts` heeft én de gebruiker die versie nog niet heeft bevestigd.
+
+- [ ] Nee — geen release richting eindgebruikers (alleen intern/technisch)
+- [ ] Ja — **`package.json`-versie verhoogd** en **zelfde versie als sleutel** toegevoegd in `src/lib/changelog.ts` (stappen + geldige `data-tour`-targets waar nodig)
+
 ## Docs
 
 - [ ] Updated relevant feature docs under `docs/tech/...`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Run a de-slop pass after AI-assisted implementation to remove narration comments, defensive checks the type system already covers, and tests that test the language rather than business logic.
 - Research existing solutions in `src/lib/` and npm before writing new utilities or helpers.
 - Run the verification loop (build, typecheck, lint, test, security scan, diff review) before creating or updating PRs.
+- User-facing release / tour “Wat is nieuw”: verhoog `package.json`-versie en voeg dezelfde versiesleutel toe in `src/lib/changelog.ts` (`CHANGELOG`); zonder beide toont `/api/whats-new` geen nieuwe ronde (en gebruikers die de oude versie al bevestigden zien niets zolang de versie ongewijzigd blijft).
 - **Geen BugBot Pro**: gebruik de gratis stack — CodeRabbit op PRs, Agentic CI, GitHub Copilot-review (workflow), en `.cursor/rules` / `AGENTS.md` in Cursor. BugBot betaalde tier niet nodig.
 - **Sentry**: organisatie-slug is `h3-teamy`; **project-slug** in Sentry is `javascript-nextjs` (Project → Settings → General). Dat moet overeenkomen met `org` / `project` in `next.config.js` en `SENTRY_ORG` / `SENTRY_PROJECT` in `.github/workflows/sentry-issue-sync.yml`. Optioneel `SENTRY_PROJECT` in Vercel zetten om te overrulen. Token `SENTRY_AUTH_TOKEN` lokaal in `.env` / `.env.local` houden; naar **Vercel** en **GitHub repo secret** zetten (niet committen).
 - **Vercel Rolling Releases**: niet gebruiken zonder Pro-plan; gewone production deploys blijven voldoende.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h3-teamy",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "engines": {
     "node": "22"

--- a/src/app/api/auth/passkey/login-options/route.ts
+++ b/src/app/api/auth/passkey/login-options/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { startPasskeyLogin } from "../../../../../lib/services/passkeyService";
 import {
@@ -9,9 +9,9 @@ import {
 /**
  * POST — start passkey-login (biometrie / apparaatslot).
  */
-export async function POST(): Promise<Response> {
+export async function POST(req: NextRequest): Promise<Response> {
   try {
-    const payload = await startPasskeyLogin();
+    const payload = await startPasskeyLogin(req);
     return NextResponse.json(payload);
   } catch (error: unknown) {
     if (isDbUnavailableError(error)) {

--- a/src/app/api/auth/passkey/login-verify/route.ts
+++ b/src/app/api/auth/passkey/login-verify/route.ts
@@ -35,6 +35,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       credential,
       parsed.data.loginSessionId,
       origins,
+      req,
     );
     if ("error" in result) {
       const map: Record<string, string> = {

--- a/src/app/api/auth/passkey/register-options/route.ts
+++ b/src/app/api/auth/passkey/register-options/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     const { userId } = await getActiveUser(req);
     let payload;
     try {
-      payload = await startPasskeyRegistration(userId);
+      payload = await startPasskeyRegistration(userId, req);
     } catch (error: unknown) {
       if (error instanceof Error && error.message === "user_not_found") {
         return NextResponse.json(

--- a/src/app/api/auth/passkey/register-verify/route.ts
+++ b/src/app/api/auth/passkey/register-verify/route.ts
@@ -31,7 +31,12 @@ export async function POST(req: NextRequest): Promise<Response> {
     const origins = resolveWebAuthnExpectedOrigins(req);
     const credential = parsed.data
       .credential as unknown as RegistrationResponseJSON;
-    const result = await finishPasskeyRegistration(userId, credential, origins);
+    const result = await finishPasskeyRegistration(
+      userId,
+      credential,
+      origins,
+      req,
+    );
     if (!result.ok) {
       const map: Record<string, string> = {
         challenge_missing:

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -328,7 +328,8 @@ export default function ProfilePage() {
         </Card>
 
         {passkeySupported ? (
-          <Card style={{ maxWidth: 520, marginTop: 12 }}>
+          <div data-tour="profile-passkeys">
+            <Card style={{ maxWidth: 520, marginTop: 12 }}>
             <Stack gap="3">
               <div>
                 <h3 style={{ marginTop: 0 }}>Snel inloggen</h3>
@@ -378,6 +379,7 @@ export default function ProfilePage() {
               )}
             </Stack>
           </Card>
+          </div>
         ) : null}
 
         <div

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -24,6 +24,16 @@ export type ChangelogEntry = {
  * doesn't reappear. Versions without an entry never trigger the tour.
  */
 export const CHANGELOG: Record<string, ChangelogEntry> = {
+  "0.2.1": {
+    title: "Wat is er nieuw in 0.2.1",
+    steps: [
+      {
+        title: "Snel inloggen met passkey",
+        body: "Op je profiel kun je een passkey toevoegen (Touch ID, Face ID of Windows Hello). Daarna kun je onder Inloggen ook ‘Inloggen met passkey’ gebruiken — naast Google en e-mail.",
+        target: "[data-tour='profile-passkeys']",
+      },
+    ],
+  },
   "0.2.0": {
     title: "Wat is er nieuw in 0.2.0",
     steps: [

--- a/src/lib/services/passkeyService.ts
+++ b/src/lib/services/passkeyService.ts
@@ -11,17 +11,22 @@ import {
 } from "@simplewebauthn/server";
 import { isoUint8Array } from "@simplewebauthn/server/helpers";
 import { randomBytes } from "crypto";
+import type { NextRequest } from "next/server";
 import { prisma } from "../db";
 import { webAuthnConsumeChallenge, webAuthnStoreChallenge } from "../kv";
-import { getWebAuthnRpConfig } from "../webAuthnEnv";
+import { resolveWebAuthnRpConfig } from "../webAuthnEnv";
 
 /**
  * Start WebAuthn-registratie voor een ingelogde gebruiker; slaat de challenge op onder `userId`.
  *
  * @param userId - Actieve gebruiker (sessie).
+ * @param req - Inkomend API-verzoek (RP-ID volgt host/preview).
  * @throws Error `user_not_found` als de gebruiker niet bestaat.
  */
-export async function startPasskeyRegistration(userId: string): Promise<{
+export async function startPasskeyRegistration(
+  userId: string,
+  req: NextRequest,
+): Promise<{
   optionsJSON: Awaited<ReturnType<typeof generateRegistrationOptions>>;
 }> {
   const user = await prisma.user.findUnique({
@@ -37,7 +42,7 @@ export async function startPasskeyRegistration(userId: string): Promise<{
     select: { credentialId: true, transports: true },
   });
 
-  const { rpID, rpName } = getWebAuthnRpConfig();
+  const { rpID, rpName } = resolveWebAuthnRpConfig(req);
   const userName = user.email ?? user.id;
   const userDisplayName =
     `${user.firstName} ${user.lastName}`.trim() || userName;
@@ -86,11 +91,13 @@ export async function startPasskeyRegistration(userId: string): Promise<{
  * @param userId - Dezelfde gebruiker als bij {@link startPasskeyRegistration}.
  * @param response - Ruwe browser-response (`startRegistration`).
  * @param expectedOrigins - Toegestane origins voor clientDataJSON (zie {@link ../webAuthnEnv.getWebAuthnAllowedOrigins}).
+ * @param req - Inkomend API-verzoek (zelfde RP-ID als bij opties).
  */
 export async function finishPasskeyRegistration(
   userId: string,
   response: RegistrationResponseJSON,
   expectedOrigins: string[],
+  req: NextRequest,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const expectedChallenge = await webAuthnConsumeChallenge(
     "registration",
@@ -100,7 +107,7 @@ export async function finishPasskeyRegistration(
     return { ok: false, error: "challenge_missing" };
   }
 
-  const { rpID } = getWebAuthnRpConfig();
+  const { rpID } = resolveWebAuthnRpConfig(req);
 
   let verification;
   try {
@@ -144,12 +151,14 @@ export async function finishPasskeyRegistration(
 
 /**
  * Start passkey-login (discoverable credentials); retourneert een aparte `loginSessionId` voor challenge-lookup.
+ *
+ * @param req - Inkomend API-verzoek (RP-ID volgt host/preview).
  */
-export async function startPasskeyLogin(): Promise<{
+export async function startPasskeyLogin(req: NextRequest): Promise<{
   optionsJSON: Awaited<ReturnType<typeof generateAuthenticationOptions>>;
   loginSessionId: string;
 }> {
-  const { rpID } = getWebAuthnRpConfig();
+  const { rpID } = resolveWebAuthnRpConfig(req);
   const loginSessionId = randomBytes(24).toString("base64url");
   const options = await generateAuthenticationOptions({
     rpID,
@@ -172,11 +181,13 @@ export async function startPasskeyLogin(): Promise<{
  * @param response - Ruwe browser-response (`startAuthentication`).
  * @param loginSessionId - Id uit {@link startPasskeyLogin}.
  * @param expectedOrigins - Zie {@link finishPasskeyRegistration}.
+ * @param req - Inkomend API-verzoek (zelfde RP-ID als bij opties).
  */
 export async function finishPasskeyLogin(
   response: AuthenticationResponseJSON,
   loginSessionId: string,
   expectedOrigins: string[],
+  req: NextRequest,
 ): Promise<{ userId: string } | { error: string }> {
   const expectedChallenge = await webAuthnConsumeChallenge(
     "authentication",
@@ -200,7 +211,7 @@ export async function finishPasskeyLogin(
     return { error: "credential_unknown" };
   }
 
-  const { rpID } = getWebAuthnRpConfig();
+  const { rpID } = resolveWebAuthnRpConfig(req);
 
   let verification;
   try {

--- a/src/lib/webAuthnEnv.ts
+++ b/src/lib/webAuthnEnv.ts
@@ -1,3 +1,4 @@
+import type { NextRequest } from "next/server";
 import { resolveNextAuthUrl } from "./nextAuthUrl";
 
 export type WebAuthnRpConfig = {
@@ -6,8 +7,35 @@ export type WebAuthnRpConfig = {
 };
 
 /**
- * Leest RP-ID en weergavenaam voor WebAuthn.
- * `WEBAUTHN_RP_ID` overrult; anders hostname van `NEXTAUTH_URL` / `VERCEL_URL`, anders `localhost`.
+ * Bepaalt RP-ID voor WebAuthn op basis van dit HTTP-verzoek (aanbevolen).
+ * Gebruikt `WEBAUTHN_RP_ID` als die gezet is; anders de hostname uit
+ * `x-forwarded-host` / `host` zodat preview en 127.0.0.1 overeenkomen met de site in de browser.
+ * Valt terug op {@link getWebAuthnRpConfig} zonder Host-header (tests/batch).
+ *
+ * @param req - Inkomend API-verzoek (App Router route handler).
+ */
+export function resolveWebAuthnRpConfig(req: NextRequest): WebAuthnRpConfig {
+  const rpName = process.env.WEBAUTHN_RP_NAME ?? "H3 Teamy";
+  const explicit = process.env.WEBAUTHN_RP_ID?.trim();
+  if (explicit) {
+    return { rpID: explicit, rpName };
+  }
+  const forwarded = req.headers.get("x-forwarded-host");
+  const hostHeader = req.headers.get("host");
+  const raw = forwarded ?? hostHeader;
+  if (raw) {
+    const hostname = raw.split(":")[0]?.trim();
+    if (hostname) {
+      return { rpID: hostname, rpName };
+    }
+  }
+  return getWebAuthnRpConfig();
+}
+
+/**
+ * Fallback RP-configuratie zonder inkomend verzoek (tests, batch, scripts).
+ * `WEBAUTHN_RP_ID` heeft voorrang; anders hostname van `NEXTAUTH_URL` / `VERCEL_URL`, anders `localhost`
+ * (niet aanbevolen voor productie).
  *
  * @returns Configuratie voor SimpleWebAuthn `rpID` / `rpName`.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Samenvatting

- **WebAuthn RP-ID:** `resolveWebAuthnRpConfig(req)` voor registratie/login.
- **Schema-drift (image):** `withPrismaSchemaDriftAsDbUnavailable` rond passkey-Prisma-paden; `DbUnavailableError` bij ontbrekende tabel/kolom; helpers `prismaSchemaDrift` / `passkeyPrismaErrors` + tests en docs van `image` gemerged.
- **Merge:** `origin/image` ingetrokken; conflict in `passkeyService.ts` opgelost door beide intenties te combineren.
- **Versie / Wat is nieuw / AGENTS / PR-template:** zoals eerder op deze branch.

## Verificatie

- `npx tsc --noEmit`
- `npx vitest run src/lib/prismaSchemaDrift.test.ts src/lib/passkeyPrismaErrors.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9e5f56e-7cec-4e5c-8fd5-c0381d89ab2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9e5f56e-7cec-4e5c-8fd5-c0381d89ab2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nieuwe functies**
  * Geïntroduceerd gebruikersgerichte releasetour die bij nieuwe versies verschijnt.
  * Toegevoegde tourstap in changelog die gebruikers begeleidt bij inloggen met passkey.
  * Profielpagina voorbereid om releasetours te tonen.

* **Verbeteringen**
  * Passkey-authenticatie aangepast om verzoekcontext te gebruiken, robuustere origin/host-afhandeling voor WebAuthn.

* **Chores**
  * Versie opgehoogd naar 0.2.1 en documentatie/releaseworkflow bijgewerkt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->