### PR TITLE
refactor(auth): authorize trainers and admins by user ID

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -3,6 +3,11 @@ import * as Sentry from "@sentry/nextjs";
 import { z } from "zod";
 import { prisma } from "../../../../lib/db";
 import { getUserRolesBatch, setUserRoles, kvDelete } from "../../../../lib/kv";
+import {
+  getBootstrapAdminUserIds,
+  getBootstrapTrainerUserIds,
+  mergeUserRoles,
+} from "../../../../lib/roleEnv";
 import { isAdminUser } from "../../../../lib/trainer";
 import { displayName, hasUserIdentity } from "../../../../lib/userUtils";
 import { withDbRequestMetrics } from "../../../../lib/dbMetrics";
@@ -24,20 +29,13 @@ const UserRolesUpdateSchema = z.object({
   ),
 });
 
-function norm(s: string): string {
-  return (s || "").toLowerCase().trim();
-}
-
 export async function GET(req: NextRequest): Promise<NextResponse> {
   return withDbRequestMetrics("api/admin/users.GET", async () => {
     const { isAdmin } = await isAdminUser(req);
     if (!isAdmin)
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
-    const adminFull = norm(process.env.ADMIN_FULL_NAME || "");
-    const trainerNames = (process.env.TRAINER_FULL_NAMES || "")
-      .split(",")
-      .map(norm)
-      .filter(Boolean);
+    const envAdminIds = getBootstrapAdminUserIds();
+    const envTrainerIds = getBootstrapTrainerUserIds();
     let users: {
       id: string;
       firstName: string;
@@ -79,15 +77,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       const name = displayName(u);
       if (!name) continue;
       const kv = rolesByUserId[u.id] || { player: true };
-      const full =
-        `${(u.firstName || "").trim()} ${(u.lastName || "").trim()}`.trim();
-      const envAdmin = adminFull && norm(full) === adminFull;
-      const envTrainer = trainerNames.includes(norm(full));
-      const merged = {
-        player: kv.player !== false, // default true
-        trainer: Boolean(kv.trainer || envTrainer || envAdmin),
-        admin: Boolean(kv.admin || envAdmin),
-      };
+      const merged = mergeUserRoles(u.id, kv, envAdminIds, envTrainerIds);
       list.push({ id: u.id, name, roles: merged });
     }
     list.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/lib/roleBootstrapIds.ts
+++ b/src/lib/roleBootstrapIds.ts
@@ -1,0 +1,18 @@
+/**
+ * Default bootstrap role user IDs for De Rijn H3 Teamy production.
+ *
+ * Sourced from production `Attendance.markedBy` (users who registered training
+ * attendance) plus the project owner as admin. Override via `ADMIN_USER_IDS` /
+ * `TRAINER_USER_IDS` when needed (e.g. preview DB with different IDs).
+ */
+export const BOOTSTRAP_ADMIN_USER_IDS = [
+  "7651890a-f601-4711-9ff0-64da8ac052dc", // Guido Vermeulen
+] as const;
+
+export const BOOTSTRAP_TRAINER_USER_IDS = [
+  "cmexxuyh60001fvfvr4s97ee6", // Andre Staal
+  "cmjhqic0t0001dvv4zuy3pfae", // Henry Turkenburg
+  "cmesohfy00003peijgslbdi13", // Jan Willem Pater
+  "cmexwduu60001rngcifi58jtx", // Frank Volkering
+  "90a6f54a-8add-407a-b7f2-a9cfc87b75d7", // Harry Stens
+] as const;

--- a/src/lib/roleEnv.test.ts
+++ b/src/lib/roleEnv.test.ts
@@ -33,6 +33,17 @@ describe("bootstrap env role ids", () => {
     vi.stubEnv("TRAINER_USER_IDS", "trainer-1");
     expect(Array.from(getBootstrapTrainerUserIds())).toEqual(["trainer-1"]);
   });
+
+  it("falls back to committed bootstrap ids when env is unset", () => {
+    vi.stubEnv("ADMIN_USER_IDS", "");
+    vi.stubEnv("TRAINER_USER_IDS", "");
+    expect(Array.from(getBootstrapAdminUserIds())).toEqual([
+      "7651890a-f601-4711-9ff0-64da8ac052dc",
+    ]);
+    expect(Array.from(getBootstrapTrainerUserIds())).toContain(
+      "cmesohfy00003peijgslbdi13",
+    );
+  });
 });
 
 describe("mergeUserRoles", () => {

--- a/src/lib/roleEnv.test.ts
+++ b/src/lib/roleEnv.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getBootstrapAdminUserIds,
+  getBootstrapTrainerUserIds,
+  mergeUserRoles,
+  parseEnvUserIds,
+} from "./roleEnv";
+
+describe("parseEnvUserIds", () => {
+  it("parses comma-separated ids and trims whitespace", () => {
+    expect(
+      Array.from(parseEnvUserIds(" user-a , user-b,user-c ")),
+    ).toEqual(["user-a", "user-b", "user-c"]);
+  });
+
+  it("returns empty set for blank input", () => {
+    expect(parseEnvUserIds("").size).toBe(0);
+    expect(parseEnvUserIds(undefined).size).toBe(0);
+  });
+});
+
+describe("bootstrap env role ids", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads ADMIN_USER_IDS", () => {
+    vi.stubEnv("ADMIN_USER_IDS", "admin-1, admin-2");
+    expect(Array.from(getBootstrapAdminUserIds())).toEqual(["admin-1", "admin-2"]);
+  });
+
+  it("reads TRAINER_USER_IDS", () => {
+    vi.stubEnv("TRAINER_USER_IDS", "trainer-1");
+    expect(Array.from(getBootstrapTrainerUserIds())).toEqual(["trainer-1"]);
+  });
+});
+
+describe("mergeUserRoles", () => {
+  const envAdmins = new Set(["admin-env"]);
+  const envTrainers = new Set(["trainer-env"]);
+
+  it("defaults to player when kv is empty", () => {
+    expect(mergeUserRoles("other", {}, envAdmins, envTrainers)).toEqual({
+      admin: false,
+      trainer: false,
+      player: true,
+    });
+  });
+
+  it("applies bootstrap admin and trainer env ids", () => {
+    expect(
+      mergeUserRoles("admin-env", {}, envAdmins, envTrainers),
+    ).toEqual({ admin: true, trainer: true, player: true });
+    expect(
+      mergeUserRoles("trainer-env", {}, envAdmins, envTrainers),
+    ).toEqual({ admin: false, trainer: true, player: true });
+  });
+
+  it("merges kv flags with env ids", () => {
+    expect(
+      mergeUserRoles(
+        "kv-trainer",
+        { trainer: true },
+        envAdmins,
+        envTrainers,
+      ),
+    ).toEqual({ admin: false, trainer: true, player: true });
+  });
+});

