### PR TITLE
fix(auth): password-reset emails when Resend is configured

### DIFF
--- a/docs/tech/password-reset/README.md
+++ b/docs/tech/password-reset/README.md
@@ -12,7 +12,7 @@ Generates a short-lived token (Redis or in-memory) and emails a link to set a ne
 
 ## Environment
 
-- `ENABLE_EMAIL=true`
+- `ENABLE_EMAIL=true` (optional — auto-enables when `RESEND_API_KEY`, `EMAIL_FROM`, and `APP_URL` are set)
 - `RESEND_API_KEY`
 - `APP_URL`
 - `EMAIL_FROM` (verified sender in Resend)

--- a/src/app/api/auth/password/reset-request/route.ts
+++ b/src/app/api/auth/password/reset-request/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
+import { getOutboundEmailConfig } from "../../../../../lib/emailEnv";
 import { createPasswordResetToken } from "../../../../../lib/kv";
 
 export async function POST(req: NextRequest) {
@@ -8,41 +9,59 @@ export async function POST(req: NextRequest) {
     async (span) => {
       try {
         const { email } = await req.json().catch(() => ({ email: "" }));
-        span.setAttribute("email_present", Boolean(email));
-        if (!email) return NextResponse.json({ ok: true });
+        const normalizedEmail = String(email).trim().toLowerCase();
+        span.setAttribute("email_present", Boolean(normalizedEmail));
+        if (!normalizedEmail) return NextResponse.json({ ok: true });
 
-        const { ok, token } = await createPasswordResetToken(
-          String(email).toLowerCase(),
+        const { ok, token, recipientEmail } = await createPasswordResetToken(
+          normalizedEmail,
         );
-        const enableEmail = process.env.ENABLE_EMAIL === "true";
-        const appUrl = process.env.APP_URL || "";
-        const fromEmail = process.env.EMAIL_FROM || "";
+        const emailConfig = getOutboundEmailConfig();
 
-        if (enableEmail && process.env.RESEND_API_KEY && appUrl && fromEmail) {
+        if (token && emailConfig) {
           try {
             const { Resend } = await import("resend");
-            const resend = new Resend(process.env.RESEND_API_KEY);
-            if (token) {
-              const url = `${appUrl.replace(/\/$/, "")}/reset/${encodeURIComponent(token)}`;
-              await resend.emails.send({
-                from: fromEmail,
-                to: email,
-                subject: "Reset your password",
-                html: `<p>Click the link below to reset your password:</p><p><a href="${url}">${url}</a></p><p>This link expires in 15 minutes.</p>`,
-              });
+            const resend = new Resend(emailConfig.resendApiKey);
+            const url = `${emailConfig.appUrl}/reset/${encodeURIComponent(token)}`;
+            const result = await resend.emails.send({
+              from: emailConfig.fromEmail,
+              to: recipientEmail ?? normalizedEmail,
+              subject: "Wachtwoord resetten — H3 Teamy",
+              html: `<p>Je hebt gevraagd om je wachtwoord te resetten voor H3 Teamy.</p><p><a href="${url}">Klik hier om een nieuw wachtwoord te kiezen</a></p><p>Of kopieer deze link: ${url}</p><p>De link is 15 minuten geldig.</p><p>Heb je dit niet aangevraagd? Negeer deze e-mail.</p>`,
+            });
+            if (result.error) {
+              Sentry.captureException(
+                new Error(result.error.message || "resend_send_failed"),
+                {
+                  tags: { context: "password_reset_email" },
+                  extra: { resend: result.error },
+                },
+              );
             }
-          } catch (e) {
-            Sentry.captureException(e);
+          } catch (error: unknown) {
+            Sentry.captureException(error, {
+              tags: { context: "password_reset_email" },
+            });
           }
+        } else if (token && !emailConfig) {
+          Sentry.captureMessage("password_reset_email_not_configured", {
+            level: "warning",
+            tags: { context: "password_reset_email" },
+            extra: {
+              enableEmailFlag: process.env.ENABLE_EMAIL ?? null,
+              hasResendKey: Boolean(process.env.RESEND_API_KEY),
+              hasFrom: Boolean(process.env.EMAIL_FROM),
+              hasAppUrl: Boolean(process.env.APP_URL),
+            },
+          });
         }
 
-        // In dev, return token to make testing simple
-        const body: any = { ok };
+        const body: { ok: boolean; token?: string } = { ok };
         if (process.env.NODE_ENV !== "production") body.token = token;
         return NextResponse.json(body);
-      } catch (error) {
-        Sentry.captureException(error as any);
-        return NextResponse.json({ ok: true }); // generic success to avoid enumeration
+      } catch (error: unknown) {
+        Sentry.captureException(error);
+        return NextResponse.json({ ok: true });
       }
     },
   );

--- a/src/lib/emailEnv.test.ts
+++ b/src/lib/emailEnv.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getOutboundEmailConfig, isOutboundEmailEnabled } from "./emailEnv";
+
+describe("isOutboundEmailEnabled", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("is false when ENABLE_EMAIL=false", () => {
+    vi.stubEnv("ENABLE_EMAIL", "false");
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_FROM", "noreply@example.com");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+    expect(isOutboundEmailEnabled()).toBe(false);
+  });
+
+  it("is true when ENABLE_EMAIL=true and Resend is configured", () => {
+    vi.stubEnv("ENABLE_EMAIL", "true");
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_FROM", "noreply@example.com");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+    expect(isOutboundEmailEnabled()).toBe(true);
+  });
+
+  it("auto-enables when unset and Resend is fully configured", () => {
+    vi.stubEnv("ENABLE_EMAIL", "");
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_FROM", "noreply@example.com");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+    expect(isOutboundEmailEnabled()).toBe(true);
+  });
+
+  it("is false when unset and Resend is incomplete", () => {
+    vi.stubEnv("ENABLE_EMAIL", "");
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_FROM", "");
+    vi.stubEnv("APP_URL", "https://teamy.example");
+    expect(isOutboundEmailEnabled()).toBe(false);
+  });
+});
+
+describe("getOutboundEmailConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns trimmed config when enabled", () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    vi.stubEnv("EMAIL_FROM", "noreply@example.com");
+    vi.stubEnv("APP_URL", "https://teamy.example/");
+    expect(getOutboundEmailConfig()).toEqual({
+      resendApiKey: "re_test",
+      fromEmail: "noreply@example.com",
+      appUrl: "https://teamy.example",
+    });
+  });
+});

