### PR TITLE
feat: activeer Vercel Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@simplewebauthn/browser": "^13.3.0",
         "@simplewebauthn/server": "^13.3.0",
         "@tailwindcss/postcss": "^4.3.0",
+        "@vercel/speed-insights": "^2.0.0",
         "ai": "^6.0.190",
         "bcryptjs": "^3.0.3",
         "braintrust": "^3.11.0",
@@ -5246,6 +5247,44 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.0",
     "@tailwindcss/postcss": "^4.3.0",
+    "@vercel/speed-insights": "^2.0.0",
     "ai": "^6.0.190",
     "bcryptjs": "^3.0.3",
     "braintrust": "^3.11.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 import Providers from "../components/Providers";
 import BottomNav from "../components/BottomNav";
@@ -131,6 +132,7 @@ export default function RootLayout({
         `,
           }}
         />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Activeert [Vercel Speed Insights](https://vercel.com/docs/speed-insights) voor H3-Teamy door `@vercel/speed-insights` toe te voegen en de `SpeedInsights`-component in de root layout te mounten. Na deploy en het inschakelen in het Vercel-projectdashboard worden Core Web Vitals (LCP, FID, CLS, enz.) verzameld.

## Wijzigingen

- Dependency: `@vercel/speed-insights@^2`
- `src/app/layout.tsx`: import en `<SpeedInsights />` vóór `</body>`

## Vercel-dashboard (na merge/deploy)

1. Ga naar [Speed Insights — h3-teamy](https://vercel.com/guido-vermeulens-projects/h3-teamy/speed-insights)
2. Klik **Enable** als dat nog niet is gedaan
3. Na de volgende production/preview deploy verschijnen metrics zodra bezoekers de site gebruiken

## User-facing release (“Wat is nieuw”)

- [x] Nee — geen release richting eindgebruikers (alleen intern/technisch)

## Docs

- [x] Geen feature-docs nodig (standaard Vercel-integratie)

## Verificatie

- `npm run lint`
- `npx tsc --noEmit`
- `npx vitest run`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a460c08f-e267-4bc8-9e03-17e8ce68b8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a460c08f-e267-4bc8-9e03-17e8ce68b8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