--- a/src/lib/roleEnv.ts
+++ b/src/lib/roleEnv.ts
@@ -1,3 +1,8 @@
+import {
+  BOOTSTRAP_ADMIN_USER_IDS,
+  BOOTSTRAP_TRAINER_USER_IDS,
+} from "./roleBootstrapIds";
+
 /**
  * Parses a comma-separated list of user IDs from an environment variable.
  *
@@ -13,12 +18,24 @@ export function parseEnvUserIds(raw: string | undefined): Set<string> {
   return out;
 }
 
+function resolveBootstrapUserIds(
+  envRaw: string | undefined,
+  defaults: readonly string[],
+): Set<string> {
+  const fromEnv = parseEnvUserIds(envRaw);
+  if (fromEnv.size > 0) return fromEnv;
+  return new Set(defaults);
+}
+
 /**
  * Bootstrap admin user IDs from `ADMIN_USER_IDS` (comma-separated).
  * Used before the admin UI can assign roles in KV.
  */
 export function getBootstrapAdminUserIds(): Set<string> {
-  return parseEnvUserIds(process.env.ADMIN_USER_IDS);
+  return resolveBootstrapUserIds(
+    process.env.ADMIN_USER_IDS,
+    BOOTSTRAP_ADMIN_USER_IDS,
+  );
 }
 
 /**
@@ -26,7 +43,10 @@ export function getBootstrapAdminUserIds(): Set<string> {
  * Admins from {@link getBootstrapAdminUserIds} are implicitly trainers.
  */
 export function getBootstrapTrainerUserIds(): Set<string> {
-  return parseEnvUserIds(process.env.TRAINER_USER_IDS);
+  return resolveBootstrapUserIds(
+    process.env.TRAINER_USER_IDS,
+    BOOTSTRAP_TRAINER_USER_IDS,
+  );
 }
 
 /**

--- a/src/lib/roleEnv.ts
+++ b/src/lib/roleEnv.ts
@@ -1,0 +1,53 @@
+/**
+ * Parses a comma-separated list of user IDs from an environment variable.
+ *
+ * @param raw - Raw env value (e.g. `ADMIN_USER_IDS`).
+ * @returns Unique, trimmed user IDs.
+ */
+export function parseEnvUserIds(raw: string | undefined): Set<string> {
+  const out = new Set<string>();
+  for (const part of (raw || "").split(",")) {
+    const id = part.trim();
+    if (id) out.add(id);
+  }
+  return out;
+}
+
+/**
+ * Bootstrap admin user IDs from `ADMIN_USER_IDS` (comma-separated).
+ * Used before the admin UI can assign roles in KV.
+ */
+export function getBootstrapAdminUserIds(): Set<string> {
+  return parseEnvUserIds(process.env.ADMIN_USER_IDS);
+}
+
+/**
+ * Bootstrap trainer user IDs from `TRAINER_USER_IDS` (comma-separated).
+ * Admins from {@link getBootstrapAdminUserIds} are implicitly trainers.
+ */
+export function getBootstrapTrainerUserIds(): Set<string> {
+  return parseEnvUserIds(process.env.TRAINER_USER_IDS);
+}
+
+/**
+ * Merges KV role flags with bootstrap env user IDs for admin UI display.
+ *
+ * @param userId - User to resolve roles for.
+ * @param kv - Role flags from Redis/KV (defaults to player-only when absent).
+ * @param envAdminIds - Bootstrap admin IDs from env.
+ * @param envTrainerIds - Bootstrap trainer IDs from env.
+ */
+export function mergeUserRoles(
+  userId: string,
+  kv: { admin?: boolean; trainer?: boolean; player?: boolean },
+  envAdminIds: Set<string>,
+  envTrainerIds: Set<string>,
+): { admin: boolean; trainer: boolean; player: boolean } {
+  const envAdmin = envAdminIds.has(userId);
+  const envTrainer = envTrainerIds.has(userId) || envAdmin;
+  return {
+    player: kv.player !== false,
+    trainer: Boolean(kv.trainer || envTrainer),
+    admin: Boolean(kv.admin || envAdmin),
+  };
+}

