### PR TITLE
feat(attendance): smart 14-day attendance nudge

### DIFF
--- a/src/app/api/training/nudge/route.ts
+++ b/src/app/api/training/nudge/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../../../lib/authOptions";
+import { getActiveUser } from "../../../../lib/activeUser";
+import { getUserProfile } from "../../../../lib/kv";
+import {
+  computeRecentAttendance,
+  decideNudgeBucket,
+  getOrCreateNudge,
+} from "../../../../lib/services/attendanceNudgeService";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Returns an attendance nudge for the active player based on the rolling
+ * 14-day training-attendance window. Anonymous visitors always get
+ * `{ nudge: null }` — the feature is only meaningful for accounts that have
+ * appeared on training rosters.
+ *
+ * Response shape:
+ * - `{ nudge: null }` when the user is mid-range, the window is too thin, or
+ *   no session is present.
+ * - `{ nudge: { tone, message } }` for `encourage` (<50%) or `cheer` (100%).
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ nudge: null });
+    }
+
+    const { userId } = await getActiveUser(req);
+    const { attended, total } = await computeRecentAttendance(userId);
+    const bucket = decideNudgeBucket(attended, total);
+    if (!bucket) {
+      return NextResponse.json({ nudge: null });
+    }
+
+    const profile = await getUserProfile(userId).catch(() => null);
+    const firstName = profile?.firstName?.trim() || undefined;
+    const nudge = await getOrCreateNudge(userId, bucket, { firstName });
+
+    return NextResponse.json({ nudge });
+  } catch (err: unknown) {
+    Sentry.captureException(err, { tags: { component: "api-training-nudge" } });
+    return NextResponse.json({ nudge: null });
+  }
+}

--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toYMD } from "../../lib/training";
 import { getBadgeForAttendance } from "../../lib/badges";
 import { Card, EmptyState, Stack } from "../../components/ui";
