### PR TITLE
Improve mobile UX and fix Google login resilience

### DIFF
--- a/src/app/admin/feedback/loading.tsx
+++ b/src/app/admin/feedback/loading.tsx
@@ -1,0 +1,21 @@
+import { AppBar } from "../../../components/ui";
+
+export default function Loading() {
+  return (
+    <main>
+      <div className="container" aria-busy="true" aria-label="Feedback laden">
+        <AppBar title="Feedback" fallbackHref="/admin" />
+        <div className="skeleton" style={{ height: 16, width: "35%" }} />
+        <div className="row" style={{ marginTop: 20 }}>
+          <div className="skeleton" style={{ height: 44, width: 120 }} />
+          <div className="skeleton" style={{ height: 44, width: 140 }} />
+        </div>
+        <div className="list">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="card skeleton" style={{ height: 96 }} />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import * as Sentry from "@sentry/nextjs";
-import { EmptyState } from "../../../components/ui";
+import { AppBar, EmptyState } from "../../../components/ui";
 
 type FeedbackRow = {
   id: string;
@@ -132,18 +131,17 @@ export default function AdminFeedbackPage(): React.JSX.Element {
   if (forbidden) {
     return (
       <main className="container">
-        <h1>Geen toegang</h1>
+        <AppBar title="Geen toegang" fallbackHref="/admin" />
         <p className="muted">
           Je hebt admin-rechten nodig om deze pagina te zien.
         </p>
-        <Link href="/">Terug naar start</Link>
       </main>
     );
   }
 
   return (
     <main className="container pb-24">
-      <h1>Feedback</h1>
+      <AppBar title="Feedback" fallbackHref="/admin" />
       <p className="muted">
         {counts.BUG} {counts.BUG === 1 ? "bug" : "bugs"} • {counts.IDEA}{" "}
         {counts.IDEA === 1 ? "idee" : "ideeën"}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -803,26 +803,36 @@ body.modal-open .card {
   z-index: 1000;
 }
 .bottomNavLinks {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  overflow-x: auto;
-  flex-wrap: nowrap;
-  -webkit-overflow-scrolling: touch;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: 2px;
 }
 .bottomNavLinks a,
 .bottomNavLinks button {
   color: var(--text);
   text-decoration: none;
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 0;
   border-radius: var(--radius-md);
-  padding: 8px 12px;
-  min-height: 40px;
-  display: inline-flex;
+  padding: 4px 2px;
+  min-width: 0;
+  min-height: 48px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  white-space: nowrap;
+  justify-content: center;
+  gap: 2px;
   font: inherit;
+}
+.bottomNavLinks a > span {
+  font-size: 22px;
+  line-height: 1;
+}
+.bottomNavLinks small {
+  font-size: 11px;
+  font-weight: 600;
 }
 .bottomNavLinks a:focus-visible,
 .bottomNavLinks button:focus-visible {
@@ -831,8 +841,8 @@ body.modal-open .card {
 }
 
 .navActive {
-  border-color: var(--accent);
   color: var(--accent) !important;
+  background: color-mix(in oklab, var(--accent) 12%, transparent) !important;
 }
 
 /* Christmas theme navigation */
@@ -1009,6 +1019,56 @@ body.modal-open .card {
 }
 
 /* ---------- UI primitives ---------- */
+
+/* App bar — stable drill-down navigation with an iOS-style back target. */
+.ui-app-bar {
+  display: grid;
+  grid-template-columns: var(--hit) minmax(0, 1fr) var(--hit);
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 56px;
+  margin: calc(-1 * var(--space-2)) 0 var(--space-4);
+}
+.ui-app-bar h1 {
+  min-width: 0;
+  margin: 0;
+  font-size: clamp(1.15rem, 5vw, 1.5rem);
+  line-height: 1.2;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ui-app-bar-back {
+  width: var(--hit);
+  height: var(--hit);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+}
+.ui-app-bar-back span {
+  font-size: 34px;
+  font-weight: 300;
+  line-height: 1;
+  transform: translateY(-1px);
+}
+.ui-app-bar-back:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+.ui-app-bar-back:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.ui-app-bar-action {
+  display: flex;
+  justify-content: flex-end;
+}
 
 /* Stack — vertical/horizontal spacing helper */
 .ui-stack {

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -33,6 +33,7 @@ export default function LoginForm({
   const [invitationCode, setInvitationCode] = useState("");
   const [notice, setNotice] = useState<Notice>(null);
   const [signingIn, setSigningIn] = useState(false);
+  const [signingInWithGoogle, setSigningInWithGoogle] = useState(false);
   const [registering, setRegistering] = useState(false);
   const [passkeyLoading, setPasskeyLoading] = useState(false);
   const [webAuthnUsable, setWebAuthnUsable] = useState(false);
@@ -189,7 +190,9 @@ export default function LoginForm({
   }
 
   async function loginGoogle(): Promise<void> {
+    if (signingInWithGoogle) return;
     setNotice(null);
+    setSigningInWithGoogle(true);
     try {
       await signIn("google", { callbackUrl });
     } catch (error: unknown) {
@@ -198,6 +201,7 @@ export default function LoginForm({
         tone: "error",
         text: "Google-inloggen mislukt (netwerk of server). Probeer het opnieuw.",
       });
+      setSigningInWithGoogle(false);
     }
   }
 
@@ -214,6 +218,8 @@ export default function LoginForm({
           <Button
             variant="primary"
             isFullWidth
+            loading={signingInWithGoogle}
+            loadingLabel="Google openen…"
             onClick={() => void loginGoogle()}
           >
             Inloggen met Google

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -10,6 +10,7 @@ import { getBadgeForAttendance, type AttendanceBadge } from "../../lib/badges";
 import { APP_VERSION } from "../../lib/version";
 import { Button, Card, Input, Stack, showToast } from "../../components/ui";
 import { isBenignWebAuthnClientError } from "../../lib/webAuthnClientErrors";
+import { useSession } from "../../components/SessionContext";
 
 type Profile = {
   id: string;
@@ -21,6 +22,7 @@ type PasskeyRow = { id: string; createdAt: string; label: string | null };
 type Roles = { admin: boolean; trainer: boolean; player: boolean };
 
 export default function ProfilePage() {
+  const { loggedIn } = useSession();
   const [, setProfile] = useState<Profile>(null);
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -386,6 +388,19 @@ export default function ProfilePage() {
               </Stack>
             </Card>
           </div>
+        ) : null}
+
+        {loggedIn ? (
+          <form
+            action="/api/auth/signout"
+            method="post"
+            style={{ maxWidth: 520 }}
+          >
+            <input type="hidden" name="callbackUrl" value="/" />
+            <Button type="submit" variant="secondary" isFullWidth>
+              Uitloggen
+            </Button>
+          </form>
         ) : null}
 
         <div

--- a/src/app/report/[eventId]/loading.tsx
+++ b/src/app/report/[eventId]/loading.tsx
@@ -1,0 +1,19 @@
+import { AppBar } from "../../../components/ui";
+
+export default function Loading() {
+  return (
+    <main>
+      <div className="container" aria-busy="true" aria-label="Verslag laden">
+        <AppBar title="Wedstrijdverslag" />
+        <div className="skeleton" style={{ height: 18, width: "45%" }} />
+        <div className="list" style={{ marginTop: 24 }}>
+          <div className="skeleton" style={{ height: 18, width: "100%" }} />
+          <div className="skeleton" style={{ height: 18, width: "92%" }} />
+          <div className="skeleton" style={{ height: 18, width: "96%" }} />
+          <div className="skeleton" style={{ height: 18, width: "72%" }} />
+        </div>
+        <div className="card skeleton" style={{ height: 132, marginTop: 28 }} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/report/[eventId]/page.tsx
+++ b/src/app/report/[eventId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getReport } from "../../../lib/kv";
-import Link from "next/link";
 import MvpVotingPanel from "../../../components/MvpVotingPanel";
+import { AppBar } from "../../../components/ui";
 
 type Params = {
   params: Promise<{ eventId: string }> | { eventId: string };
@@ -16,7 +16,7 @@ export default async function ReportPage({ params }: Params) {
   return (
     <main>
       <div className="container">
-        <h1>Wedstrijdverslag</h1>
+        <AppBar title="Wedstrijdverslag" />
         <div className="muted" style={{ marginBottom: 12 }}>
           Wedstrijd: {eventId}
         </div>
@@ -33,9 +33,6 @@ export default async function ReportPage({ params }: Params) {
           Gepubliceerd {new Date(report.createdAt).toLocaleString("nl-NL")}
         </div>
         <MvpVotingPanel eventId={eventId} />
-        <div style={{ marginTop: 16 }}>
-          <Link href="/">← Terug</Link>
-        </div>
       </div>
     </main>
   );

--- a/src/app/trainer/attendance/[date]/page.tsx
+++ b/src/app/trainer/attendance/[date]/page.tsx
@@ -57,7 +57,6 @@ export default function SessionChecklist() {
       if (!mounted) return;
       setPresent(new Set((att?.presentUserIds || []) as string[]));
       setDirty(false);
-      showToast("Opkomst opgeslagen", "success");
     }
     load();
     return () => {

--- a/src/app/trainer/attendance/[date]/page.tsx
+++ b/src/app/trainer/attendance/[date]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
+import { AppBar, Button, showToast } from "../../../../components/ui";
 
 type User = { id: string; name: string };
 
@@ -56,6 +57,7 @@ export default function SessionChecklist() {
       if (!mounted) return;
       setPresent(new Set((att?.presentUserIds || []) as string[]));
       setDirty(false);
+      showToast("Opkomst opgeslagen", "success");
     }
     load();
     return () => {
@@ -93,6 +95,11 @@ export default function SessionChecklist() {
         return;
       }
       setDirty(false);
+      showToast("Opkomst opgeslagen", "success");
+    } catch {
+      setSaveError(
+        "Opslaan mislukt. Controleer je verbinding en probeer opnieuw.",
+      );
     } finally {
       setSaving(false);
     }
@@ -105,7 +112,10 @@ export default function SessionChecklist() {
   if (isTrainer === false) {
     return (
       <div className="container">
-        <h1>{date}</h1>
+        <AppBar
+          title={date || "Trainingsopkomst"}
+          fallbackHref="/trainer/attendance"
+        />
         <div className="muted">Je hebt geen toegang.</div>
       </div>
     );
@@ -113,7 +123,12 @@ export default function SessionChecklist() {
   if (isTrainer === null) {
     return (
       <div className="container">
-        <div className="muted">Laden…</div>
+        <AppBar title="Trainingsopkomst" fallbackHref="/trainer/attendance" />
+        <div
+          className="card skeleton"
+          style={{ height: 72 }}
+          aria-label="Opkomst laden"
+        />
       </div>
     );
   }
@@ -121,7 +136,10 @@ export default function SessionChecklist() {
   return (
     <main>
       <div className="container">
-        <h1>Opkomst – {date}</h1>
+        <AppBar
+          title={`Opkomst – ${date}`}
+          fallbackHref="/trainer/attendance"
+        />
 
         <div className="card" style={{ position: "sticky", top: 0, zIndex: 1 }}>
           <div
@@ -133,9 +151,14 @@ export default function SessionChecklist() {
           >
             <div className="muted">Aanwezig: {present.size}</div>
             <div className="row" style={{ gap: 8 }}>
-              <button onClick={onSave} disabled={!dirty || saving}>
-                {saving ? "Opslaan…" : "Opslaan"}
-              </button>
+              <Button
+                onClick={() => void onSave()}
+                disabled={!dirty}
+                loading={saving}
+                loadingLabel="Opslaan…"
+              >
+                Opslaan
+              </Button>
             </div>
           </div>
           {saveError ? (

--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSession } from "./SessionContext";
+import BottomNav from "./BottomNav";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+vi.mock("./SessionContext", () => ({
+  useSession: vi.fn(),
+}));
+
+describe("BottomNav", () => {
+  beforeEach(() => {
+    vi.mocked(usePathname).mockReturnValue("/");
+  });
+
+  it("keeps a mobile login entry point for anonymous users", () => {
+    vi.mocked(useSession).mockReturnValue({
+      loading: false,
+      loggedIn: false,
+      isTrainer: false,
+      isAdmin: false,
+      refresh: vi.fn(),
+    });
+
+    render(<BottomNav />);
+
+    expect(screen.getByRole("link", { name: "Inloggen" })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+  });
+
+  it("links authenticated users to their profile", () => {
+    vi.mocked(useSession).mockReturnValue({
+      loading: false,
+      loggedIn: true,
+      isTrainer: false,
+      isAdmin: false,
+      refresh: vi.fn(),
+    });
+
+    render(<BottomNav />);
+
+    expect(screen.getByRole("link", { name: "Profiel" })).toHaveAttribute(
+      "href",
+      "/profile",
+    );
+  });
+});

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -68,12 +68,18 @@ export default function BottomNav() {
             </Link>
           ) : null}
           <Link
-            href="/profile"
-            className={isActive("/profile") ? "navActive" : undefined}
-            aria-current={isActive("/profile") ? "page" : undefined}
+            href={loggedIn ? "/profile" : "/login"}
+            className={
+              isActive(loggedIn ? "/profile" : "/login")
+                ? "navActive"
+                : undefined
+            }
+            aria-current={
+              isActive(loggedIn ? "/profile" : "/login") ? "page" : undefined
+            }
           >
             {icons.profile}
-            <small>Profiel</small>
+            <small>{loggedIn ? "Profiel" : "Inloggen"}</small>
           </Link>
         </div>
       </div>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -15,18 +15,33 @@ export default function BottomNav() {
 
   if (loading) return null;
 
+  const icons = {
+    calendar: <span aria-hidden="true">◫</span>,
+    attendance: <span aria-hidden="true">✓</span>,
+    trainer: <span aria-hidden="true">＋</span>,
+    admin: <span aria-hidden="true">◇</span>,
+    profile: <span aria-hidden="true">○</span>,
+  };
+
   return (
     <nav className="bottomBar" aria-label="Hoofdnavigatie">
       <div className="container" style={{ padding: 0 }}>
         <div className="bottomNavLinks">
-          <Link href="/" className={isActive("/") ? "navActive" : undefined}>
-            RSVP
+          <Link
+            href="/"
+            className={isActive("/") ? "navActive" : undefined}
+            aria-current={isActive("/") ? "page" : undefined}
+          >
+            {icons.calendar}
+            <small>RSVP</small>
           </Link>
           <Link
             href="/attendance"
             className={isActive("/attendance") ? "navActive" : undefined}
+            aria-current={isActive("/attendance") ? "page" : undefined}
           >
-            Opkomst
+            {icons.attendance}
+            <small>Opkomst</small>
           </Link>
           {loggedIn && isTrainer ? (
             <Link
@@ -34,34 +49,32 @@ export default function BottomNav() {
               className={
                 isActive("/trainer/attendance") ? "navActive" : undefined
               }
+              aria-current={
+                isActive("/trainer/attendance") ? "page" : undefined
+              }
             >
-              Trainer
+              {icons.trainer}
+              <small>Trainer</small>
             </Link>
           ) : null}
           {loggedIn && isAdmin ? (
             <Link
               href="/admin"
               className={isActive("/admin") ? "navActive" : undefined}
+              aria-current={isActive("/admin") ? "page" : undefined}
             >
-              Admin
+              {icons.admin}
+              <small>Admin</small>
             </Link>
           ) : null}
           <Link
             href="/profile"
             className={isActive("/profile") ? "navActive" : undefined}
+            aria-current={isActive("/profile") ? "page" : undefined}
           >
-            Profiel
+            {icons.profile}
+            <small>Profiel</small>
           </Link>
-          {loggedIn ? (
-            <form action="/api/auth/signout" method="post">
-              <input type="hidden" name="callbackUrl" value="/" />
-              <button type="submit">Uitloggen</button>
-            </form>
-          ) : (
-            <Link href={{ pathname: "/login", query: { callbackUrl: "/" } }}>
-              Inloggen
-            </Link>
-          )}
         </div>
       </div>
     </nav>

--- a/src/components/ui/AppBar.test.tsx
+++ b/src/components/ui/AppBar.test.tsx
@@ -4,19 +4,17 @@ import AppBar from "./AppBar";
 
 const back = vi.fn();
 const push = vi.fn();
+const replace = vi.fn();
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ back, push }),
+  useRouter: () => ({ back, push, replace }),
 }));
 
 describe("AppBar", () => {
   beforeEach(() => {
     back.mockReset();
     push.mockReset();
-    Object.defineProperty(document, "referrer", {
-      configurable: true,
-      value: "",
-    });
+    replace.mockReset();
   });
 
   it("renders its title and back control", () => {
@@ -28,50 +26,13 @@ describe("AppBar", () => {
     expect(screen.getByRole("button", { name: "Terug" })).toBeInTheDocument();
   });
 
-  it("uses the fallback route without browser history", () => {
-    Object.defineProperty(window.history, "length", {
-      configurable: true,
-      value: 1,
-    });
+  it("replaces the detail route with its safe in-app fallback", () => {
     render(<AppBar title="Feedback" fallbackHref="/admin" />);
 
     fireEvent.click(screen.getByRole("button", { name: "Terug" }));
 
-    expect(push).toHaveBeenCalledWith("/admin");
+    expect(replace).toHaveBeenCalledWith("/admin");
     expect(back).not.toHaveBeenCalled();
-  });
-
-  it("uses browser history only when the referrer is from this app", () => {
-    Object.defineProperty(window.history, "length", {
-      configurable: true,
-      value: 2,
-    });
-    Object.defineProperty(document, "referrer", {
-      configurable: true,
-      value: `${window.location.origin}/attendance`,
-    });
-    render(<AppBar title="Feedback" fallbackHref="/admin" />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Terug" }));
-
-    expect(back).toHaveBeenCalledOnce();
     expect(push).not.toHaveBeenCalled();
-  });
-
-  it("uses the fallback for history originating outside the app", () => {
-    Object.defineProperty(window.history, "length", {
-      configurable: true,
-      value: 2,
-    });
-    Object.defineProperty(document, "referrer", {
-      configurable: true,
-      value: "https://example.com/shared-link",
-    });
-    render(<AppBar title="Feedback" fallbackHref="/admin" />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Terug" }));
-
-    expect(push).toHaveBeenCalledWith("/admin");
-    expect(back).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/AppBar.test.tsx
+++ b/src/components/ui/AppBar.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AppBar from "./AppBar";
+
+const back = vi.fn();
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ back, push }),
+}));
+
+describe("AppBar", () => {
+  beforeEach(() => {
+    back.mockReset();
+    push.mockReset();
+  });
+
+  it("renders its title and back control", () => {
+    render(<AppBar title="Wedstrijdverslag" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Wedstrijdverslag" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Terug" })).toBeInTheDocument();
+  });
+
+  it("uses the fallback route without browser history", () => {
+    Object.defineProperty(window.history, "length", {
+      configurable: true,
+      value: 1,
+    });
+    render(<AppBar title="Feedback" fallbackHref="/admin" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Terug" }));
+
+    expect(push).toHaveBeenCalledWith("/admin");
+    expect(back).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/AppBar.test.tsx
+++ b/src/components/ui/AppBar.test.tsx
@@ -13,6 +13,10 @@ describe("AppBar", () => {
   beforeEach(() => {
     back.mockReset();
     push.mockReset();
+    Object.defineProperty(document, "referrer", {
+      configurable: true,
+      value: "",
+    });
   });
 
   it("renders its title and back control", () => {
@@ -28,6 +32,40 @@ describe("AppBar", () => {
     Object.defineProperty(window.history, "length", {
       configurable: true,
       value: 1,
+    });
+    render(<AppBar title="Feedback" fallbackHref="/admin" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Terug" }));
+
+    expect(push).toHaveBeenCalledWith("/admin");
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it("uses browser history only when the referrer is from this app", () => {
+    Object.defineProperty(window.history, "length", {
+      configurable: true,
+      value: 2,
+    });
+    Object.defineProperty(document, "referrer", {
+      configurable: true,
+      value: `${window.location.origin}/attendance`,
+    });
+    render(<AppBar title="Feedback" fallbackHref="/admin" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Terug" }));
+
+    expect(back).toHaveBeenCalledOnce();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("uses the fallback for history originating outside the app", () => {
+    Object.defineProperty(window.history, "length", {
+      configurable: true,
+      value: 2,
+    });
+    Object.defineProperty(document, "referrer", {
+      configurable: true,
+      value: "https://example.com/shared-link",
     });
     render(<AppBar title="Feedback" fallbackHref="/admin" />);
 

--- a/src/components/ui/AppBar.tsx
+++ b/src/components/ui/AppBar.tsx
@@ -21,20 +21,7 @@ export default function AppBar({
   const router = useRouter();
 
   function goBack(): void {
-    let hasSameOriginReferrer = false;
-    try {
-      hasSameOriginReferrer =
-        document.referrer.length > 0 &&
-        new URL(document.referrer).origin === window.location.origin;
-    } catch {
-      // A malformed referrer is not safe evidence of in-app history.
-    }
-
-    if (hasSameOriginReferrer && window.history.length > 1) {
-      router.back();
-      return;
-    }
-    router.push(fallbackHref);
+    router.replace(fallbackHref);
   }
 
   return (

--- a/src/components/ui/AppBar.tsx
+++ b/src/components/ui/AppBar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { Route } from "next";
+import { useRouter } from "next/navigation";
+
+type AppBarProps = {
+  title: string;
+  fallbackHref?: Route;
+  backLabel?: string;
+  action?: ReactNode;
+};
+
+/** Compact, safe-area-aware header for drill-down screens. */
+export default function AppBar({
+  title,
+  fallbackHref = "/",
+  backLabel = "Terug",
+  action,
+}: AppBarProps) {
+  const router = useRouter();
+
+  function goBack(): void {
+    if (window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push(fallbackHref);
+  }
+
+  return (
+    <div className="ui-app-bar">
+      <button
+        type="button"
+        className="ui-app-bar-back"
+        onClick={goBack}
+        aria-label={backLabel}
+      >
+        <span aria-hidden="true">‹</span>
+      </button>
+      <h1>{title}</h1>
+      <div className="ui-app-bar-action">{action}</div>
+    </div>
+  );
+}

--- a/src/components/ui/AppBar.tsx
+++ b/src/components/ui/AppBar.tsx
@@ -21,7 +21,16 @@ export default function AppBar({
   const router = useRouter();
 
   function goBack(): void {
-    if (window.history.length > 1) {
+    let hasSameOriginReferrer = false;
+    try {
+      hasSameOriginReferrer =
+        document.referrer.length > 0 &&
+        new URL(document.referrer).origin === window.location.origin;
+    } catch {
+      // A malformed referrer is not safe evidence of in-app history.
+    }
+
+    if (hasSameOriginReferrer && window.history.length > 1) {
       router.back();
       return;
     }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { default as Button } from "./Button";
+export { default as AppBar } from "./AppBar";
 export { default as Card } from "./Card";
 export { default as EmptyState } from "./EmptyState";
 export { Input, Textarea } from "./Input";

--- a/src/lib/authOptions.authorize.test.ts
+++ b/src/lib/authOptions.authorize.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Prisma } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";
 import { prisma } from "./db";
-import { authOptions } from "./authOptions";
+import { authOptions, normalizeAuthEnv } from "./authOptions";
 import { createPasskeyExchangeToken } from "./passkeyExchangeToken";
 import { USER_CORE_SELECT, type UserCoreRow } from "./userPrismaSelect";
 import { DbUnavailableError } from "./dbUnavailableError";
@@ -219,5 +219,16 @@ describe("Credentials authorize", () => {
         extra: { prismaCode: "P2002" },
       });
     });
+  });
+});
+
+describe("normalizeAuthEnv", () => {
+  it("removes whitespace accidentally stored around OAuth credentials", () => {
+    expect(normalizeAuthEnv("  oauth-client-id\n")).toBe("oauth-client-id");
+    expect(normalizeAuthEnv("oauth-secret\r\n")).toBe("oauth-secret");
+  });
+
+  it("returns an empty value when the variable is missing", () => {
+    expect(normalizeAuthEnv(undefined)).toBe("");
   });
 });

--- a/src/lib/authOptions.ts
+++ b/src/lib/authOptions.ts
@@ -31,13 +31,21 @@ function reportCredentialsAuthorizeError(
 }
 
 /**
+ * Normalizes dashboard-managed auth values, which can accidentally include
+ * leading or trailing whitespace when pasted into a deployment environment.
+ */
+export function normalizeAuthEnv(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+/**
  * NextAuth configuration: Google + credentials, JWT sessions with user id on `session.user.id`.
  */
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID || "",
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+      clientId: normalizeAuthEnv(process.env.GOOGLE_CLIENT_ID),
+      clientSecret: normalizeAuthEnv(process.env.GOOGLE_CLIENT_SECRET),
     }),
     Credentials({
       name: "Credentials",
@@ -102,7 +110,7 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: normalizeAuthEnv(process.env.NEXTAUTH_SECRET) || undefined,
   callbacks: {
     async jwt({ token, user }) {
       if (user?.id) {

--- a/tests/report-extract.test.ts
+++ b/tests/report-extract.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import {
@@ -14,6 +14,22 @@ const reportDescribe = runReportE2E ? describe : describe.skip;
 
 reportDescribe("Match Report Extract", () => {
   const baseUrl = process.env.TEST_API_URL || "http://localhost:3000";
+  const requiredFixtures = [
+    "tests/fixtures/Home-Match-1.JPG",
+    "tests/fixtures/Home-Match-2.JPG",
+    "tests/fixtures/Away-Match-1.JPG",
+    "tests/fixtures/home-match-1-expected.json",
+    "tests/fixtures/away-match-1-expected.json",
+  ];
+
+  beforeEach(({ skip }) => {
+    const missingFixtures = requiredFixtures.filter(
+      (fixture) => !existsSync(join(process.cwd(), fixture)),
+    );
+    if (missingFixtures.length > 0) {
+      skip(`Missing required fixtures: ${missingFixtures.join(", ")}`);
+    }
+  });
 
   describe("Home Match Extraction", () => {
     it("should extract JSON from home match image 1", async () => {

--- a/tests/report-generate.test.ts
+++ b/tests/report-generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 import { existsSync } from "fs";
 import { join } from "path";
 import {
@@ -13,6 +13,19 @@ const reportDescribe = runReportE2E ? describe : describe.skip;
 
 reportDescribe("Match Report Generate", () => {
   const baseUrl = process.env.TEST_API_URL || "http://localhost:3000";
+  const requiredFixtures = [
+    "tests/fixtures/home-match-1-expected.json",
+    "tests/fixtures/away-match-1-expected.json",
+  ];
+
+  beforeEach(({ skip }) => {
+    const missingFixtures = requiredFixtures.filter(
+      (fixture) => !existsSync(join(process.cwd(), fixture)),
+    );
+    if (missingFixtures.length > 0) {
+      skip(`Missing required fixtures: ${missingFixtures.join(", ")}`);
+    }
+  });
 
   describe("Home Match Report Generation", () => {
     it("should generate report from extracted JSON", async () => {

--- a/tests/report-integration.test.ts
+++ b/tests/report-integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 import { existsSync } from "fs";
 import { join } from "path";
 import {
@@ -15,6 +15,22 @@ const reportDescribe = runReportE2E ? describe : describe.skip;
 
 reportDescribe("Match Report Integration", () => {
   const baseUrl = process.env.TEST_API_URL || "http://localhost:3000";
+  const requiredFixtures = [
+    "tests/fixtures/Home-Match-1.JPG",
+    "tests/fixtures/Home-Match-2.JPG",
+    "tests/fixtures/Away-Match-1.JPG",
+    "tests/fixtures/home-match-1-expected.json",
+    "tests/fixtures/away-match-1-expected.json",
+  ];
+
+  beforeEach(({ skip }) => {
+    const missingFixtures = requiredFixtures.filter(
+      (fixture) => !existsSync(join(process.cwd(), fixture)),
+    );
+    if (missingFixtures.length > 0) {
+      skip(`Missing required fixtures: ${missingFixtures.join(", ")}`);
+    }
+  });
 
   describe("Full Pipeline: Image to Report", () => {
     it("should extract JSON and generate report from home match image 1", async () => {


### PR DESCRIPTION
## Summary

- make Google OAuth resilient to whitespace in deployed environment values
- add native-style mobile detail navigation, tab navigation, loading skeletons, and mutation feedback
- improve the admin area with shared tabs, user search, responsive role controls, protected refresh, retries, empty states, and per-item feedback status progress
- upgrade report screenshot extraction to `openai/gpt-5.6-sol`, the current flagship vision-capable OpenAI model on Vercel AI Gateway
- repair stale or provider-mismatched extraction overrides such as `openai/claude-sonnet-4-6`
- expose extraction model metadata in the admin test tool and show readable provider errors
- mark missing report fixtures as intentional Vitest skips instead of false passes

## Verification

- `npm test -- --run` — 586 passed, 28 intentionally skipped
- focused model/admin navigation tests — 38 passed
- TypeScript passed
- production build passed
- formatting and ESLint passed with two pre-existing warnings

## Notes

- GPT-5.6 Sol was selected because OpenAI identifies GPT-5.6 as its flagship family and Vercel lists `openai/gpt-5.6-sol` as its most capable member with image input and structured-output support.
- GTA/arena work and local Claude files remain outside this PR.