--- a/src/lib/emailEnv.ts
+++ b/src/lib/emailEnv.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether outbound email (Resend) is enabled for password reset and similar flows.
+ * Explicit `ENABLE_EMAIL=false` disables; `true` forces on; when unset, auto-enables
+ * when Resend + sender + APP_URL are configured.
+ */
+export function isOutboundEmailEnabled(): boolean {
+  const flag = process.env.ENABLE_EMAIL?.trim().toLowerCase();
+  if (flag === "false") return false;
+  if (flag === "true") return true;
+  return Boolean(
+    process.env.RESEND_API_KEY &&
+      process.env.EMAIL_FROM?.trim() &&
+      process.env.APP_URL?.trim(),
+  );
+}
+
+/** Resend sender, app base URL, and API key when outbound email is enabled. */
+export function getOutboundEmailConfig(): {
+  resendApiKey: string;
+  fromEmail: string;
+  appUrl: string;
+} | null {
+  if (!isOutboundEmailEnabled()) return null;
+  const resendApiKey = process.env.RESEND_API_KEY?.trim() ?? "";
+  const fromEmail = process.env.EMAIL_FROM?.trim() ?? "";
+  const appUrl = process.env.APP_URL?.trim().replace(/\/$/, "") ?? "";
+  if (!resendApiKey || !fromEmail || !appUrl) return null;
+  return { resendApiKey, fromEmail, appUrl };
+}

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -387,10 +387,15 @@ function makeToken(): string {
 
 export async function createPasswordResetToken(
   email: string,
-): Promise<{ ok: boolean; token?: string }> {
+): Promise<{ ok: boolean; token?: string; recipientEmail?: string }> {
   const p = await getPrisma();
-  const user = p ? await p.user.findFirst({ where: { email } }) : null;
-  if (!user) return { ok: true }; // do not leak existence
+  const user = p
+    ? await p.user.findFirst({
+        where: { email: { equals: email, mode: "insensitive" } },
+        select: { id: true, email: true },
+      })
+    : null;
+  if (!user) return { ok: true };
   const token = makeToken();
   const key = `pwreset:${token}`;
   const redis = await getRedis();
@@ -401,7 +406,7 @@ export async function createPasswordResetToken(
     memoryJson.set(key, JSON.stringify({ userId: user.id }));
     memoryTtl.set(key, Date.now() + ttlSec * 1000);
   }
-  return { ok: true, token };
+  return { ok: true, token, recipientEmail: user.email ?? email };
 }
 
 export async function redeemPasswordResetToken(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tycho (`tycho.veens@gmail.com`) used “wachtwoord vergeten” but received no email. Production logged successful `POST /api/auth/password/reset-request` (200) and created reset tokens, but **no mail was sent** because `ENABLE_EMAIL` was unset while the route only sends when `ENABLE_EMAIL === "true"`. Resend (`RESEND_API_KEY`, `EMAIL_FROM`, `APP_URL`) is configured and sending works.

## Fix

- Auto-enable outbound email when Resend + sender + `APP_URL` are set (unless `ENABLE_EMAIL=false`).
- Dutch password-reset email subject/body.
- Case-insensitive email lookup for token creation; send to canonical DB email.
- Sentry warning when email is skipped (misconfig) or Resend returns an error.

## User-facing release

- [x] Nee — bugfix, geen tour/changelog

## After merge

Ask Tycho to use **wachtwoord vergeten** again with `tycho.veens@gmail.com`. Optionally set `ENABLE_EMAIL=true` on Vercel for explicit control.

## Verification

- `npx vitest run src/lib/emailEnv.test.ts` — 5 passed
- Resend delivery test to `delivered@resend.dev` succeeded with production credentials
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b40b4e40-f859-4f2a-9620-2183b1c22937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b40b4e40-f859-4f2a-9620-2183b1c22937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nieuwe functies**
  * Uitgaande e-mail wordt automatisch ingeschakeld wanneer de vereiste Resend-configuratie compleet is.
  * Wachtwoordresetmails gebruiken genormaliseerde e-mailadressen en de juiste ontvangergegevens.
  * Resetmails bevatten bijgewerkte Nederlandstalige inhoud en configuratie voor de applicatie-URL.

* **Bugfixes**
  * Ontbrekende e-mailconfiguratie en verzendfouten worden afzonderlijk verwerkt zonder onnodige foutinformatie aan gebruikers te tonen.
  * E-mailadressen worden voortaan consistent getrimd en naar kleine letters omgezet.

* **Documentatie**
  * De configuratie voor uitgaande e-mail beschrijft nu duidelijk dat inschakeling optioneel en automatisch mogelijk is.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->