+import AttendanceNudge from "../../components/AttendanceNudge";
 
 type Row = {
   userId: string;
@@ -82,6 +83,8 @@ export default function AttendanceOverview() {
     <main>
       <div className="container">
         <h1>Opkomst</h1>
+
+        <AttendanceNudge />
 
         <Card style={{ marginBottom: 12 }}>
           <Stack gap="2">

--- a/src/components/AttendanceNudge.test.tsx
+++ b/src/components/AttendanceNudge.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AttendanceNudge from "./AttendanceNudge";
+
+const fetchJsonIfOkOr = vi.fn();
+vi.mock("../lib/safeClientJson", () => ({
+  fetchJsonIfOkOr: (...args: unknown[]) => fetchJsonIfOkOr(...args),
+}));
+
+describe("AttendanceNudge", () => {
+  beforeEach(() => {
+    fetchJsonIfOkOr.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when the API returns null", async () => {
+    fetchJsonIfOkOr.mockResolvedValue({ nudge: null });
+    const { container } = render(<AttendanceNudge />);
+    await waitFor(() =>
+      expect(fetchJsonIfOkOr).toHaveBeenCalledWith(
+        "/api/training/nudge",
+        expect.any(Object),
+        "attendance-nudge",
+      ),
+    );
+    // Component returns null after the fetch resolves with no nudge.
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+
+  it("renders an encourage nudge with the AI message", async () => {
+    fetchJsonIfOkOr.mockResolvedValue({
+      nudge: {
+        tone: "encourage",
+        message: "Druk gehad? De bak ligt klaar.",
+      },
+    });
+    render(<AttendanceNudge />);
+    await screen.findByTestId("attendance-nudge-encourage");
+    expect(
+      screen.getByText("Druk gehad? De bak ligt klaar."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a cheer nudge with the AI message", async () => {
+    fetchJsonIfOkOr.mockResolvedValue({
+      nudge: {
+        tone: "cheer",
+        message: "Twee weken full house — top.",
+      },
+    });
+    render(<AttendanceNudge />);
+    await screen.findByTestId("attendance-nudge-cheer");
+    expect(
+      screen.getByText("Twee weken full house — top."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Top!")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the fetch helper returns null", async () => {
+    fetchJsonIfOkOr.mockResolvedValue(null);
+    const { container } = render(<AttendanceNudge />);
+    await waitFor(() => expect(fetchJsonIfOkOr).toHaveBeenCalled());
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+});

--- a/src/components/AttendanceNudge.tsx
+++ b/src/components/AttendanceNudge.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card } from "./ui";
+import { fetchJsonIfOkOr } from "../lib/safeClientJson";
+
+type Nudge = { tone: "encourage" | "cheer"; message: string };
+type Response = { nudge: Nudge | null };
+
+/**
+ * Top-of-page attendance nudge. Fetches `/api/training/nudge`; renders a warm
+ * encouragement when the player's 14-day attendance is under 50% and a cheer
+ * when they were at every training. Mid-range players see nothing.
+ *
+ * Logged-out and mid-range players get `nudge: null` from the API and this
+ * component renders nothing.
+ */
+export default function AttendanceNudge(): React.JSX.Element | null {
+  const [nudge, setNudge] = useState<Nudge | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      const data = await fetchJsonIfOkOr<Response>(
+        "/api/training/nudge",
+        { cache: "no-store" },
+        "attendance-nudge",
+      );
+      if (!mounted) return;
+      setNudge(data?.nudge ?? null);
+      setLoaded(true);
+    }
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!loaded || !nudge) return null;
+
+  const accent =
+    nudge.tone === "cheer" ? "var(--accent)" : "var(--accent, #2563eb)";
+
+  return (
+    <Card
+      style={{
+        marginBottom: 12,
+        borderColor: accent,
+      }}
+    >
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid={`attendance-nudge-${nudge.tone}`}
+      >
+        <div
+          style={{
+            fontSize: 13,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+            color: "var(--muted)",
+            marginBottom: 4,
+          }}
+        >
+          {nudge.tone === "cheer" ? "Top!" : "Hee 👋"}
+        </div>
+        <div>{nudge.message}</div>
+      </div>
+    </Card>
+  );
+}

--- a/src/lib/ai/attendanceNudge.test.ts
+++ b/src/lib/ai/attendanceNudge.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  AttendanceNudgeSchema,
+  NUDGE_SYSTEM_PROMPT,
+  generateAttendanceNudge,
+} from "./attendanceNudge";
+
+describe("AttendanceNudgeSchema", () => {
+  it("accepts a well-formed encourage payload", () => {
+    const r = AttendanceNudgeSchema.safeParse({
+      tone: "encourage",
+      message: "Hee, de bak mist je. Tot woensdag?",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a well-formed cheer payload", () => {
+    const r = AttendanceNudgeSchema.safeParse({
+      tone: "cheer",
+      message: "Twee weken full house — de hele bak ziet je trekken.",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an unknown tone", () => {
+    const r = AttendanceNudgeSchema.safeParse({
+      tone: "scold",
+      message: "x".repeat(20),
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects messages over the 220 char cap", () => {
+    const r = AttendanceNudgeSchema.safeParse({
+      tone: "cheer",
+      message: "x".repeat(221),
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("NUDGE_SYSTEM_PROMPT", () => {
+  it("mentions both tones", () => {
+    expect(NUDGE_SYSTEM_PROMPT).toContain("encourage");
+    expect(NUDGE_SYSTEM_PROMPT).toContain("cheer");
+  });
+
+  it("instructs the model to write in Dutch", () => {
+    expect(NUDGE_SYSTEM_PROMPT).toContain("NL");
+  });
+
+  it("forbids shaming", () => {
+    expect(NUDGE_SYSTEM_PROMPT.toLowerCase()).toContain("nooit beschamend");
+  });
+});
+
+describe("generateAttendanceNudge", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("calls the AI SDK with anthropic/claude-opus-4 and returns the parsed object", async () => {
+    const generateObject = vi.fn(async () => ({
+      object: {
+        tone: "encourage",
+        message: "Druk gehad? Geen ramp. Woensdag staat de bak klaar.",
+      },
+    }));
+    vi.doMock("./client", () => ({ generateObject }));
+    const mod = await import("./attendanceNudge");
+    const out = await mod.generateAttendanceNudge({
+      tone: "encourage",
+      attended: 1,
+      total: 4,
+      firstName: "Joost",
+    });
+    expect(out.tone).toBe("encourage");
+    expect(generateObject).toHaveBeenCalledTimes(1);
+    const args = generateObject.mock.calls[0][0] as {
+      model: string;
+      system: string;
+      prompt: string;
+    };
+    expect(args.model).toBe("anthropic/claude-opus-4");
+    expect(args.system).toBe(NUDGE_SYSTEM_PROMPT);
+    expect(args.prompt).toContain("Joost");
+    expect(args.prompt).toContain("1 van 4");
+    expect(args.prompt).toContain("encourage");
+  });
+
+  it("omits the firstName line when no name is provided", async () => {
+    const generateObject = vi.fn(async () => ({
+      object: { tone: "cheer", message: "Top — alle trainingen erop zitten." },
+    }));
+    vi.doMock("./client", () => ({ generateObject }));
+    const mod = await import("./attendanceNudge");
+    await mod.generateAttendanceNudge({ tone: "cheer", attended: 4, total: 4 });
+    const args = generateObject.mock.calls[0][0] as { prompt: string };
+    expect(args.prompt).not.toContain("Voornaam:");
+  });
+
+  it("propagates errors from the SDK", async () => {
+    vi.doMock("./client", () => ({
+      generateObject: () => {
+        throw new Error("boom");
+      },
+    }));
+    const mod = await import("./attendanceNudge");
+    await expect(
+      mod.generateAttendanceNudge({ tone: "encourage", attended: 0, total: 4 }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/lib/ai/attendanceNudge.test.ts
+++ b/src/lib/ai/attendanceNudge.test.ts
@@ -52,6 +52,11 @@ describe("NUDGE_SYSTEM_PROMPT", () => {
   it("forbids shaming", () => {
     expect(NUDGE_SYSTEM_PROMPT.toLowerCase()).toContain("nooit beschamend");
   });
+
+  it("instructs the model not to invent a training day", () => {
+    expect(NUDGE_SYSTEM_PROMPT).toContain("Eerstvolgende training");
+    expect(NUDGE_SYSTEM_PROMPT).toContain("Verzin NOOIT");
+  });
 });
 
 describe("generateAttendanceNudge", () => {
@@ -73,6 +78,7 @@ describe("generateAttendanceNudge", () => {
       attended: 1,
       total: 4,
       firstName: "Joost",
+      nextTrainingLabel: "woensdag",
     });
     expect(out.tone).toBe("encourage");
     expect(generateObject).toHaveBeenCalledTimes(1);
@@ -86,9 +92,10 @@ describe("generateAttendanceNudge", () => {
     expect(args.prompt).toContain("Joost");
     expect(args.prompt).toContain("1 van 4");
     expect(args.prompt).toContain("encourage");
+    expect(args.prompt).toContain("Eerstvolgende training: woensdag");
   });
 
-  it("omits the firstName line when no name is provided", async () => {
+  it("omits the firstName and next-training lines when not provided", async () => {
     const generateObject = vi.fn(async () => ({
       object: { tone: "cheer", message: "Top — alle trainingen erop zitten." },
     }));
@@ -97,6 +104,23 @@ describe("generateAttendanceNudge", () => {
     await mod.generateAttendanceNudge({ tone: "cheer", attended: 4, total: 4 });
     const args = generateObject.mock.calls[0][0] as { prompt: string };
     expect(args.prompt).not.toContain("Voornaam:");
+    expect(args.prompt).not.toContain("Eerstvolgende training");
+  });
+
+  it("does not pass the next-training label for cheer tone", async () => {
+    const generateObject = vi.fn(async () => ({
+      object: { tone: "cheer", message: "Twee weken full house — top." },
+    }));
+    vi.doMock("./client", () => ({ generateObject }));
+    const mod = await import("./attendanceNudge");
+    await mod.generateAttendanceNudge({
+      tone: "cheer",
+      attended: 4,
+      total: 4,
+      nextTrainingLabel: "woensdag",
+    });
+    const args = generateObject.mock.calls[0][0] as { prompt: string };
+    expect(args.prompt).not.toContain("Eerstvolgende training");
   });
 
   it("propagates errors from the SDK", async () => {

--- a/src/lib/ai/attendanceNudge.ts
+++ b/src/lib/ai/attendanceNudge.ts
@@ -25,6 +25,8 @@ Twee tones:
 - "encourage": speler kwam minder dan de helft van de trainingen. Wees warm, nooit beschamend, nooit moraliserend. Erken dat het leven druk is. Eindig met een concrete uitnodiging voor de eerstvolgende training. Geen verwijten, geen percentages opnoemen.
 - "cheer": speler was bij ALLE trainingen. Wees blij en concreet. Eén korte zin van waardering, één zin met positieve impact op het team.
 
+Bij encourage krijg je een veld "Eerstvolgende training". Gebruik EXACT dat label in je uitnodiging (bv. "vandaag", "morgen", "overmorgen", "woensdag", "vrijdag"). Verzin NOOIT zelf een dag — niet "donderdag" of "zaterdag" of een andere dag dan wat is meegegeven. De club traint alleen op woensdag en vrijdag.
+
 Schrijf in spreektaal, "je"-vorm. Maximaal 2 zinnen, samen onder 220 karakters. Geen emoji-spam (max 1).
 Geef JSON terug met velden { tone, message }. Houd "tone" gelijk aan de meegegeven tone.`;
 
@@ -34,6 +36,13 @@ export type NudgeInput = {
   attended: number;
   total: number;
   firstName?: string;
+  /**
+   * Dutch label for the next training day, relative to "today" — e.g.
+   * `"vandaag"`, `"morgen"`, `"overmorgen"`, `"woensdag"`, `"vrijdag"`. Only
+   * meaningful for `tone === "encourage"`; the prompt tells the model to use
+   * this label verbatim and never invent a day.
+   */
+  nextTrainingLabel?: string;
 };
 
 /**
@@ -48,11 +57,16 @@ export async function generateAttendanceNudge(
 ): Promise<AttendanceNudge> {
   const { generateObject } = await import("./client");
   const namePart = input.firstName ? `Voornaam: ${input.firstName}\n` : "";
+  const nextPart =
+    input.tone === "encourage" && input.nextTrainingLabel
+      ? `Eerstvolgende training: ${input.nextTrainingLabel}\n`
+      : "";
   const { object } = await generateObject({
     model: "anthropic/claude-opus-4",
     schema: AttendanceNudgeSchema,
     system: NUDGE_SYSTEM_PROMPT,
-    prompt: `${namePart}Tone: ${input.tone}\nAanwezig: ${input.attended} van ${input.total} trainingen (laatste 14 dagen).`,
+    prompt:
+      `${namePart}Tone: ${input.tone}\nAanwezig: ${input.attended} van ${input.total} trainingen (laatste 14 dagen).\n${nextPart}`.trimEnd(),
   });
   return object;
 }

--- a/src/lib/ai/attendanceNudge.ts
+++ b/src/lib/ai/attendanceNudge.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+/**
+ * Schema for the structured nudge object the AI coach returns for a player's
+ * 14-day training attendance bucket. Drives the `generateObject` call so the
+ * model is forced to emit valid, parseable JSON.
+ */
+export const AttendanceNudgeSchema = z.object({
+  tone: z.enum(["encourage", "cheer"]),
+  message: z.string().min(10).max(220),
+});
+
+/** Parsed nudge payload: tone bucket and the Dutch message body. */
+export type AttendanceNudge = z.infer<typeof AttendanceNudgeSchema>;
+
+/**
+ * System prompt sent on every nudge call. Defines the coach persona and the
+ * editorial tone (Dutch, warm, never shaming). Kept as a module-level constant
+ * so it's eligible for prompt caching by the gateway.
+ */
+export const NUDGE_SYSTEM_PROMPT = `Je bent de teamcoach-stem in H3-Teamy, de app van waterpolo-team H3.
+Je schrijft korte persoonlijke berichten (NL, max 2 zinnen) voor één speler op basis van zijn opkomstcijfer over de laatste 14 dagen.
+
+Twee tones:
+- "encourage": speler kwam minder dan de helft van de trainingen. Wees warm, nooit beschamend, nooit moraliserend. Erken dat het leven druk is. Eindig met een concrete uitnodiging voor de eerstvolgende training. Geen verwijten, geen percentages opnoemen.
+- "cheer": speler was bij ALLE trainingen. Wees blij en concreet. Eén korte zin van waardering, één zin met positieve impact op het team.
+
+Schrijf in spreektaal, "je"-vorm. Maximaal 2 zinnen, samen onder 220 karakters. Geen emoji-spam (max 1).
+Geef JSON terug met velden { tone, message }. Houd "tone" gelijk aan de meegegeven tone.`;
+
+/** Input for the nudge call: bucket + raw counts so the model can personalize. */
+export type NudgeInput = {
+  tone: "encourage" | "cheer";
+  attended: number;
+  total: number;
+  firstName?: string;
+};
+
+/**
+ * Calls the AI SDK through the Vercel AI Gateway with model
+ * `anthropic/claude-opus-4` and returns a structured attendance nudge.
+ *
+ * Loaded dynamically so the Braintrust-wrapped client does not pull `ai` /
+ * `braintrust` into the bundle of routes that don't need it (e.g. edge).
+ */
+export async function generateAttendanceNudge(
+  input: NudgeInput,
+): Promise<AttendanceNudge> {
+  const { generateObject } = await import("./client");
+  const namePart = input.firstName ? `Voornaam: ${input.firstName}\n` : "";
+  const { object } = await generateObject({
+    model: "anthropic/claude-opus-4",
+    schema: AttendanceNudgeSchema,
+    system: NUDGE_SYSTEM_PROMPT,
+    prompt: `${namePart}Tone: ${input.tone}\nAanwezig: ${input.attended} van ${input.total} trainingen (laatste 14 dagen).`,
+  });
+  return object;
+}

--- a/src/lib/services/attendanceNudgeService.test.ts
+++ b/src/lib/services/attendanceNudgeService.test.ts
@@ -156,7 +156,7 @@ describe("getOrCreateNudge", () => {
     });
     expect(kvSetJson).toHaveBeenCalledTimes(1);
     const [key] = kvSetJson.mock.calls[0];
-    expect(key).toContain("nudge:v2:u1:2025-09-10:encourage:1of4");
+    expect(key).toContain("nudge:v3:u1:2025-09-10:encourage:1of4");
   });
 
   it("passes 'woensdag' when today is the preceding Saturday", async () => {

--- a/src/lib/services/attendanceNudgeService.test.ts
+++ b/src/lib/services/attendanceNudgeService.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+const { kvGetJson, kvSetJson, getAttendanceForDates, generateAttendanceNudge } =
+  vi.hoisted(() => ({
+    kvGetJson: vi.fn(),
+    kvSetJson: vi.fn(),
+    getAttendanceForDates: vi.fn(),
+    generateAttendanceNudge: vi.fn(),
+  }));
+
+vi.mock("../kv", () => ({
+  kvGetJson,
+  kvSetJson,
+  getAttendanceForDates,
+}));
+
+vi.mock("../ai/attendanceNudge", () => ({
+  generateAttendanceNudge,
+}));
+
+import {
+  decideNudgeBucket,
+  computeRecentAttendance,
+  getOrCreateNudge,
+} from "./attendanceNudgeService";
+
+describe("decideNudgeBucket", () => {
+  it("returns null when fewer than 2 trainings are scheduled", () => {
+    expect(decideNudgeBucket(0, 0)).toBeNull();
+    expect(decideNudgeBucket(1, 1)).toBeNull();
+  });
+
+  it("flags 100% as a cheer when at least 2 trainings attended", () => {
+    expect(decideNudgeBucket(2, 2)).toEqual({
+      tone: "cheer",
+      attended: 2,
+      total: 2,
+      pct: 100,
+    });
+    expect(decideNudgeBucket(4, 4)).toEqual({
+      tone: "cheer",
+      attended: 4,
+      total: 4,
+      pct: 100,
+    });
+  });
+
+  it("flags below 50% as an encouragement", () => {
+    expect(decideNudgeBucket(1, 4)).toEqual({
+      tone: "encourage",
+      attended: 1,
+      total: 4,
+      pct: 25,
+    });
+    expect(decideNudgeBucket(0, 4)).toEqual({
+      tone: "encourage",
+      attended: 0,
+      total: 4,
+      pct: 0,
+    });
+  });
+
+  it("returns null for the mid-range (50%–<100%)", () => {
+    expect(decideNudgeBucket(2, 4)).toBeNull(); // 50%
+    expect(decideNudgeBucket(3, 4)).toBeNull(); // 75%
+    expect(decideNudgeBucket(3, 5)).toBeNull(); // 60%
+  });
+
+  it("guards against impossible inputs", () => {
+    expect(decideNudgeBucket(-1, 4)).toBeNull();
+    expect(decideNudgeBucket(5, 4)).toBeNull();
+    expect(decideNudgeBucket(Number.NaN, 4)).toBeNull();
+    expect(decideNudgeBucket(2, Number.NaN)).toBeNull();
+  });
+});
+
+describe("computeRecentAttendance", () => {
+  beforeEach(() => {
+    getAttendanceForDates.mockReset();
+  });
+
+  it("counts attendance over the rolling 14-day window", async () => {
+    // Wed 2025-09-03 and Fri 2025-09-05 fall inside a 2-week window ending 2025-09-10
+    const today = new Date("2025-09-10T12:00:00Z");
+    getAttendanceForDates.mockResolvedValue({
+      "2025-08-29": ["other"],
+      "2025-09-03": ["u1", "u2"],
+      "2025-09-05": ["u1"],
+    });
+    const out = await computeRecentAttendance("u1", today);
+    expect(out.total).toBeGreaterThanOrEqual(2);
+    expect(out.attended).toBe(2);
+  });
+
+  it("returns 0/0 when the window has no scheduled trainings", async () => {
+    // Force an empty window via stub: any small window without Wed/Fri
+    getAttendanceForDates.mockResolvedValue({});
+    const out = await computeRecentAttendance(
+      "u1",
+      new Date("2025-09-10T12:00:00Z"),
+    );
+    expect(out.attended).toBe(0);
+    expect(typeof out.total).toBe("number");
+  });
+});
+
+describe("getOrCreateNudge", () => {
+  beforeEach(() => {
+    kvGetJson.mockReset();
+    kvSetJson.mockReset();
+    kvSetJson.mockResolvedValue(undefined);
+    generateAttendanceNudge.mockReset();
+  });
+
+  const today = new Date("2025-09-10T12:00:00Z");
+  const bucket = {
+    tone: "encourage" as const,
+    attended: 1,
+    total: 4,
+    pct: 25,
+  };
+
+  it("returns the cached nudge without invoking the LLM", async () => {
+    kvGetJson.mockResolvedValue({
+      tone: "encourage",
+      message: "Cached message — just come back!",
+    });
+    const out = await getOrCreateNudge("u1", bucket, { today });
+    expect(out.message).toBe("Cached message — just come back!");
+    expect(generateAttendanceNudge).not.toHaveBeenCalled();
+    expect(kvSetJson).not.toHaveBeenCalled();
+  });
+
+  it("invokes the LLM and caches the result on a miss", async () => {
+    kvGetJson.mockResolvedValue(null);
+    generateAttendanceNudge.mockResolvedValue({
+      tone: "encourage",
+      message: "Fresh AI message.",
+    });
+    const out = await getOrCreateNudge("u1", bucket, {
+      firstName: "Joost",
+      today,
+    });
+    expect(out.message).toBe("Fresh AI message.");
+    expect(generateAttendanceNudge).toHaveBeenCalledWith({
+      tone: "encourage",
+      attended: 1,
+      total: 4,
+      firstName: "Joost",
+    });
+    expect(kvSetJson).toHaveBeenCalledTimes(1);
+    const [key] = kvSetJson.mock.calls[0];
+    expect(key).toContain("nudge:v1:u1:2025-09-10:encourage:1of4");
+  });
+
+  it("falls back to a static Dutch encourage message when the LLM throws", async () => {
+    kvGetJson.mockResolvedValue(null);
+    generateAttendanceNudge.mockRejectedValue(new Error("ai down"));
+    const out = await getOrCreateNudge("u1", bucket, { today });
+    expect(out.tone).toBe("encourage");
+    expect(out.message).toMatch(/bak ligt klaar/);
+    expect(kvSetJson).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a static Dutch cheer message when the LLM throws", async () => {
+    kvGetJson.mockResolvedValue(null);
+    generateAttendanceNudge.mockRejectedValue(new Error("ai down"));
+    const out = await getOrCreateNudge(
+      "u1",
+      { tone: "cheer", attended: 4, total: 4, pct: 100 },
+      { today },
+    );
+    expect(out.tone).toBe("cheer");
+    expect(out.message).toMatch(/Alle trainingen erop zitten/);
+  });
+
+  it("ignores a cache row whose tone no longer matches the bucket", async () => {
+    kvGetJson.mockResolvedValue({
+      tone: "cheer",
+      message: "stale cheer",
+    });
+    generateAttendanceNudge.mockResolvedValue({
+      tone: "encourage",
+      message: "fresh encourage",
+    });
+    const out = await getOrCreateNudge("u1", bucket, { today });
+    expect(out.message).toBe("fresh encourage");
+  });
+});

--- a/src/lib/services/attendanceNudgeService.test.ts
+++ b/src/lib/services/attendanceNudgeService.test.ts
@@ -135,12 +135,13 @@ describe("getOrCreateNudge", () => {
     expect(kvSetJson).not.toHaveBeenCalled();
   });
 
-  it("invokes the LLM and caches the result on a miss", async () => {
+  it("invokes the LLM and caches the result on a miss, passing the next-training label", async () => {
     kvGetJson.mockResolvedValue(null);
     generateAttendanceNudge.mockResolvedValue({
       tone: "encourage",
       message: "Fresh AI message.",
     });
+    // 2025-09-10 is a Wednesday, so next training is "vandaag".
     const out = await getOrCreateNudge("u1", bucket, {
       firstName: "Joost",
       today,
@@ -151,17 +152,65 @@ describe("getOrCreateNudge", () => {
       attended: 1,
       total: 4,
       firstName: "Joost",
+      nextTrainingLabel: "vandaag",
     });
     expect(kvSetJson).toHaveBeenCalledTimes(1);
     const [key] = kvSetJson.mock.calls[0];
-    expect(key).toContain("nudge:v1:u1:2025-09-10:encourage:1of4");
+    expect(key).toContain("nudge:v2:u1:2025-09-10:encourage:1of4");
   });
 
-  it("falls back to a static Dutch encourage message when the LLM throws", async () => {
+  it("passes 'woensdag' when today is the preceding Saturday", async () => {
+    kvGetJson.mockResolvedValue(null);
+    generateAttendanceNudge.mockResolvedValue({
+      tone: "encourage",
+      message: "Tot woensdag!",
+    });
+    // Saturday 2025-09-06; next training is Wednesday 2025-09-10.
+    await getOrCreateNudge("u1", bucket, {
+      today: new Date(2025, 8, 6),
+    });
+    const args = generateAttendanceNudge.mock.calls[0][0];
+    expect(args.nextTrainingLabel).toBe("woensdag");
+  });
+
+  it("passes 'morgen' the day before a training day", async () => {
+    kvGetJson.mockResolvedValue(null);
+    generateAttendanceNudge.mockResolvedValue({
+      tone: "encourage",
+      message: "Tot morgen!",
+    });
+    // Tuesday 2025-09-09; next training is Wednesday 2025-09-10 → "morgen".
+    await getOrCreateNudge("u1", bucket, {
+      today: new Date(2025, 8, 9),
+    });
+    const args = generateAttendanceNudge.mock.calls[0][0];
+    expect(args.nextTrainingLabel).toBe("morgen");
+  });
+
+  it("does not pass a next-training label for cheer tone", async () => {
+    kvGetJson.mockResolvedValue(null);
+    generateAttendanceNudge.mockResolvedValue({
+      tone: "cheer",
+      message: "Top!",
+    });
+    await getOrCreateNudge(
+      "u1",
+      { tone: "cheer", attended: 4, total: 4, pct: 100 },
+      { today },
+    );
+    const args = generateAttendanceNudge.mock.calls[0][0];
+    expect(args.nextTrainingLabel).toBeUndefined();
+  });
+
+  it("falls back to a static Dutch encourage message that names the next training day when the LLM throws", async () => {
     kvGetJson.mockResolvedValue(null);
     generateAttendanceNudge.mockRejectedValue(new Error("ai down"));
-    const out = await getOrCreateNudge("u1", bucket, { today });
+    // Saturday → next training is Wednesday.
+    const out = await getOrCreateNudge("u1", bucket, {
+      today: new Date(2025, 8, 6),
+    });
     expect(out.tone).toBe("encourage");
+    expect(out.message).toContain("woensdag");
     expect(out.message).toMatch(/bak ligt klaar/);
     expect(kvSetJson).not.toHaveBeenCalled();
   });

--- a/src/lib/services/attendanceNudgeService.ts
+++ b/src/lib/services/attendanceNudgeService.ts
@@ -90,7 +90,7 @@ function staticFallback(
 }
 
 function cacheKey(userId: string, today: Date, bucket: NudgeBucket): string {
-  return `nudge:v2:${userId}:${toYMD(today)}:${bucket.tone}:${bucket.attended}of${bucket.total}`;
+  return `nudge:v3:${userId}:${toYMD(today)}:${bucket.tone}:${bucket.attended}of${bucket.total}`;
 }
 
 /**

--- a/src/lib/services/attendanceNudgeService.ts
+++ b/src/lib/services/attendanceNudgeService.ts
@@ -4,7 +4,12 @@ import {
   type AttendanceNudge,
 } from "../ai/attendanceNudge";
 import { kvGetJson, kvSetJson, getAttendanceForDates } from "../kv";
-import { generateTrainingDates, toYMD } from "../training";
+import {
+  describeRelativeDay,
+  generateTrainingDates,
+  nextTrainingDate,
+  toYMD,
+} from "../training";
 
 /** Bucket the player's last-14-day attendance falls into, with raw counts. */
 export type NudgeBucket = {
@@ -64,7 +69,10 @@ export async function computeRecentAttendance(
   return { attended, total: dates.length };
 }
 
-function staticFallback(bucket: NudgeBucket): AttendanceNudge {
+function staticFallback(
+  bucket: NudgeBucket,
+  nextTrainingLabel?: string,
+): AttendanceNudge {
   if (bucket.tone === "cheer") {
     return {
       tone: "cheer",
@@ -72,15 +80,17 @@ function staticFallback(bucket: NudgeBucket): AttendanceNudge {
         "Alle trainingen erop zitten in twee weken — dat zien we. Ga zo door.",
     };
   }
+  const dayPart = nextTrainingLabel
+    ? `De bak ligt klaar ${nextTrainingLabel} — kom je weer aansluiten?`
+    : "De bak ligt klaar — kom je weer aansluiten?";
   return {
     tone: "encourage",
-    message:
-      "Druk gehad? Geen ramp. De bak ligt klaar — kom je weer aansluiten?",
+    message: `Druk gehad? Geen ramp. ${dayPart}`,
   };
 }
 
 function cacheKey(userId: string, today: Date, bucket: NudgeBucket): string {
-  return `nudge:v1:${userId}:${toYMD(today)}:${bucket.tone}:${bucket.attended}of${bucket.total}`;
+  return `nudge:v2:${userId}:${toYMD(today)}:${bucket.tone}:${bucket.attended}of${bucket.total}`;
 }
 
 /**
@@ -99,12 +109,20 @@ export async function getOrCreateNudge(
   if (cached && cached.tone === bucket.tone && cached.message) {
     return cached;
   }
+
+  let nextTrainingLabel: string | undefined;
+  if (bucket.tone === "encourage") {
+    const nextDate = nextTrainingDate(today);
+    if (nextDate) nextTrainingLabel = describeRelativeDay(nextDate, today);
+  }
+
   try {
     const fresh = await generateAttendanceNudge({
       tone: bucket.tone,
       attended: bucket.attended,
       total: bucket.total,
       firstName: opts.firstName,
+      nextTrainingLabel,
     });
     await kvSetJson(key, fresh).catch(() => {});
     return fresh;
@@ -113,6 +131,6 @@ export async function getOrCreateNudge(
       tags: { component: "attendance-nudge" },
       extra: { userId, bucket: bucket.tone },
     });
-    return staticFallback(bucket);
+    return staticFallback(bucket, nextTrainingLabel);
   }
 }

--- a/src/lib/services/attendanceNudgeService.ts
+++ b/src/lib/services/attendanceNudgeService.ts
@@ -1,0 +1,118 @@
+import * as Sentry from "@sentry/nextjs";
+import {
+  generateAttendanceNudge,
+  type AttendanceNudge,
+} from "../ai/attendanceNudge";
+import { kvGetJson, kvSetJson, getAttendanceForDates } from "../kv";
+import { generateTrainingDates, toYMD } from "../training";
+
+/** Bucket the player's last-14-day attendance falls into, with raw counts. */
+export type NudgeBucket = {
+  tone: "encourage" | "cheer";
+  attended: number;
+  total: number;
+  pct: number;
+};
+
+/**
+ * Pure decision: does this attendance window warrant a nudge, and which tone?
+ *
+ * Rules:
+ * - Window must have ≥ 2 scheduled trainings — single-training windows skew too
+ *   easily on holidays.
+ * - 100% attendance with ≥ 2 attended → `cheer`.
+ * - Below 50% → `encourage`.
+ * - Otherwise → `null` (mid-range, no nudge).
+ *
+ * @param attended - Trainings the player attended in the window (can be 0).
+ * @param total - Trainings scheduled in the window.
+ */
+export function decideNudgeBucket(
+  attended: number,
+  total: number,
+): NudgeBucket | null {
+  if (!Number.isFinite(attended) || !Number.isFinite(total)) return null;
+  if (total < 2) return null;
+  if (attended < 0 || attended > total) return null;
+  const pct = Math.round((attended / total) * 100);
+  if (attended === total && attended >= 2) {
+    return { tone: "cheer", attended, total, pct };
+  }
+  if (pct < 50) {
+    return { tone: "encourage", attended, total, pct };
+  }
+  return null;
+}
+
+/**
+ * Computes the user's attendance counts in the rolling 14-day window ending on
+ * `today` (inclusive). `today` is parameterized so tests can pin a date.
+ */
+export async function computeRecentAttendance(
+  userId: string,
+  today: Date = new Date(),
+): Promise<{ attended: number; total: number }> {
+  const from = new Date(today);
+  from.setDate(from.getDate() - 13);
+  const dates = generateTrainingDates(from, today);
+  if (dates.length === 0) return { attended: 0, total: 0 };
+  const map = await getAttendanceForDates(dates);
+  let attended = 0;
+  for (const d of dates) {
+    if ((map[d] || []).includes(userId)) attended++;
+  }
+  return { attended, total: dates.length };
+}
+
+function staticFallback(bucket: NudgeBucket): AttendanceNudge {
+  if (bucket.tone === "cheer") {
+    return {
+      tone: "cheer",
+      message:
+        "Alle trainingen erop zitten in twee weken — dat zien we. Ga zo door.",
+    };
+  }
+  return {
+    tone: "encourage",
+    message:
+      "Druk gehad? Geen ramp. De bak ligt klaar — kom je weer aansluiten?",
+  };
+}
+
+function cacheKey(userId: string, today: Date, bucket: NudgeBucket): string {
+  return `nudge:v1:${userId}:${toYMD(today)}:${bucket.tone}:${bucket.attended}of${bucket.total}`;
+}
+
+/**
+ * Returns the cached nudge for this user/day/bucket, or generates a fresh one
+ * via the LLM and caches it. On AI failure, returns a static Dutch fallback so
+ * the UI never has to render "AI down".
+ */
+export async function getOrCreateNudge(
+  userId: string,
+  bucket: NudgeBucket,
+  opts: { firstName?: string; today?: Date } = {},
+): Promise<AttendanceNudge> {
+  const today = opts.today ?? new Date();
+  const key = cacheKey(userId, today, bucket);
+  const cached = await kvGetJson<AttendanceNudge>(key).catch(() => null);
+  if (cached && cached.tone === bucket.tone && cached.message) {
+    return cached;
+  }
+  try {
+    const fresh = await generateAttendanceNudge({
+      tone: bucket.tone,
+      attended: bucket.attended,
+      total: bucket.total,
+      firstName: opts.firstName,
+    });
+    await kvSetJson(key, fresh).catch(() => {});
+    return fresh;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { component: "attendance-nudge" },
+      extra: { userId, bucket: bucket.tone },
+    });
+    return staticFallback(bucket);
+  }
+}

--- a/src/lib/training.test.ts
+++ b/src/lib/training.test.ts
@@ -62,6 +62,44 @@ describe("nextTrainingDate", () => {
     const thu = new Date(2025, 8, 4);
     expect(toYMD(nextTrainingDate(thu)!)).toBe("2025-09-05");
   });
+
+  // 2025-09 is CEST (UTC+2). 17:20Z = 19:20 in Amsterdam (Wed start).
+  // 18:15Z = 20:15 in Amsterdam (Fri start).
+  it("returns today on a Wednesday before training starts (Amsterdam time)", () => {
+    expect(toYMD(nextTrainingDate(new Date("2025-09-10T17:19:00Z"))!)).toBe(
+      "2025-09-10",
+    );
+  });
+
+  it("skips to Friday on a Wednesday at training start", () => {
+    expect(toYMD(nextTrainingDate(new Date("2025-09-10T17:20:00Z"))!)).toBe(
+      "2025-09-12",
+    );
+  });
+
+  it("skips to Friday on a Wednesday well past training start", () => {
+    expect(toYMD(nextTrainingDate(new Date("2025-09-10T20:00:00Z"))!)).toBe(
+      "2025-09-12",
+    );
+  });
+
+  it("returns today on a Friday before training starts (Amsterdam time)", () => {
+    expect(toYMD(nextTrainingDate(new Date("2025-09-12T18:14:00Z"))!)).toBe(
+      "2025-09-12",
+    );
+  });
+
+  it("skips to next Wednesday on a Friday at training start", () => {
+    expect(toYMD(nextTrainingDate(new Date("2025-09-12T18:15:00Z"))!)).toBe(
+      "2025-09-17",
+    );
+  });
+
+  it("skips to next Wednesday on a Friday after training", () => {
+    expect(toYMD(nextTrainingDate(new Date("2025-09-12T22:00:00Z"))!)).toBe(
+      "2025-09-17",
+    );
+  });
 });
 
 describe("describeRelativeDay", () => {

--- a/src/lib/training.test.ts
+++ b/src/lib/training.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   defaultSeasonWindow,
+  describeRelativeDay,
   generateTrainingDates,
+  nextTrainingDate,
   splitTrainingSessionDatesForDisplay,
   toYMD,
 } from "./training";
@@ -24,6 +26,58 @@ describe("generateTrainingDates", () => {
       const w = dt.getDay();
       expect(w === 3 || w === 5).toBe(true);
     }
+  });
+});
+
+describe("nextTrainingDate", () => {
+  // 2025-09 calendar reference:
+  // Mon 1, Tue 2, Wed 3, Thu 4, Fri 5, Sat 6, Sun 7
+  // Mon 8, Tue 9, Wed 10, Thu 11, Fri 12, Sat 13, Sun 14
+  it("returns the same day when called on a Wednesday", () => {
+    const wed = new Date(2025, 8, 3); // Wed 2025-09-03
+    expect(toYMD(nextTrainingDate(wed)!)).toBe("2025-09-03");
+  });
+
+  it("returns the same day when called on a Friday", () => {
+    const fri = new Date(2025, 8, 5);
+    expect(toYMD(nextTrainingDate(fri)!)).toBe("2025-09-05");
+  });
+
+  it("returns Wednesday when called on the preceding Saturday", () => {
+    const sat = new Date(2025, 8, 6);
+    expect(toYMD(nextTrainingDate(sat)!)).toBe("2025-09-10");
+  });
+
+  it("returns Wednesday when called on a Sunday", () => {
+    const sun = new Date(2025, 8, 7);
+    expect(toYMD(nextTrainingDate(sun)!)).toBe("2025-09-10");
+  });
+
+  it("returns Wednesday when called on a Tuesday", () => {
+    const tue = new Date(2025, 8, 9);
+    expect(toYMD(nextTrainingDate(tue)!)).toBe("2025-09-10");
+  });
+
+  it("returns Friday when called on a Thursday", () => {
+    const thu = new Date(2025, 8, 4);
+    expect(toYMD(nextTrainingDate(thu)!)).toBe("2025-09-05");
+  });
+});
+
+describe("describeRelativeDay", () => {
+  const today = new Date(2025, 8, 6); // Saturday 2025-09-06
+  it("returns 'vandaag' for the same day", () => {
+    expect(describeRelativeDay(today, today)).toBe("vandaag");
+  });
+  it("returns 'morgen' for the next day", () => {
+    expect(describeRelativeDay(new Date(2025, 8, 7), today)).toBe("morgen");
+  });
+  it("returns 'overmorgen' for two days out", () => {
+    expect(describeRelativeDay(new Date(2025, 8, 8), today)).toBe("overmorgen");
+  });
+  it("returns the Dutch weekday name for further-out days", () => {
+    expect(describeRelativeDay(new Date(2025, 8, 10), today)).toBe("woensdag");
+    expect(describeRelativeDay(new Date(2025, 8, 12), today)).toBe("vrijdag");
   });
 });
 

--- a/src/lib/training.ts
+++ b/src/lib/training.ts
@@ -75,6 +75,55 @@ export function defaultSeasonWindow(): { from: string; to: string } {
 }
 
 /**
+ * The next training date on or after `from`, looking up to 14 days ahead.
+ * Returns `null` if no Wed/Fri falls in that window (effectively never, but
+ * callers should still handle it).
+ *
+ * Inclusive of `from` itself: if `from` is a Wed or Fri, that same day is the
+ * answer. The bucket logic upstream already excludes mid-range users, so an
+ * encourage-bucket player on a training-day morning gets a "vandaag" nudge,
+ * which is the desired behavior.
+ */
+export function nextTrainingDate(from: Date = new Date()): Date | null {
+  for (let i = 0; i < 14; i++) {
+    const d = new Date(from.getFullYear(), from.getMonth(), from.getDate() + i);
+    const wd = d.getDay();
+    if (wd === 3 || wd === 5) return d;
+  }
+  return null;
+}
+
+const NL_DAY_NAMES = [
+  "zondag",
+  "maandag",
+  "dinsdag",
+  "woensdag",
+  "donderdag",
+  "vrijdag",
+  "zaterdag",
+];
+
+/**
+ * Returns a Dutch day-of-week label for `date`, relative to `today`. Same day
+ * → `"vandaag"`, next day → `"morgen"`, day-after → `"overmorgen"`, otherwise
+ * the literal weekday name (e.g. `"woensdag"`). Comparison is on the calendar
+ * day, ignoring time-of-day.
+ */
+export function describeRelativeDay(
+  date: Date,
+  today: Date = new Date(),
+): string {
+  const d0 = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const d1 = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const dayMs = 24 * 60 * 60 * 1000;
+  const diff = Math.round((d1.getTime() - d0.getTime()) / dayMs);
+  if (diff === 0) return "vandaag";
+  if (diff === 1) return "morgen";
+  if (diff === 2) return "overmorgen";
+  return NL_DAY_NAMES[date.getDay()];
+}
+
+/**
  * Splits training session dates (YYYY-MM-DD) into recent past, older past, and today-or-future
  * for compact trainer UI. Dates are compared as strings on the calendar day.
  *

--- a/src/lib/training.ts
+++ b/src/lib/training.ts
@@ -75,20 +75,63 @@ export function defaultSeasonWindow(): { from: string; to: string } {
 }
 
 /**
- * The next training date on or after `from`, looking up to 14 days ahead.
- * Returns `null` if no Wed/Fri falls in that window (effectively never, but
- * callers should still handle it).
+ * Wall-clock training start times, keyed by `Date.getDay()` weekday number
+ * (0=Sun, 3=Wed, 5=Fri). Interpreted in Europe/Amsterdam.
+ */
+export const TRAINING_START_BY_WEEKDAY: Record<
+  number,
+  { hour: number; minute: number }
+> = {
+  3: { hour: 19, minute: 20 },
+  5: { hour: 20, minute: 15 },
+};
+
+const AMSTERDAM_TZ = "Europe/Amsterdam";
+
+/**
+ * Returns the hour and minute (24h) of `d` in Europe/Amsterdam, regardless of
+ * the server's timezone. Used to decide whether a same-day training is still
+ * joinable.
+ */
+function amsterdamHourMinute(d: Date): { hour: number; minute: number } {
+  const fmt = new Intl.DateTimeFormat("en-GB", {
+    timeZone: AMSTERDAM_TZ,
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  const parts = fmt.formatToParts(d);
+  const hour = Number(parts.find((p) => p.type === "hour")?.value ?? "0");
+  const minute = Number(parts.find((p) => p.type === "minute")?.value ?? "0");
+  return { hour, minute };
+}
+
+/**
+ * The next *joinable* training date on or after `from`, looking up to 14 days
+ * ahead. Returns `null` if none is found (effectively never).
  *
- * Inclusive of `from` itself: if `from` is a Wed or Fri, that same day is the
- * answer. The bucket logic upstream already excludes mid-range users, so an
- * encourage-bucket player on a training-day morning gets a "vandaag" nudge,
- * which is the desired behavior.
+ * Inclusive of `from`'s calendar day, but only if the Amsterdam wall-clock
+ * time of `from` is still before that day's training start (Wed 19:20, Fri
+ * 20:15). After the start time, the same day is skipped — a "kom je vandaag"
+ * nudge would arrive too late.
  */
 export function nextTrainingDate(from: Date = new Date()): Date | null {
+  const { hour, minute } = amsterdamHourMinute(from);
   for (let i = 0; i < 14; i++) {
-    const d = new Date(from.getFullYear(), from.getMonth(), from.getDate() + i);
-    const wd = d.getDay();
-    if (wd === 3 || wd === 5) return d;
+    const candidate = new Date(
+      from.getFullYear(),
+      from.getMonth(),
+      from.getDate() + i,
+    );
+    const wd = candidate.getDay();
+    const start = TRAINING_START_BY_WEEKDAY[wd];
+    if (!start) continue;
+    if (i === 0) {
+      const past =
+        hour > start.hour || (hour === start.hour && minute >= start.minute);
+      if (past) continue;
+    }
+    return candidate;
   }
   return null;
 }

--- a/src/lib/training.ts
+++ b/src/lib/training.ts
@@ -88,22 +88,39 @@ export const TRAINING_START_BY_WEEKDAY: Record<
 
 const AMSTERDAM_TZ = "Europe/Amsterdam";
 
+function numberPart(parts: Intl.DateTimeFormatPart[], type: string): number {
+  return Number(parts.find((p) => p.type === type)?.value ?? "0");
+}
+
 /**
- * Returns the hour and minute (24h) of `d` in Europe/Amsterdam, regardless of
+ * Returns calendar and time parts for `d` in Europe/Amsterdam, regardless of
  * the server's timezone. Used to decide whether a same-day training is still
  * joinable.
  */
-function amsterdamHourMinute(d: Date): { hour: number; minute: number } {
+function amsterdamDateTimeParts(d: Date): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+} {
   const fmt = new Intl.DateTimeFormat("en-GB", {
     timeZone: AMSTERDAM_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
     hourCycle: "h23",
   });
   const parts = fmt.formatToParts(d);
-  const hour = Number(parts.find((p) => p.type === "hour")?.value ?? "0");
-  const minute = Number(parts.find((p) => p.type === "minute")?.value ?? "0");
-  return { hour, minute };
+  return {
+    year: numberPart(parts, "year"),
+    month: numberPart(parts, "month"),
+    day: numberPart(parts, "day"),
+    hour: numberPart(parts, "hour"),
+    minute: numberPart(parts, "minute"),
+  };
 }
 
 /**
@@ -116,13 +133,9 @@ function amsterdamHourMinute(d: Date): { hour: number; minute: number } {
  * nudge would arrive too late.
  */
 export function nextTrainingDate(from: Date = new Date()): Date | null {
-  const { hour, minute } = amsterdamHourMinute(from);
+  const { year, month, day, hour, minute } = amsterdamDateTimeParts(from);
   for (let i = 0; i < 14; i++) {
-    const candidate = new Date(
-      from.getFullYear(),
-      from.getMonth(),
-      from.getDate() + i,
-    );
+    const candidate = new Date(year, month - 1, day + i);
     const wd = candidate.getDay();
     const start = TRAINING_START_BY_WEEKDAY[wd];
     if (!start) continue;


### PR DESCRIPTION
## Summary

- New AI-written banner on `/attendance`: warm Dutch encouragement when the player's rolling 14-day training attendance is below 50%, a cheer when they were at every training (≥2). Mid-range and thin (<2 trainings scheduled) windows render nothing.
- Architecture mirrors the existing AI Product Manager flow: schema + module-level system prompt in `src/lib/ai/attendanceNudge.ts`, business logic + 24h KV cache in `src/lib/services/attendanceNudgeService.ts`, thin route at `/api/training/nudge`.
- Falls back to a static Dutch message on LLM failure so the page never renders an error state. Logged-out visitors short-circuit to `{ nudge: null }` before touching the DB.

## What's new for the user

- **<50% in last 14 days** → encourage banner, e.g. _"Druk gehad? Geen ramp. De bak ligt klaar — kom je weer aansluiten?"_
- **100% with ≥2 attended** → cheer banner, e.g. _"Twee weken full house — top."_
- Otherwise: nothing changes.

## Files

- `src/lib/ai/attendanceNudge.ts` (+test) — Zod schema + module-level system prompt + `generateAttendanceNudge()` (Claude Opus 4 via Vercel AI Gateway).
- `src/lib/services/attendanceNudgeService.ts` (+test) — pure `decideNudgeBucket()`, `computeRecentAttendance()`, `getOrCreateNudge()` with KV cache key `nudge:v1:<userId>:<YYYY-MM-DD>:<tone>:<n>of<m>`.
- `src/app/api/training/nudge/route.ts` — thin handler.
- `src/components/AttendanceNudge.tsx` (+test) — banner with `role="status"` and tone-keyed test IDs.
- `src/app/attendance/page.tsx` — mount the banner above the personal stats card.

## Verification (local)

- [x] `npm run lint` — clean (1 pre-existing warning in `src/types/ical.d.ts`).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 358/358 pass (26 new).
- [x] `npm run build` — green; `/api/training/nudge` registered as a dynamic route.
- [x] Smoke: dev server boots; unauthenticated `GET /api/training/nudge` returns `{"nudge":null}`; `/attendance` renders 200.

## Test plan (preview)

- [ ] Visit the preview URL while logged out → no nudge rendered, no errors in console.
- [ ] Log in as a user whose last-14-day attendance is <50% → encourage banner appears at the top of `/attendance`.
- [ ] Log in as a user with 100% attendance over the last 14 days (≥2 sessions) → cheer banner appears.
- [ ] Log in as a mid-range user → no banner.
- [ ] Toggle a training attendance via `/trainer/attendance/[date]` to flip the bucket → banner updates on next page load (cache key is bucket-keyed).
- [ ] If `BRAINTRUST_API_KEY` / AI Gateway is misconfigured on preview, the banner should still render the static Dutch fallback (graceful degrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Opmerkingen bij deze release

* **Nieuwe functies**
  * Gepersonaliseerde trainingsaanmoedigingen zichtbaar op de aanwezigheidsoverzichtpagina; berichten worden afgestemd op uw deelname van de afgelopen 14 dagen en geleverd in het Nederlands.
  * Nieuwe planningstools voor het bepalen van volgende trainingsdata en menselijke leesbare dagbeschrijvingen.

* **Tests**
  * Uitgebreide unit- en integratietests toegevoegd voor nudge-logica, AI-gegenereerde berichten en trainingsdatumberekeningen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->