### PR TITLE
fix(auth): normalize email on credentials login

### DIFF
--- a/src/lib/authOptions.authorize.test.ts
+++ b/src/lib/authOptions.authorize.test.ts
@@ -135,6 +135,35 @@ describe("Credentials authorize", () => {
     });
   });
 
+  it("normalizes email casing and whitespace before lookup", async () => {
+    const row: UserCoreRow = {
+      id: "u1",
+      email: "pelsarjen@gmail.com",
+      passwordHash: "$2a$10$hashed",
+      firstName: "Arjen",
+      lastName: "Pels",
+    };
+    vi.mocked(prisma.user.findFirst).mockResolvedValueOnce(row);
+
+    const bcrypt = await import("bcryptjs");
+    vi.mocked(bcrypt.default.compare).mockResolvedValueOnce(true);
+
+    const result = await authorize?.({
+      email: "  Pelsarjen@gmail.com  ",
+      password: "secret",
+    });
+
+    expect(result).toEqual({
+      id: "u1",
+      name: "Arjen Pels",
+      email: "pelsarjen@gmail.com",
+    });
+    expect(prisma.user.findFirst).toHaveBeenCalledWith({
+      where: { email: "pelsarjen@gmail.com" },
+      select: USER_CORE_SELECT,
+    });
+  });
+
   it("returns null on P2022 schema drift and reports to Sentry", async () => {
     const err = new Prisma.PrismaClientKnownRequestError("column missing", {
       code: "P2022",

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -80,7 +80,9 @@ export const authOptions: NextAuthOptions = {
           }
         }
 
-        const email = (creds?.email as string) || "";
+        const email = String(creds?.email ?? "")
+          .trim()
+          .toLowerCase();
         const password = (creds?.password as string) || "";
         if (!email || !password) return null;
         try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Credentials login now trims and lowercases the email before user lookup, matching registration (`register`) and password reset (`reset-request`).

This fixes failed logins when mobile autofill capitalizes the local part (e.g. `Pelsarjen@gmail.com` instead of `pelsarjen@gmail.com`).

## User-facing release (“Wat is nieuw”)

- [x] Nee — geen release richting eindgebruikers (alleen intern/technisch)

## Docs

- [ ] Updated relevant feature docs under `docs/tech/...`
- [ ] `npm run docs:generate` succeeds locally

## Testing

- Added unit test for mixed-case/whitespace email normalization in `authOptions.authorize.test.ts`
- `npx vitest run src/lib/authOptions.authorize.test.ts` — 9 passed
- `npx tsc --noEmit` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e0b-075b-7dc9-93a7-e2047a0a3d65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e0b-075b-7dc9-93a7-e2047a0a3d65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Verbeteringen**
  - E-mailadressen bij inloggen worden voortaan automatisch getrimd en naar kleine letters omgezet.
  - Dit voorkomt problemen wanneer een e-mailadres hoofdletters of extra spaties bevat.
- **Tests**
  - De normalisatie van e-mailadressen wordt automatisch gecontroleerd.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->