### PR TITLE
fix(auth): shared KV store for password-reset tokens (expired link bug)

### DIFF
--- a/src/lib/kv.passwordReset.test.ts
+++ b/src/lib/kv.passwordReset.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as Sentry from "@sentry/nextjs";
 
 vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
@@ -81,6 +80,9 @@ describe("password reset token storage", () => {
     );
     expect(redeemed.ok).toBe(true);
     expect(mockUserUpdate).toHaveBeenCalled();
-    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalled();
+    expect(
+      [...store.keys()].some((key) => key.startsWith("pwreset:")),
+    ).toBe(false);
   });
 });

--- a/src/lib/kv.passwordReset.test.ts
+++ b/src/lib/kv.passwordReset.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Sentry from "@sentry/nextjs";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockUserFindFirst = vi.fn();
+const mockUserUpdate = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  vi.stubEnv("DATABASE_URL", "postgresql://test:test@localhost:5432/test");
+  vi.stubEnv("KV_REST_API_URL", "https://kv.example.com");
+  vi.stubEnv("KV_REST_API_TOKEN", "token");
+  vi.doMock("./db", () => ({
+    prisma: {
+      user: {
+        findFirst: mockUserFindFirst,
+        update: mockUserUpdate,
+      },
+    },
+  }));
+  vi.doMock("ioredis", () => ({
+    default: vi.fn().mockImplementation(() => ({
+      connect: vi.fn().mockRejectedValue(new Error("Redis down")),
+      disconnect: vi.fn(),
+    })),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("password reset token storage", () => {
+  it("stores and redeems via KV REST when Redis is unavailable", async () => {
+    mockUserFindFirst.mockResolvedValue({
+      id: "user_test",
+      email: "grvermeulen@gmail.com",
+    });
+    mockUserUpdate.mockResolvedValue({});
+
+    const store = new Map<string, string>();
+    vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/set/")) {
+        const match = url.match(/\/set\/([^/]+)\/([^?]+)/);
+        if (match) {
+          store.set(decodeURIComponent(match[1]), decodeURIComponent(match[2]));
+        }
+        return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+      }
+      if (url.includes("/get/")) {
+        const match = url.match(/\/get\/([^/]+)/);
+        const key = match ? decodeURIComponent(match[1]) : "";
+        const val = store.get(key) ?? null;
+        return new Response(JSON.stringify({ result: val }), { status: 200 });
+      }
+      if (url.includes("/del/")) {
+        const match = url.match(/\/del\/([^/]+)/);
+        const key = match ? decodeURIComponent(match[1]) : "";
+        store.delete(key);
+        return new Response(JSON.stringify({ result: 1 }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const { createPasswordResetToken, redeemPasswordResetToken } = await import(
+      "./kv"
+    );
+    const created = await createPasswordResetToken("grvermeulen@gmail.com");
+    expect(created.token).toBeTruthy();
+
+    const redeemed = await redeemPasswordResetToken(
+      created.token!,
+      "newpassword123",
+    );
+    expect(redeemed.ok).toBe(true);
+    expect(mockUserUpdate).toHaveBeenCalled();
+    expect(vi.mocked(Sentry.captureException)).toHaveBeenCalled();
+  });
+});

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -303,8 +303,13 @@ export async function kvSetJson(key: string, value: any): Promise<void> {
 export async function kvDelete(key: string): Promise<void> {
   const redis = await getRedis();
   if (redis) {
-    await redis.del(key).catch(() => {});
-    return;
+    try {
+      await redis.del(key);
+      return;
+    } catch (error: unknown) {
+      captureKvCacheError(error, "kvDelete_redis");
+      markRedisUnavailable();
+    }
   }
   if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
     await fetch(
@@ -315,11 +320,96 @@ export async function kvDelete(key: string): Promise<void> {
           Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
         },
       },
-    ).catch(() => {});
+    ).catch((error: unknown) => {
+      captureKvCacheError(error, "kvDelete_rest");
+    });
     return;
   }
   memoryJson.delete(key);
   memoryTtl.delete(key);
+}
+
+function kvRestBaseUrl(): string | null {
+  const url = process.env.KV_REST_API_URL;
+  return url ? url.replace(/\/$/, "") : null;
+}
+
+/** Redis-first string storage with TTL; falls back to KV REST then in-memory. */
+async function kvSetStringWithTtl(
+  key: string,
+  value: string,
+  ttlSec: number,
+): Promise<boolean> {
+  const redis = await getRedis();
+  if (redis) {
+    try {
+      await redis.set(key, value, "EX", ttlSec);
+      return true;
+    } catch (error: unknown) {
+      captureKvCacheError(error, "kvSetStringWithTtl_redis");
+      markRedisUnavailable();
+    }
+  }
+  const restBase = kvRestBaseUrl();
+  if (restBase && process.env.KV_REST_API_TOKEN) {
+    try {
+      const res = await fetch(
+        `${restBase}/set/${encodeURIComponent(key)}/${encodeURIComponent(value)}?EX=${ttlSec}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
+          },
+          cache: "no-store",
+        },
+      );
+      if (res.ok) return true;
+    } catch (error: unknown) {
+      captureKvCacheError(error, "kvSetStringWithTtl_rest");
+    }
+  }
+  memoryJson.set(key, value);
+  memoryTtl.set(key, Date.now() + ttlSec * 1000);
+  return process.env.NODE_ENV !== "production";
+}
+
+/** Redis-first string lookup; falls back to KV REST then in-memory TTL map. */
+async function kvGetString(key: string): Promise<string | null> {
+  const redis = await getRedis();
+  if (redis) {
+    try {
+      const val = (await redis.get(key)) as string | null;
+      return val ?? null;
+    } catch (error: unknown) {
+      captureKvCacheError(error, "kvGetString_redis");
+      markRedisUnavailable();
+    }
+  }
+  const restBase = kvRestBaseUrl();
+  if (restBase && process.env.KV_REST_API_TOKEN) {
+    try {
+      const res = await fetch(`${restBase}/get/${encodeURIComponent(key)}`, {
+        headers: {
+          Authorization: `Bearer ${process.env.KV_REST_API_TOKEN}`,
+        },
+        cache: "no-store",
+      });
+      if (!res.ok) return null;
+      const data = await res.json().catch(() => ({}) as { result?: string | null });
+      const val = data?.result;
+      return typeof val === "string" ? val : null;
+    } catch (error: unknown) {
+      captureKvCacheError(error, "kvGetString_rest");
+    }
+  }
+  if (process.env.NODE_ENV === "production") return null;
+  const exp = memoryTtl.get(key);
+  if (typeof exp === "number" && Date.now() > exp) {
+    memoryJson.delete(key);
+    memoryTtl.delete(key);
+    return null;
+  }
+  return memoryJson.get(key) ?? null;
 }
 
 const WEBAUTHN_CHALLENGE_TTL_SEC = 5 * 60;
@@ -393,22 +483,7 @@ function makeToken(): string {
 
 async function hasActivePasswordResetPending(userId: string): Promise<boolean> {
   const pendingKey = passwordResetPendingKey(userId);
-  const redis = await getRedis();
-  if (redis) {
-    try {
-      return Boolean(await redis.get(pendingKey));
-    } catch (error: unknown) {
-      captureKvCacheError(error, "password_reset_pending_get");
-      return false;
-    }
-  }
-  const exp = memoryTtl.get(pendingKey);
-  if (typeof exp === "number" && Date.now() > exp) {
-    memoryJson.delete(pendingKey);
-    memoryTtl.delete(pendingKey);
-    return false;
-  }
-  return memoryJson.has(pendingKey);
+  return Boolean(await kvGetString(pendingKey));
 }
 
 async function setPasswordResetPending(
@@ -416,32 +491,12 @@ async function setPasswordResetPending(
   ttlSec: number,
 ): Promise<boolean> {
   const pendingKey = passwordResetPendingKey(userId);
-  const redis = await getRedis();
-  if (redis) {
-    try {
-      await redis.set(pendingKey, "1", "EX", ttlSec);
-      return true;
-    } catch (error: unknown) {
-      captureKvCacheError(error, "password_reset_pending_set");
-      return false;
-    }
-  }
-  memoryJson.set(pendingKey, "1");
-  memoryTtl.set(pendingKey, Date.now() + ttlSec * 1000);
-  return true;
+  return kvSetStringWithTtl(pendingKey, "1", ttlSec);
 }
 
 async function clearPasswordResetPending(userId: string): Promise<void> {
   const pendingKey = passwordResetPendingKey(userId);
-  const redis = await getRedis();
-  if (redis) {
-    await redis.del(pendingKey).catch((error: unknown) => {
-      captureKvCacheError(error, "password_reset_pending_del");
-    });
-    return;
-  }
-  memoryJson.delete(pendingKey);
-  memoryTtl.delete(pendingKey);
+  await kvDelete(pendingKey);
 }
 
 export async function createPasswordResetToken(
@@ -465,20 +520,13 @@ export async function createPasswordResetToken(
   }
   const token = makeToken();
   const key = passwordResetRedisKey(token);
-  const redis = await getRedis();
   const ttlSec = PASSWORD_RESET_TTL_SEC;
-  if (redis) {
-    try {
-      await redis.set(key, user.id, "EX", ttlSec);
-      await setPasswordResetPending(user.id, ttlSec);
-    } catch (error: unknown) {
-      captureKvCacheError(error, "password_reset_set");
-      return { ok: true };
-    }
-  } else {
-    memoryJson.set(key, JSON.stringify({ userId: user.id }));
-    memoryTtl.set(key, Date.now() + ttlSec * 1000);
-    await setPasswordResetPending(user.id, ttlSec);
+  const stored = await kvSetStringWithTtl(key, user.id, ttlSec);
+  if (!stored) return { ok: true };
+  const pendingSet = await setPasswordResetPending(user.id, ttlSec);
+  if (!pendingSet) {
+    await kvDelete(key);
+    return { ok: true };
   }
   return { ok: true, token, recipientEmail: user.email ?? email };
 }
@@ -491,28 +539,14 @@ export async function redeemPasswordResetToken(
   if (!normalizedToken || !newPassword || newPassword.length < 8)
     return { ok: false, error: "invalid" };
   const key = passwordResetRedisKey(normalizedToken);
-  const redis = await getRedis();
-  let userId: string | null = null;
-  if (redis) {
+  let userId: string | null = await kvGetString(key);
+  if (userId?.startsWith("{")) {
     try {
-      userId = (await redis.get(key)) as string | null;
-    } catch (error: unknown) {
-      captureKvCacheError(error, "password_reset_get");
-      return { ok: false, error: "db_unavailable" };
-    }
-  } else {
-    const exp = memoryTtl.get(key);
-    if (typeof exp === "number" && Date.now() > exp) {
-      memoryJson.delete(key);
-      memoryTtl.delete(key);
-    }
-    const val = memoryJson.get(key);
-    if (val) {
-      try {
-        userId = JSON.parse(val).userId as string;
-      } catch {
-        userId = null;
-      }
+      const parsed = JSON.parse(userId) as { userId?: string };
+      userId =
+        typeof parsed.userId === "string" ? parsed.userId : null;
+    } catch {
+      userId = null;
     }
   }
   if (!userId) return { ok: false, error: "invalid_or_expired" };
@@ -522,12 +556,7 @@ export async function redeemPasswordResetToken(
   await p.user
     .update({ where: { id: userId }, data: { passwordHash: hash } })
     .catch(() => null);
-  if (redis) {
-    await redis.del(key).catch(() => {});
-  } else {
-    memoryJson.delete(key);
-    memoryTtl.delete(key);
-  }
+  await kvDelete(key);
   await clearPasswordResetPending(userId);
   return { ok: true };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production logs show reset links failing within seconds (not after the 60-minute TTL). Example for `grvermeulen@gmail.com`:

- `17:01:13` — `POST /api/auth/password/reset-request` → 200
- `17:01:37` — `GET /reset/TMQ1J5VD` → 200
- `17:01:46` — `POST /api/auth/password/reset-confirm` → **400** (`invalid_or_expired`)

Password-reset tokens were stored only via ioredis with a **per-lambda in-memory fallback**. When Redis was unavailable on the instance that created the token, the link was emailed but another serverless instance could not find the token on confirm.

## Fix

- Route password-reset token + pending-flag storage through shared helpers: Redis → KV REST → memory (dev only).
- In production, skip in-memory fallback so we never email a link that cannot be redeemed cross-instance.
- Improve `kvDelete` to fall through to KV REST when Redis fails.

## Testing

- `npx vitest run src/lib/kv.passwordReset.test.ts`
- Related kv tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b40b4e40-f859-4f2a-9620-2183b1c22937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b40b4e40-f859-4f2a-9620-2183b1c22937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Wachtwoordherstel blijft beschikbaar wanneer de primaire opslagverbinding tijdelijk niet bereikbaar is.
  - Opslagfouten worden beter afgehandeld en gemonitord.
  - In productie wordt geen schijnbaar succesvol wachtwoordherstel meer gemeld wanneer opslag niet beschikbaar is.
  - Bestaande wachtwoordhersteltokens blijven compatibel met oudere opslagindelingen.
  - Verlopen of gebruikte tokens worden betrouwbaar verwijderd na gebruik.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->