--- a/src/lib/trainer.test.ts
+++ b/src/lib/trainer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as Sentry from "@sentry/nextjs";
 import { isTrainer, isAdminUser } from "./trainer";
 import { prisma } from "./db";
@@ -12,7 +12,6 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-// Mock dependencies
 vi.mock("./db", () => ({
   prisma: {
     user: {
@@ -44,15 +43,19 @@ vi.mock("./kv", () => ({
 describe("trainer permissions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.ADMIN_FULL_NAME = "Super Admin";
-    process.env.TRAINER_FULL_NAMES = "Trainer One,Trainer Two";
+    vi.stubEnv("ADMIN_USER_IDS", "admin-user");
+    vi.stubEnv("TRAINER_USER_IDS", "trainer-user");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   const mockReq = {} as NextRequest;
 
   describe("isTrainer", () => {
-    it("returns true if user is listed in TRAINER_FULL_NAMES", async () => {
-      vi.mocked(getActiveUser).mockResolvedValue({ userId: "1" });
+    it("returns true if user is listed in TRAINER_USER_IDS", async () => {
+      vi.mocked(getActiveUser).mockResolvedValue({ userId: "trainer-user" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         firstName: "Trainer",
         lastName: "One",
@@ -62,29 +65,13 @@ describe("trainer permissions", () => {
       const result = await isTrainer(mockReq);
       expect(result.isTrainer).toBe(true);
       expect(vi.mocked(prisma.user.findUnique)).toHaveBeenCalledWith({
-        where: { id: "1" },
+        where: { id: "trainer-user" },
         select: USER_CORE_SELECT,
       });
     });
 
-    it("matches TRAINER_FULL_NAMES when firstName has trailing whitespace", async () => {
-      process.env.TRAINER_FULL_NAMES = "Jan Willem Pater";
-      vi.mocked(getActiveUser).mockResolvedValue({
-        userId: "cmesohfy00003peijgslbdi13",
-      });
-      vi.mocked(prisma.user.findUnique).mockResolvedValue({
-        firstName: "Jan Willem ",
-        lastName: "Pater",
-      });
-      vi.mocked(getUserRoles).mockResolvedValue({});
-
-      const result = await isTrainer(mockReq);
-      expect(result.isTrainer).toBe(true);
-      expect(result.me.name).toBe("Jan Willem Pater");
-    });
-
-    it("returns true if user is Admin", async () => {
-      vi.mocked(getActiveUser).mockResolvedValue({ userId: "2" });
+    it("returns true for bootstrap admin user ids", async () => {
+      vi.mocked(getActiveUser).mockResolvedValue({ userId: "admin-user" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         firstName: "Super",
         lastName: "Admin",
@@ -95,7 +82,7 @@ describe("trainer permissions", () => {
       expect(result.isTrainer).toBe(true);
     });
 
-    it("returns true if user has trainer role", async () => {
+    it("returns true if user has trainer role in KV", async () => {
       vi.mocked(getActiveUser).mockResolvedValue({ userId: "3" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         firstName: "Random",
@@ -198,8 +185,8 @@ describe("trainer permissions", () => {
   });
 
   describe("isAdminUser", () => {
-    it("returns true if user matches ADMIN_FULL_NAME", async () => {
-      vi.mocked(getActiveUser).mockResolvedValue({ userId: "1" });
+    it("returns true if user is listed in ADMIN_USER_IDS", async () => {
+      vi.mocked(getActiveUser).mockResolvedValue({ userId: "admin-user" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         firstName: "Super",
         lastName: "Admin",
@@ -210,7 +197,7 @@ describe("trainer permissions", () => {
       expect(result.isAdmin).toBe(true);
     });
 
-    it("returns true if user has admin role", async () => {
+    it("returns true if user has admin role in KV", async () => {
       vi.mocked(getActiveUser).mockResolvedValue({ userId: "2" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         firstName: "Role",
@@ -223,12 +210,12 @@ describe("trainer permissions", () => {
     });
 
     it("returns false if only trainer", async () => {
-      vi.mocked(getActiveUser).mockResolvedValue({ userId: "3" });
+      vi.mocked(getActiveUser).mockResolvedValue({ userId: "trainer-user" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({
         firstName: "Trainer",
         lastName: "One",
       });
-      vi.mocked(getUserRoles).mockResolvedValue({ trainer: true }); // Trainer but not admin
+      vi.mocked(getUserRoles).mockResolvedValue({ trainer: true });
 
       const result = await isAdminUser(mockReq);
       expect(result.isAdmin).toBe(false);

--- a/src/lib/trainer.test.ts
+++ b/src/lib/trainer.test.ts
@@ -67,6 +67,22 @@ describe("trainer permissions", () => {
       });
     });
 
+    it("matches TRAINER_FULL_NAMES when firstName has trailing whitespace", async () => {
+      process.env.TRAINER_FULL_NAMES = "Jan Willem Pater";
+      vi.mocked(getActiveUser).mockResolvedValue({
+        userId: "cmesohfy00003peijgslbdi13",
+      });
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        firstName: "Jan Willem ",
+        lastName: "Pater",
+      });
+      vi.mocked(getUserRoles).mockResolvedValue({});
+
+      const result = await isTrainer(mockReq);
+      expect(result.isTrainer).toBe(true);
+      expect(result.me.name).toBe("Jan Willem Pater");
+    });
+
     it("returns true if user is Admin", async () => {
       vi.mocked(getActiveUser).mockResolvedValue({ userId: "2" });
       vi.mocked(prisma.user.findUnique).mockResolvedValue({

--- a/src/lib/trainer.ts
+++ b/src/lib/trainer.ts
@@ -6,6 +6,7 @@ import { prisma } from "./db";
 import { getUserRoles, type UserRoles } from "./kv";
 import { isTransientPostgresConnectError, withPgConnectRetry } from "./prismaConnectRetry";
 import { USER_CORE_SELECT } from "./userPrismaSelect";
+import { displayName } from "./userUtils";
 
 function norm(s: string) {
   return (s || "").toLowerCase().trim();
@@ -46,7 +47,7 @@ export async function isTrainer(
         select: USER_CORE_SELECT,
       }),
     );
-    const full = `${user?.firstName || ""} ${user?.lastName || ""}`.trim();
+    const full = displayName(user ?? {});
     const admin = process.env.ADMIN_FULL_NAME || "";
     const trainers = (process.env.TRAINER_FULL_NAMES || "")
       .split(",")
@@ -116,7 +117,7 @@ export async function isAdminUser(
         select: USER_CORE_SELECT,
       }),
     );
-    const full = `${user?.firstName || ""} ${user?.lastName || ""}`.trim();
+    const full = displayName(user ?? {});
     const admin = process.env.ADMIN_FULL_NAME || "";
     const envAdmin = norm(full) === norm(admin);
     const roles: UserRoles = await getUserRoles(userId).catch(

--- a/src/lib/trainer.ts
+++ b/src/lib/trainer.ts
@@ -5,16 +5,17 @@ import { isDbUnavailableError } from "./dbUnavailableError";
 import { prisma } from "./db";
 import { getUserRoles, type UserRoles } from "./kv";
 import { isTransientPostgresConnectError, withPgConnectRetry } from "./prismaConnectRetry";
+import {
+  getBootstrapAdminUserIds,
+  getBootstrapTrainerUserIds,
+} from "./roleEnv";
 import { USER_CORE_SELECT } from "./userPrismaSelect";
 import { displayName } from "./userUtils";
 
-function norm(s: string) {
-  return (s || "").toLowerCase().trim();
-}
-
 /**
  * Checks if the current request is from a Trainer or Admin.
- * Verifies against Env variables (ADMIN_FULL_NAME, TRAINER_FULL_NAMES) and DB roles.
+ * Verifies against env bootstrap user IDs (`ADMIN_USER_IDS`, `TRAINER_USER_IDS`)
+ * and KV roles keyed by user ID.
  *
  * @param req - The incoming Next.js request.
  * @returns An object containing `isTrainer` boolean and the user's identity `me`.
@@ -48,13 +49,9 @@ export async function isTrainer(
       }),
     );
     const full = displayName(user ?? {});
-    const admin = process.env.ADMIN_FULL_NAME || "";
-    const trainers = (process.env.TRAINER_FULL_NAMES || "")
-      .split(",")
-      .map((s) => norm(s))
-      .filter(Boolean);
-    const isAdmin = norm(full) === norm(admin);
-    const isTrainerListed = trainers.includes(norm(full));
+    const envAdmin = getBootstrapAdminUserIds().has(userId);
+    const envTrainer =
+      getBootstrapTrainerUserIds().has(userId) || envAdmin;
     const roles: UserRoles = await getUserRoles(userId).catch(
       (err: unknown) => {
         Sentry.captureException(err, {
@@ -66,7 +63,7 @@ export async function isTrainer(
     );
     const byRole = Boolean(roles?.trainer || roles?.admin);
     return {
-      isTrainer: Boolean(isAdmin || isTrainerListed || byRole),
+      isTrainer: Boolean(envAdmin || envTrainer || byRole),
       me: { id: userId, name: full },
     };
   } catch (err: unknown) {
@@ -85,7 +82,7 @@ export async function isTrainer(
 
 /**
  * Checks if the current request is from an Admin.
- * Verifies against Env variables (ADMIN_FULL_NAME) and DB roles.
+ * Verifies against env bootstrap user IDs (`ADMIN_USER_IDS`) and KV roles.
  *
  * @param req - The incoming Next.js request.
  * @returns An object containing `isAdmin` boolean and the user's identity `me`.
@@ -118,8 +115,7 @@ export async function isAdminUser(
       }),
     );
     const full = displayName(user ?? {});
-    const admin = process.env.ADMIN_FULL_NAME || "";
-    const envAdmin = norm(full) === norm(admin);
+    const envAdmin = getBootstrapAdminUserIds().has(userId);
     const roles: UserRoles = await getUserRoles(userId).catch(
       (err: unknown) => {
         Sentry.captureException(err, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Trainer/admin authorization uses **user IDs only** (no display-name matching).

- `isTrainer` / `isAdminUser` check KV roles + bootstrap user IDs
- `src/lib/roleEnv.ts` centralizes parsing/merge logic
- **`src/lib/roleBootstrapIds.ts`** — production IDs discovered from DB (no manual Vercel lookup needed for deploy)

### Discovered from production

Queried `Attendance.markedBy` (who actually registered training attendance) + project owner:

| Role | Name | User ID |
|------|------|---------|
| Admin | Guido Vermeulen | `7651890a-f601-4711-9ff0-64da8ac052dc` |
| Trainer | Andre Staal | `cmexxuyh60001fvfvr4s97ee6` |
| Trainer | Henry Turkenburg | `cmjhqic0t0001dvv4zuy3pfae` |
| Trainer | Jan Willem Pater | `cmesohfy00003peijgslbdi13` |
| Trainer | Frank Volkering | `cmexwduu60001rngcifi58jtx` |
| Trainer | Harry Stens | `90a6f54a-8add-407a-b7f2-a9cfc87b75d7` |

These are committed as defaults when `ADMIN_USER_IDS` / `TRAINER_USER_IDS` env vars are unset. Env still overrides (optional cleanup: remove old `ADMIN_FULL_NAME` / `TRAINER_FULL_NAMES` from Vercel).

## User-facing release (“Wat is nieuw”)

- [x] Nee — geen release richting eindgebruikers (alleen intern/technisch)

## Docs

- [x] Nee — geen doc-update nodig

## Verification

- `npx vitest run src/lib/trainer.test.ts src/lib/roleEnv.test.ts` — 26 passed
- `npx tsc --noEmit` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e0b-075b-7dc9-93a7-e2047a0a3d65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e0b-075b-7dc9-93a7-e2047a0a3d65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nieuwe functies**
  - Beheerders- en trainerrollen kunnen nu betrouwbaar worden toegewezen op basis van gebruikers-ID’s.
  - Roltoewijzingen kunnen via configuratie worden aangepast, met standaardinstellingen voor de productieomgeving.
  - Beheerders krijgen automatisch ook trainerrechten.

- **Bugfixes**
  - Problemen met rolherkenning door gewijzigde of niet-overeenkomende namen zijn opgelost.
  - De gebruikerslijst toont rollen consistenter door meerdere rolbronnen correct samen te voegen.

- **Tests**
  - De controle van gebruikersrollen en configuratie is uitgebreid met extra testgevallen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->