### PR TITLE
fix(auth): Postgres fallback for password-reset tokens

### DIFF
--- a/prisma/migrations/20260827190000_add_password_reset_token/migration.sql
+++ b/prisma/migrations/20260827190000_add_password_reset_token/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("token")
+);
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,20 @@ model User {
   attendances Attendance[]
   feedback  Feedback[]
   passkeys  Passkey[]
+  passwordResetTokens PasswordResetToken[]
+}
+
+/** Short-lived wachtwoord-reset token (KV-fallback in Postgres). */
+model PasswordResetToken {
+  token     String   @id
+  userId    String
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 /** WebAuthn-passkey (Touch ID, Face ID, Windows Hello, enz.) gekoppeld aan een gebruiker. */

--- a/src/lib/kv.passwordReset.test.ts
+++ b/src/lib/kv.passwordReset.test.ts
@@ -6,6 +6,10 @@ vi.mock("@sentry/nextjs", () => ({
 
 const mockUserFindFirst = vi.fn();
 const mockUserUpdate = vi.fn();
+const mockPasswordResetDeleteMany = vi.fn();
+const mockPasswordResetCreate = vi.fn();
+const mockPasswordResetFindUnique = vi.fn();
+const mockPasswordResetCount = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -19,6 +23,12 @@ beforeEach(() => {
       user: {
         findFirst: mockUserFindFirst,
         update: mockUserUpdate,
+      },
+      passwordResetToken: {
+        deleteMany: mockPasswordResetDeleteMany,
+        create: mockPasswordResetCreate,
+        findUnique: mockPasswordResetFindUnique,
+        count: mockPasswordResetCount,
       },
     },
   }));
@@ -42,7 +52,8 @@ describe("password reset token storage", () => {
       email: "grvermeulen@gmail.com",
     });
     mockUserUpdate.mockResolvedValue({});
-
+    mockPasswordResetDeleteMany.mockResolvedValue({ count: 0 });
+    mockPasswordResetCount.mockResolvedValue(0);
     const store = new Map<string, string>();
     vi.spyOn(global, "fetch").mockImplementation(async (input) => {
       const url = String(input);
@@ -84,5 +95,40 @@ describe("password reset token storage", () => {
     expect(
       [...store.keys()].some((key) => key.startsWith("pwreset:")),
     ).toBe(false);
+  });
+
+  it("stores and redeems via Postgres when KV and Redis are unavailable", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    mockUserFindFirst.mockResolvedValue({
+      id: "user_test",
+      email: "grvermeulen@gmail.com",
+    });
+    mockUserUpdate.mockResolvedValue({});
+    mockPasswordResetCount.mockResolvedValue(0);
+    mockPasswordResetDeleteMany.mockResolvedValue({ count: 0 });
+    mockPasswordResetCreate.mockResolvedValue({});
+    vi.spyOn(global, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    const { createPasswordResetToken, redeemPasswordResetToken } = await import(
+      "./kv"
+    );
+    const created = await createPasswordResetToken("grvermeulen@gmail.com");
+    expect(created.token).toBeTruthy();
+    expect(mockPasswordResetCreate).toHaveBeenCalled();
+
+    const normalized = created.token!.trim().toUpperCase();
+    mockPasswordResetFindUnique.mockResolvedValue({
+      token: normalized,
+      userId: "user_test",
+      expiresAt: new Date(Date.now() + 3600_000),
+    });
+
+    const redeemed = await redeemPasswordResetToken(
+      created.token!,
+      "newpassword123",
+    );
+    expect(redeemed.ok).toBe(true);
+    expect(mockUserUpdate).toHaveBeenCalled();
+    expect(mockPasswordResetDeleteMany).toHaveBeenCalled();
   });
 });

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -564,7 +564,85 @@ function makeToken(): string {
 
 async function hasActivePasswordResetPending(userId: string): Promise<boolean> {
   const pendingKey = passwordResetPendingKey(userId);
-  return Boolean(await kvGetString(pendingKey));
+  if (await kvGetString(pendingKey)) return true;
+  const p = await getPrisma();
+  if (!p) return false;
+  const active = await p.passwordResetToken.count({
+    where: { userId, expiresAt: { gt: new Date() } },
+  });
+  return active > 0;
+}
+
+async function storePasswordResetToken(
+  userId: string,
+  token: string,
+  ttlSec: number,
+): Promise<boolean> {
+  const normalizedToken = normalizePasswordResetToken(token);
+  const key = passwordResetRedisKey(normalizedToken);
+  const kvOk = await kvSetStringWithTtl(key, userId, ttlSec);
+  if (kvOk) return true;
+  const p = await getPrisma();
+  if (!p) return false;
+  try {
+    await p.passwordResetToken.deleteMany({ where: { userId } });
+    await p.passwordResetToken.create({
+      data: {
+        token: normalizedToken,
+        userId,
+        expiresAt: new Date(Date.now() + ttlSec * 1000),
+      },
+    });
+    return true;
+  } catch (error: unknown) {
+    captureKvCacheError(error, "password_reset_db_set");
+    return false;
+  }
+}
+
+async function lookupPasswordResetUserId(
+  normalizedToken: string,
+): Promise<string | null> {
+  const key = passwordResetRedisKey(normalizedToken);
+  let userId: string | null = await kvGetString(key);
+  if (userId?.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(userId) as { userId?: string };
+      userId =
+        typeof parsed.userId === "string" ? parsed.userId : null;
+    } catch {
+      userId = null;
+    }
+  }
+  if (userId) return userId;
+  const p = await getPrisma();
+  if (!p) return null;
+  const row = await p.passwordResetToken.findUnique({
+    where: { token: normalizedToken },
+  });
+  if (!row) return null;
+  if (row.expiresAt <= new Date()) {
+    await p.passwordResetToken
+      .delete({ where: { token: normalizedToken } })
+      .catch(() => null);
+    return null;
+  }
+  return row.userId;
+}
+
+async function clearPasswordResetToken(
+  normalizedToken: string,
+  userId: string,
+): Promise<void> {
+  const key = passwordResetRedisKey(normalizedToken);
+  await kvDelete(key);
+  await clearPasswordResetPending(userId);
+  const p = await getPrisma();
+  if (p) {
+    await p.passwordResetToken
+      .deleteMany({ where: { userId } })
+      .catch(() => null);
+  }
 }
 
 async function setPasswordResetPending(
@@ -600,9 +678,8 @@ export async function createPasswordResetToken(
     return { ok: true, suppressed: true };
   }
   const token = makeToken();
-  const key = passwordResetRedisKey(token);
   const ttlSec = PASSWORD_RESET_TTL_SEC;
-  const stored = await kvSetStringWithTtl(key, user.id, ttlSec);
+  const stored = await storePasswordResetToken(user.id, token, ttlSec);
   if (!stored) {
     Sentry.captureMessage("password_reset_storage_failed", {
       level: "error",
@@ -610,11 +687,7 @@ export async function createPasswordResetToken(
     });
     return { ok: true };
   }
-  const pendingSet = await setPasswordResetPending(user.id, ttlSec);
-  if (!pendingSet) {
-    await kvDelete(key);
-    return { ok: true };
-  }
+  await setPasswordResetPending(user.id, ttlSec);
   return { ok: true, token, recipientEmail: user.email ?? email };
 }
 
@@ -625,17 +698,7 @@ export async function redeemPasswordResetToken(
   const normalizedToken = normalizePasswordResetToken(token);
   if (!normalizedToken || !newPassword || newPassword.length < 8)
     return { ok: false, error: "invalid" };
-  const key = passwordResetRedisKey(normalizedToken);
-  let userId: string | null = await kvGetString(key);
-  if (userId?.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(userId) as { userId?: string };
-      userId =
-        typeof parsed.userId === "string" ? parsed.userId : null;
-    } catch {
-      userId = null;
-    }
-  }
+  const userId = await lookupPasswordResetUserId(normalizedToken);
   if (!userId) return { ok: false, error: "invalid_or_expired" };
   const p = await getPrisma();
   if (!p) return { ok: false, error: "db_unavailable" };
@@ -643,8 +706,7 @@ export async function redeemPasswordResetToken(
   await p.user
     .update({ where: { id: userId }, data: { passwordHash: hash } })
     .catch(() => null);
-  await kvDelete(key);
-  await clearPasswordResetPending(userId);
+  await clearPasswordResetToken(normalizedToken, userId);
   return { ok: true };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #584/#585, production `reset-request` still returns `{"ok":true}` without `sent` — no email. Redis Cloud `REDIS_URL` without KV REST cannot store tokens on serverless.

## Fix

- Add `PasswordResetToken` Prisma model + migration
- Fall back to Postgres when KV storage fails (create, lookup, redeem, duplicate guard)
- Migration already applied to production DB (`20260827190000_add_password_reset_token`)

## Testing

- `npx vitest run src/lib/kv.passwordReset.test.ts` (KV REST + Postgres paths)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b40b4e40-f859-4f2a-9620-2183b1c22937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b40b4e40-f859-4f2a-9620-2183b1c22937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

