### PR TITLE
fix(training): new season 26 Aug 2026 – 7 Jul 2027 for attendance

### DIFF
--- a/src/lib/seasonConfig.ts
+++ b/src/lib/seasonConfig.ts
@@ -1,0 +1,9 @@
+/**
+ * Committed training season window (calendar dates, YYYY-MM-DD).
+ * Update each year when the new season starts; also set matching
+ * `SEASON_START` / `SEASON_END` (dd-mm-yyyy) in Vercel.
+ */
+export const CURRENT_SEASON = {
+  from: "2026-08-26",
+  to: "2027-07-07",
+} as const;

--- a/src/lib/training.test.ts
+++ b/src/lib/training.test.ts
@@ -139,12 +139,14 @@ describe("defaultSeasonWindow", () => {
 
   it("verlengt met een jaar als alleen SEASON_START gezet is", () => {
     vi.stubEnv("SEASON_START", "01-07-2025");
+    vi.stubEnv("SEASON_END", "");
     const w = defaultSeasonWindow();
     expect(w.from).toBe("2025-07-01");
     expect(w.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it("trekt een jaar terug als alleen SEASON_END gezet is", () => {
+    vi.stubEnv("SEASON_START", "");
     vi.stubEnv("SEASON_END", "30-06-2026");
     const w = defaultSeasonWindow();
     expect(w.to).toBe("2026-06-30");
@@ -156,6 +158,16 @@ describe("defaultSeasonWindow", () => {
     expect(w.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(w.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(w.from < w.to).toBe(true);
+  });
+
+  it("gebruikt committed season wanneer env-seizoen verlopen is", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 27)); // 2026-08-27
+    vi.stubEnv("SEASON_START", "19-09-2025");
+    vi.stubEnv("SEASON_END", "01-07-2026");
+    const w = defaultSeasonWindow();
+    expect(w).toEqual({ from: "2026-08-26", to: "2027-07-07" });
+    vi.useRealTimers();
   });
 });
 

--- a/src/lib/training.ts
+++ b/src/lib/training.ts
@@ -32,6 +32,26 @@ function addYears(date: Date, years: number): Date {
   return d;
 }
 
+import { CURRENT_SEASON } from "./seasonConfig";
+
+function resolveEnvSeasonWindow(): { from: string; to: string } | null {
+  const envStart = parseDdMmYyyy(process.env.SEASON_START);
+  const envEnd = parseDdMmYyyy(process.env.SEASON_END);
+
+  if (envStart && envEnd && envStart < envEnd) {
+    return { from: toYMD(envStart), to: toYMD(envEnd) };
+  }
+  if (envStart && !envEnd) {
+    const end = addYears(envStart, 1);
+    return { from: toYMD(envStart), to: toYMD(end) };
+  }
+  if (!envStart && envEnd) {
+    const start = addYears(envEnd, -1);
+    return { from: toYMD(start), to: toYMD(envEnd) };
+  }
+  return null;
+}
+
 export function generateTrainingDates(from: Date, to: Date): string[] {
   const dates: string[] = [];
   const start = new Date(from.getFullYear(), from.getMonth(), from.getDate());
@@ -46,19 +66,25 @@ export function generateTrainingDates(from: Date, to: Date): string[] {
 }
 
 export function defaultSeasonWindow(): { from: string; to: string } {
-  const envStart = parseDdMmYyyy(process.env.SEASON_START);
-  const envEnd = parseDdMmYyyy(process.env.SEASON_END);
+  const today = toYMD(new Date());
+  const envWindow = resolveEnvSeasonWindow();
+  const envStartSet = Boolean(parseDdMmYyyy(process.env.SEASON_START));
+  const envEndSet = Boolean(parseDdMmYyyy(process.env.SEASON_END));
 
-  if (envStart && envEnd && envStart < envEnd) {
-    return { from: toYMD(envStart), to: toYMD(envEnd) };
+  if (envWindow) {
+    if (
+      envStartSet &&
+      envEndSet &&
+      today > envWindow.to &&
+      today <= CURRENT_SEASON.to
+    ) {
+      return { from: CURRENT_SEASON.from, to: CURRENT_SEASON.to };
+    }
+    return envWindow;
   }
-  if (envStart && !envEnd) {
-    const end = addYears(envStart, 1);
-    return { from: toYMD(envStart), to: toYMD(end) };
-  }
-  if (!envStart && envEnd) {
-    const start = addYears(envEnd, -1);
-    return { from: toYMD(start), to: toYMD(envEnd) };
+
+  if (today >= CURRENT_SEASON.from && today <= CURRENT_SEASON.to) {
+    return { from: CURRENT_SEASON.from, to: CURRENT_SEASON.to };
   }
 
   // Fallback: Season runs July 1st to July 1st next year


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production still used `SEASON_START` / `SEASON_END` for the previous season (ending 1 July 2026), so after the summer break trainers had no upcoming Wednesday/Friday sessions for attendance.

This PR commits the new window (**26 Aug 2026 – 7 Jul 2027**, 91 sessions) and updates `defaultSeasonWindow()` so when both env bounds are set but that season has ended, the app uses the committed current season.

## User-facing release (“Wat is nieuw”)

- [x] Nee — geen release richting eindgebruikers (alleen intern/technisch)

## Docs

- [x] Nee — geen doc-update nodig (bestaand `SEASON_*` mechanisme)

## Vercel follow-up

Na merge, zet op **h3-teamy** (Production, Preview, Development):

| Variable | Value |
|----------|-------|
| `SEASON_START` | `26-08-2026` |
| `SEASON_END` | `07-07-2027` |

Formaat `dd-mm-yyyy`. Redeploy production zodat env en code gelijk blijven.

## Verification

- `npx vitest run src/lib/training.test.ts` — 24 passed
- `GET /api/training/sessions` lokaal met oude prod-env → 91 sessies, `2026-08-26` … `2027-07-07`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b40b4e40-f859-4f2a-9620-2183b1c22937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b40b4e40-f859-4f2a-9620-2183b1c22937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

