### PR TITLE
Improve admin UX and upgrade report extraction model

### DIFF
--- a/docs/tech/reports/README.md
+++ b/docs/tech/reports/README.md
@@ -22,7 +22,7 @@ The app uses `await Promise.resolve(params)` for `eventId` so Next.js 15+ async 
 `/api/report/extract` supports a runtime provider flag so extraction can switch without code changes.
 
 - `REPORT_EXTRACT_PROVIDER=vlm|ocr|hybrid` (default: `vlm`)
-- `REPORT_EXTRACT_OPENAI_MODEL=<model-name>` (optional; defaults to `gpt-4o` when unset. Premium GPT-5 ids and removed snapshots are remapped to `gpt-4o` in code — see Sentry JAVASCRIPT-NEXTJS-1F / JAVASCRIPT-NEXTJS-38.)
+- `REPORT_EXTRACT_OPENAI_MODEL=<model-name>` (optional; defaults to `openai/gpt-5.6-sol` when unset. Removed snapshots and non-OpenAI model ids are remapped to this vision-capable default.)
 - `REPORT_GENERATE_MODEL=<model-name>` (optional; defaults to `openai/gpt-4o` for `/api/report/generate`. Premium GPT-5 chat ids are remapped in code — see Sentry JAVASCRIPT-NEXTJS-1S.)
 - `OPENAI_API_KEY=<secret>` (required)
 - `OCR_WORKER_URL=<url>` (required for `ocr` and `hybrid`)

--- a/src/app/admin/feedback/loading.tsx
+++ b/src/app/admin/feedback/loading.tsx
@@ -1,10 +1,12 @@
 import { AppBar } from "../../../components/ui";
+import AdminNav from "../../../components/AdminNav";
 
 export default function Loading() {
   return (
     <main>
       <div className="container" aria-busy="true" aria-label="Feedback laden">
         <AppBar title="Feedback" fallbackHref="/admin" />
+        <AdminNav />
         <div className="skeleton" style={{ height: 16, width: "35%" }} />
         <div className="row" style={{ marginTop: 20 }}>
           <div className="skeleton" style={{ height: 44, width: 120 }} />

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
-import { AppBar, EmptyState } from "../../../components/ui";
+import AdminNav from "../../../components/AdminNav";
+import { AppBar, Button, EmptyState, showToast } from "../../../components/ui";
 
 type FeedbackRow = {
   id: string;
@@ -61,6 +62,7 @@ export default function AdminFeedbackPage(): React.JSX.Element {
   const [filterStatus, setFilterStatus] = useState<
     "ALL" | FeedbackRow["status"]
   >("ALL");
+  const [updatingIds, setUpdatingIds] = useState<Set<string>>(new Set());
 
   async function load(): Promise<void> {
     setLoading(true);
@@ -76,6 +78,7 @@ export default function AdminFeedbackPage(): React.JSX.Element {
         setForbidden(true);
         return;
       }
+      if (!res.ok) throw new Error(`feedback request failed: ${res.status}`);
       const data = await res.json().catch(() => ({ items: [] }));
       setRows((data?.items || []) as FeedbackRow[]);
     } catch (err: unknown) {
@@ -96,6 +99,8 @@ export default function AdminFeedbackPage(): React.JSX.Element {
     status: FeedbackRow["status"],
   ): Promise<void> {
     const previous = rows.find((r) => r.id === id)?.status ?? "NEW";
+    setUpdatingIds((current) => new Set(current).add(id));
+    setError(null);
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)));
     try {
       const res = await fetch(`/api/admin/feedback/${id}`, {
@@ -112,6 +117,11 @@ export default function AdminFeedbackPage(): React.JSX.Element {
           prev.map((r) => (r.id === id ? { ...r, status: previous } : r)),
         );
         setError("Status bijwerken mislukt.");
+      } else {
+        if (filterStatus !== "ALL" && status !== filterStatus) {
+          setRows((current) => current.filter((row) => row.id !== id));
+        }
+        showToast("Feedbackstatus bijgewerkt", "success");
       }
     } catch (err: unknown) {
       Sentry.captureException(err, { tags: { component: "admin-feedback" } });
@@ -119,6 +129,12 @@ export default function AdminFeedbackPage(): React.JSX.Element {
         prev.map((r) => (r.id === id ? { ...r, status: previous } : r)),
       );
       setError("Status bijwerken mislukt.");
+    } finally {
+      setUpdatingIds((current) => {
+        const next = new Set(current);
+        next.delete(id);
+        return next;
+      });
     }
   }
 
@@ -142,15 +158,17 @@ export default function AdminFeedbackPage(): React.JSX.Element {
   return (
     <main className="container pb-24">
       <AppBar title="Feedback" fallbackHref="/admin" />
+      <AdminNav />
       <p className="muted">
         {counts.BUG} {counts.BUG === 1 ? "bug" : "bugs"} • {counts.IDEA}{" "}
         {counts.IDEA === 1 ? "idee" : "ideeën"}
       </p>
 
-      <div className="row gap-3 mb-4">
+      <div className="admin-filter-row">
         <label>
           <span className="muted text-xs mr-1">Type</span>
           <select
+            className="ui-select"
             value={filterType}
             onChange={(e) => setFilterType(e.target.value as typeof filterType)}
           >
@@ -162,6 +180,7 @@ export default function AdminFeedbackPage(): React.JSX.Element {
         <label>
           <span className="muted text-xs mr-1">Status</span>
           <select
+            className="ui-select"
             value={filterStatus}
             onChange={(e) =>
               setFilterStatus(e.target.value as typeof filterStatus)
@@ -177,7 +196,14 @@ export default function AdminFeedbackPage(): React.JSX.Element {
         </label>
       </div>
 
-      {error ? <p className="muted">{error}</p> : null}
+      {error ? (
+        <div role="alert" className="row" style={{ marginBottom: 12 }}>
+          <span style={{ color: "var(--negative)" }}>{error}</span>
+          <Button size="sm" onClick={() => void load()}>
+            Opnieuw proberen
+          </Button>
+        </div>
+      ) : null}
 
       {loading ? (
         <div className="list" aria-busy="true">
@@ -187,20 +213,40 @@ export default function AdminFeedbackPage(): React.JSX.Element {
         </div>
       ) : rows.length === 0 ? (
         <EmptyState
-          title="Nog geen feedback"
-          body="Zodra spelers iets indienen verschijnt het hier."
+          title="Geen feedback gevonden"
+          body={
+            filterType === "ALL" && filterStatus === "ALL"
+              ? "Zodra spelers iets indienen verschijnt het hier."
+              : "Pas de filters aan om meer resultaten te zien."
+          }
+          action={
+            filterType !== "ALL" || filterStatus !== "ALL" ? (
+              <Button
+                size="sm"
+                onClick={() => {
+                  setFilterType("ALL");
+                  setFilterStatus("ALL");
+                }}
+              >
+                Filters wissen
+              </Button>
+            ) : undefined
+          }
         />
       ) : (
         <ul className="list-none p-0 grid gap-3">
           {rows.map((r) => (
             <li key={r.id} className="card">
-              <div className="row justify-between mb-1">
+              <div className="admin-feedback-header">
                 <strong>
                   <span className="badge mr-2">{TYPE_NL[r.type]}</span>
                   {r.title}
                 </strong>
                 <select
+                  className="ui-select"
                   value={r.status}
+                  disabled={updatingIds.has(r.id)}
+                  aria-label={`Status van ${r.title}`}
                   onChange={(e) =>
                     void updateStatus(
                       r.id,

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 import AdminNav from "../../../components/AdminNav";
 import { AppBar, Button, EmptyState, showToast } from "../../../components/ui";
@@ -62,6 +62,8 @@ export default function AdminFeedbackPage(): React.JSX.Element {
   const [filterStatus, setFilterStatus] = useState<
     "ALL" | FeedbackRow["status"]
   >("ALL");
+  const filterStatusRef = useRef(filterStatus);
+  filterStatusRef.current = filterStatus;
   const [updatingIds, setUpdatingIds] = useState<Set<string>>(new Set());
 
   async function load(): Promise<void> {
@@ -118,7 +120,8 @@ export default function AdminFeedbackPage(): React.JSX.Element {
         );
         setError("Status bijwerken mislukt.");
       } else {
-        if (filterStatus !== "ALL" && status !== filterStatus) {
+        const currentFilterStatus = filterStatusRef.current;
+        if (currentFilterStatus !== "ALL" && status !== currentFilterStatus) {
           setRows((current) => current.filter((row) => row.id !== id));
         }
         showToast("Feedbackstatus bijgewerkt", "success");

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -1,8 +1,12 @@
+import AdminNav from "../../components/AdminNav";
+
 export default function Loading() {
   return (
     <main>
       <div className="container">
         <h1>Admin</h1>
+        <AdminNav />
+        <div className="skeleton" style={{ height: 64, marginBottom: 16 }} />
         <div
           className="card skeleton"
           style={{ height: 56, marginBottom: 12 }}

--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -6,14 +6,11 @@ export default function Loading() {
       <div className="container">
         <h1>Admin</h1>
         <AdminNav />
-        <div className="skeleton" style={{ height: 64, marginBottom: 16 }} />
-        <div
-          className="card skeleton"
-          style={{ height: 56, marginBottom: 12 }}
-        />
+        <div className="skeleton h-16 mb-4" />
+        <div className="card skeleton h-14 mb-3" />
         <div className="list" aria-busy="true">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="card skeleton" style={{ height: 48 }} />
+            <div key={i} className="card skeleton h-12" />
           ))}
         </div>
       </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Sentry from "@sentry/nextjs";
 import { useEffect, useMemo, useState } from "react";
 import AdminNav from "../../components/AdminNav";
 import {
@@ -38,11 +39,22 @@ async function apiErrorMessage(
   response: Response,
   fallback: string,
 ): Promise<string> {
-  const payload = (await response.json().catch(() => null)) as {
-    message?: string;
-    info?: string;
-  } | null;
+  let payload: { message?: string; info?: string } | null = null;
+  try {
+    payload = (await response.json()) as {
+      message?: string;
+      info?: string;
+    } | null;
+  } catch (error: unknown) {
+    Sentry.captureException(error, {
+      tags: { component: "admin-users", operation: "parse-api-error" },
+    });
+  }
   return payload?.info || payload?.message || fallback;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export default function AdminUsersPage() {
@@ -81,7 +93,10 @@ export default function AdminUsersPage() {
         if (!mounted) return;
         setRows((data?.users || []) as UserRow[]);
         setDirty(false);
-      } catch {
+      } catch (error: unknown) {
+        Sentry.captureException(error, {
+          tags: { component: "admin-users", operation: "load" },
+        });
         if (mounted) setLoadError("Gebruikers laden mislukt.");
       } finally {
         if (mounted) setLoading(false);
@@ -119,7 +134,10 @@ export default function AdminUsersPage() {
       }
       setDirty(false);
       showToast("Gebruikersrollen opgeslagen", "success");
-    } catch {
+    } catch (error: unknown) {
+      Sentry.captureException(error, {
+        tags: { component: "admin-users", operation: "save" },
+      });
       setSaveError("Opslaan mislukt. Controleer je verbinding.");
     } finally {
       setSaving(false);
@@ -131,9 +149,13 @@ export default function AdminUsersPage() {
     setLoadError(null);
     try {
       // Rebuild roster cache for other pages and then reload admin list
-      await fetch("/api/users?refresh=1", { cache: "no-store" }).catch(
-        () => {},
-      );
+      try {
+        await fetch("/api/users?refresh=1", { cache: "no-store" });
+      } catch (error: unknown) {
+        Sentry.captureException(error, {
+          tags: { component: "admin-users", operation: "refresh-cache" },
+        });
+      }
       const res = await fetch("/api/admin/users", { cache: "no-store" });
       if (res.ok) {
         const data = await res.json();
@@ -143,7 +165,10 @@ export default function AdminUsersPage() {
       } else {
         setLoadError("Gebruikers vernieuwen mislukt.");
       }
-    } catch {
+    } catch (error: unknown) {
+      Sentry.captureException(error, {
+        tags: { component: "admin-users", operation: "refresh" },
+      });
       setLoadError("Gebruikers vernieuwen mislukt.");
     } finally {
       setRefreshing(false);
@@ -182,8 +207,11 @@ export default function AdminUsersPage() {
       const data = await res.json();
       setExtractedJson(data?.result || null);
       setExtractMeta(data?.meta || null);
-    } catch (e: any) {
-      setTestError(`Extractiefout: ${e?.message || String(e)}`);
+    } catch (error: unknown) {
+      Sentry.captureException(error, {
+        tags: { component: "admin-users", operation: "test-extract" },
+      });
+      setTestError(`Extractiefout: ${errorMessage(error)}`);
     } finally {
       setExtracting(false);
     }
@@ -219,8 +247,11 @@ export default function AdminUsersPage() {
       }
       const data = await res.json();
       setGeneratedReport(data?.report?.content || null);
-    } catch (e: any) {
-      setTestError(`Genereerfout: ${e?.message || String(e)}`);
+    } catch (error: unknown) {
+      Sentry.captureException(error, {
+        tags: { component: "admin-users", operation: "test-generate" },
+      });
+      setTestError(`Genereerfout: ${errorMessage(error)}`);
     } finally {
       setGenerating(false);
     }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import AdminNav from "../../components/AdminNav";
+import {
+  Button,
+  Card,
+  EmptyState,
+  Input,
+  showToast,
+} from "../../components/ui";
 
 type Roles = { admin?: boolean; trainer?: boolean; player?: boolean };
 type UserRow = { id: string; name: string; roles: Roles };
@@ -21,15 +28,36 @@ type MatchJson = {
   }>;
 };
 
+type ExtractMeta = {
+  providerUsed?: string;
+  model?: string;
+  fallbackUsed?: boolean;
+};
+
+async function apiErrorMessage(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  const payload = (await response.json().catch(() => null)) as {
+    message?: string;
+    info?: string;
+  } | null;
+  return payload?.info || payload?.message || fallback;
+}
+
 export default function AdminUsersPage() {
   const [rows, setRows] = useState<UserRow[]>([]);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [forbidden, setForbidden] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
   const [testImageFile, setTestImageFile] = useState<File | null>(null);
   const [extractedJson, setExtractedJson] = useState<MatchJson | null>(null);
+  const [extractMeta, setExtractMeta] = useState<ExtractMeta | null>(null);
   const [extracting, setExtracting] = useState(false);
   const [generatedReport, setGeneratedReport] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);
@@ -39,15 +67,25 @@ export default function AdminUsersPage() {
   useEffect(() => {
     let mounted = true;
     async function load() {
-      const res = await fetch("/api/admin/users", { cache: "no-store" });
-      if (res.status === 403) {
-        setForbidden(true);
-        return;
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const res = await fetch("/api/admin/users", { cache: "no-store" });
+        if (!mounted) return;
+        if (res.status === 403) {
+          setForbidden(true);
+          return;
+        }
+        if (!res.ok) throw new Error(`users request failed: ${res.status}`);
+        const data = await res.json();
+        if (!mounted) return;
+        setRows((data?.users || []) as UserRow[]);
+        setDirty(false);
+      } catch {
+        if (mounted) setLoadError("Gebruikers laden mislukt.");
+      } finally {
+        if (mounted) setLoading(false);
       }
-      const data = await res.json();
-      if (!mounted) return;
-      setRows((data?.users || []) as UserRow[]);
-      setDirty(false);
     }
     load();
     return () => {
@@ -80,6 +118,9 @@ export default function AdminUsersPage() {
         return;
       }
       setDirty(false);
+      showToast("Gebruikersrollen opgeslagen", "success");
+    } catch {
+      setSaveError("Opslaan mislukt. Controleer je verbinding.");
     } finally {
       setSaving(false);
     }
@@ -87,6 +128,7 @@ export default function AdminUsersPage() {
 
   async function onRefresh() {
     setRefreshing(true);
+    setLoadError(null);
     try {
       // Rebuild roster cache for other pages and then reload admin list
       await fetch("/api/users?refresh=1", { cache: "no-store" }).catch(
@@ -97,16 +139,23 @@ export default function AdminUsersPage() {
         const data = await res.json();
         setRows((data?.users || []) as UserRow[]);
         setDirty(false);
+        showToast("Gebruikers vernieuwd", "success");
+      } else {
+        setLoadError("Gebruikers vernieuwen mislukt.");
       }
+    } catch {
+      setLoadError("Gebruikers vernieuwen mislukt.");
     } finally {
       setRefreshing(false);
     }
   }
 
-  const sorted = useMemo(
-    () => rows.slice().sort((a, b) => a.name.localeCompare(b.name)),
-    [rows],
-  );
+  const sorted = useMemo(() => {
+    const needle = query.trim().toLocaleLowerCase("nl-NL");
+    return rows
+      .filter((row) => row.name.toLocaleLowerCase("nl-NL").includes(needle))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [query, rows]);
 
   async function onTestExtract() {
     if (!testImageFile) {
@@ -116,6 +165,7 @@ export default function AdminUsersPage() {
     setExtracting(true);
     setTestError(null);
     setExtractedJson(null);
+    setExtractMeta(null);
     try {
       const form = new FormData();
       form.set("image", testImageFile);
@@ -124,12 +174,14 @@ export default function AdminUsersPage() {
         body: form,
       });
       if (!res.ok) {
-        const text = await res.text();
-        setTestError(`Extractie mislukt: ${text}`);
+        setTestError(
+          `Extractie mislukt: ${await apiErrorMessage(res, "onbekende fout")}`,
+        );
         return;
       }
       const data = await res.json();
       setExtractedJson(data?.result || null);
+      setExtractMeta(data?.meta || null);
     } catch (e: any) {
       setTestError(`Extractiefout: ${e?.message || String(e)}`);
     } finally {
@@ -187,9 +239,15 @@ export default function AdminUsersPage() {
       <div className="container">
         <h1>Admin</h1>
 
-        <div className="row" style={{ gap: 8, marginBottom: 12 }}>
-          <Link href={{ pathname: "/admin/feedback" }}>Feedback-inbox →</Link>
-        </div>
+        <AdminNav />
+
+        <Input
+          label="Zoek gebruiker"
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Naam"
+        />
 
         <div className="card" style={{ position: "sticky", top: 0, zIndex: 1 }}>
           <div
@@ -199,14 +257,30 @@ export default function AdminUsersPage() {
               alignItems: "center",
             }}
           >
-            <div className="muted">Gebruikersrollen</div>
+            <div className="muted">
+              {loading ? "Gebruikers laden…" : `${sorted.length} gebruikers`}
+            </div>
             <div className="row" style={{ gap: 8 }}>
-              <button onClick={onRefresh} disabled={refreshing}>
-                {refreshing ? "Vernieuwen…" : "Vernieuwen"}
-              </button>
-              <button onClick={onSave} disabled={!dirty || saving}>
-                {saving ? "Opslaan…" : "Opslaan"}
-              </button>
+              <Button
+                onClick={onRefresh}
+                disabled={dirty}
+                loading={refreshing}
+                loadingLabel="Vernieuwen…"
+                size="sm"
+                title={dirty ? "Sla wijzigingen eerst op" : undefined}
+              >
+                Vernieuwen
+              </Button>
+              <Button
+                onClick={onSave}
+                disabled={!dirty}
+                loading={saving}
+                loadingLabel="Opslaan…"
+                size="sm"
+                variant="primary"
+              >
+                Opslaan
+              </Button>
             </div>
           </div>
           {saveError ? (
@@ -218,146 +292,181 @@ export default function AdminUsersPage() {
               {saveError}
             </div>
           ) : null}
-        </div>
-        <div className="list">
-          {sorted.map((u) => (
-            <div key={u.id} className="card">
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  gap: 12,
-                }}
-              >
-                <div>{u.name}</div>
-                <div className="row" style={{ gap: 8 }}>
-                  <label
-                    className="badge"
-                    style={{ cursor: "pointer", padding: "6px 10px" }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={!!u.roles.player}
-                      onChange={() => toggle(u.id, "player")}
-                      style={{ marginRight: 6 }}
-                    />
-                    Speler
-                  </label>
-                  <label
-                    className="badge"
-                    style={{ cursor: "pointer", padding: "6px 10px" }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={!!u.roles.trainer}
-                      onChange={() => toggle(u.id, "trainer")}
-                      style={{ marginRight: 6 }}
-                    />
-                    Trainer
-                  </label>
-                  <label
-                    className="badge"
-                    style={{ cursor: "pointer", padding: "6px 10px" }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={!!u.roles.admin}
-                      onChange={() => toggle(u.id, "admin")}
-                      style={{ marginRight: 6 }}
-                    />
-                    Admin
-                  </label>
-                </div>
-              </div>
+          {loadError ? (
+            <div
+              role="alert"
+              style={{ marginTop: 8, color: "var(--negative)" }}
+            >
+              {loadError}
             </div>
-          ))}
-          {sorted.length === 0 ? (
-            <div className="muted">Geen gebruikers gevonden.</div>
+          ) : null}
+        </div>
+        <div className="list" aria-busy={loading || undefined}>
+          {loading
+            ? Array.from({ length: 5 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="card skeleton"
+                  style={{ height: 76 }}
+                />
+              ))
+            : sorted.map((u) => (
+                <div key={u.id} className="card">
+                  <div
+                    className="admin-user-row"
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      gap: 12,
+                    }}
+                  >
+                    <div>{u.name}</div>
+                    <div className="admin-role-row">
+                      <label className="badge admin-role-toggle">
+                        <input
+                          type="checkbox"
+                          checked={!!u.roles.player}
+                          onChange={() => toggle(u.id, "player")}
+                          aria-label={`Speler voor ${u.name}`}
+                        />
+                        Speler
+                      </label>
+                      <label className="badge admin-role-toggle">
+                        <input
+                          type="checkbox"
+                          checked={!!u.roles.trainer}
+                          onChange={() => toggle(u.id, "trainer")}
+                          aria-label={`Trainer voor ${u.name}`}
+                        />
+                        Trainer
+                      </label>
+                      <label className="badge admin-role-toggle">
+                        <input
+                          type="checkbox"
+                          checked={!!u.roles.admin}
+                          onChange={() => toggle(u.id, "admin")}
+                          aria-label={`Admin voor ${u.name}`}
+                        />
+                        Admin
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              ))}
+          {!loading && sorted.length === 0 ? (
+            <EmptyState
+              title={query ? "Geen gebruikers gevonden" : "Nog geen gebruikers"}
+              body={
+                query
+                  ? "Pas je zoekopdracht aan."
+                  : "Vernieuw om het opnieuw te proberen."
+              }
+              action={
+                loadError ? (
+                  <Button onClick={onRefresh}>Opnieuw proberen</Button>
+                ) : undefined
+              }
+            />
           ) : null}
         </div>
 
-        <div className="card" style={{ marginTop: 24 }}>
-          <h2 style={{ marginTop: 0 }}>Wedstrijdverslag testen</h2>
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <div>
-              <input
-                type="file"
-                accept="image/*"
-                onChange={(e) => {
-                  setTestImageFile(e.target.files?.[0] || null);
-                  setExtractedJson(null);
-                  setGeneratedReport(null);
-                  setTestError(null);
-                }}
-              />
-            </div>
-            <div className="row" style={{ gap: 8 }}>
-              <button
-                onClick={onTestExtract}
-                disabled={!testImageFile || extracting}
-              >
-                {extracting ? "Extractie…" : "Test extractie"}
-              </button>
-              <button
-                onClick={onTestGenerate}
-                disabled={!extractedJson || generating}
-              >
-                {generating ? "Genereren…" : "Test verslag"}
-              </button>
-            </div>
-            {testError && (
-              <div
-                role="alert"
-                style={{
-                  padding: 10,
-                  borderRadius: "var(--radius-md)",
-                  border: "1px solid var(--negative)",
-                  background:
-                    "color-mix(in oklab, var(--negative) 12%, transparent)",
-                  color: "var(--text)",
-                }}
-              >
-                {testError}
-              </div>
-            )}
-            {extractedJson && (
+        <Card style={{ marginTop: 24 }}>
+          <details>
+            <summary className="admin-tool-summary">
+              Wedstrijdverslag testen
+            </summary>
+            <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
               <div>
-                <h3>Geëxtraheerde JSON</h3>
-                <pre
-                  style={{
-                    padding: 12,
-                    background: "rgba(255,255,255,0.04)",
-                    border: "1px solid rgba(255,255,255,0.08)",
-                    borderRadius: "var(--radius-md)",
-                    overflow: "auto",
-                    maxHeight: 400,
-                    fontSize: 12,
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => {
+                    setTestImageFile(e.target.files?.[0] || null);
+                    setExtractedJson(null);
+                    setExtractMeta(null);
+                    setGeneratedReport(null);
+                    setTestError(null);
                   }}
-                >
-                  {JSON.stringify(extractedJson, null, 2)}
-                </pre>
+                />
               </div>
-            )}
-            {generatedReport && (
-              <div>
-                <h3>Gegenereerd verslag</h3>
+              <div className="row" style={{ gap: 8 }}>
+                <Button
+                  onClick={onTestExtract}
+                  disabled={!testImageFile}
+                  loading={extracting}
+                  loadingLabel="Extractie…"
+                >
+                  Test extractie
+                </Button>
+                <Button
+                  onClick={onTestGenerate}
+                  disabled={!extractedJson}
+                  loading={generating}
+                  loadingLabel="Genereren…"
+                >
+                  Test verslag
+                </Button>
+              </div>
+              {testError && (
                 <div
+                  role="alert"
                   style={{
-                    padding: 12,
-                    background: "rgba(255,255,255,0.04)",
-                    border: "1px solid rgba(255,255,255,0.08)",
+                    padding: 10,
                     borderRadius: "var(--radius-md)",
-                    whiteSpace: "pre-wrap",
-                    lineHeight: 1.6,
+                    border: "1px solid var(--negative)",
+                    background:
+                      "color-mix(in oklab, var(--negative) 12%, transparent)",
+                    color: "var(--text)",
                   }}
                 >
-                  {generatedReport}
+                  {testError}
                 </div>
-              </div>
-            )}
-          </div>
-        </div>
+              )}
+              {extractedJson && (
+                <div>
+                  {extractMeta?.model ? (
+                    <p className="muted" role="status">
+                      Verwerkt met {extractMeta.model}
+                      {extractMeta.fallbackUsed ? " (fallback)" : ""}
+                    </p>
+                  ) : null}
+                  <h3>Geëxtraheerde JSON</h3>
+                  <pre
+                    style={{
+                      padding: 12,
+                      background: "rgba(255,255,255,0.04)",
+                      border: "1px solid rgba(255,255,255,0.08)",
+                      borderRadius: "var(--radius-md)",
+                      overflow: "auto",
+                      maxHeight: 400,
+                      fontSize: 12,
+                    }}
+                  >
+                    {JSON.stringify(extractedJson, null, 2)}
+                  </pre>
+                </div>
+              )}
+              {generatedReport && (
+                <div>
+                  <h3>Gegenereerd verslag</h3>
+                  <div
+                    style={{
+                      padding: 12,
+                      background: "rgba(255,255,255,0.04)",
+                      border: "1px solid rgba(255,255,255,0.08)",
+                      borderRadius: "var(--radius-md)",
+                      whiteSpace: "pre-wrap",
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    {generatedReport}
+                  </div>
+                </div>
+              )}
+            </div>
+          </details>
+        </Card>
       </div>
     </main>
   );

--- a/src/app/api/report/extract/route.ts
+++ b/src/app/api/report/extract/route.ts
@@ -28,6 +28,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       result: extracted.result,
       raw_text: extracted.rawText,
+      meta: {
+        providerUsed: extracted.providerUsed,
+        model: extracted.model,
+        fallbackUsed: extracted.fallbackUsed,
+      },
     });
   } catch (error: unknown) {
     const latencyMs = Date.now() - startedAt;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -474,6 +474,84 @@ h3 {
   max-width: 100%;
 }
 
+.admin-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+  padding: 4px;
+  margin-bottom: var(--space-4);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.035);
+}
+.admin-tabs a {
+  min-height: var(--hit);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: var(--muted);
+  font-weight: 600;
+  text-decoration: none;
+}
+.admin-tabs a[aria-current="page"] {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.1);
+}
+.admin-role-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+.admin-role-toggle {
+  cursor: pointer;
+  padding: 8px 10px;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+}
+.admin-role-toggle input {
+  margin-right: 6px;
+}
+.admin-filter-row,
+.admin-feedback-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.admin-filter-row label {
+  flex: 1;
+  min-width: 0;
+}
+.admin-tool-summary {
+  min-height: var(--hit);
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-weight: 700;
+}
+@media (max-width: 640px) {
+  .admin-user-row {
+    align-items: flex-start !important;
+    flex-direction: column;
+  }
+  .admin-role-row {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .admin-filter-row,
+  .admin-feedback-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .admin-feedback-header select {
+    width: 100%;
+  }
+}
+
 .eventTitle {
   font-weight: 600;
   overflow-wrap: anywhere;

--- a/src/components/AdminNav.test.tsx
+++ b/src/components/AdminNav.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AdminNav from "./AdminNav";
+
+vi.mock("next/navigation", () => ({ usePathname: vi.fn() }));
+
+describe("AdminNav", () => {
+  beforeEach(() => vi.mocked(usePathname).mockReturnValue("/admin"));
+
+  it("marks the users tab active on the admin index", () => {
+    render(<AdminNav />);
+    expect(screen.getByRole("link", { name: "Gebruikers" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("marks feedback active on nested feedback routes", () => {
+    vi.mocked(usePathname).mockReturnValue("/admin/feedback");
+    render(<AdminNav />);
+    expect(screen.getByRole("link", { name: "Feedback" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+});

--- a/src/components/AdminNav.test.tsx
+++ b/src/components/AdminNav.test.tsx
@@ -1,12 +1,19 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { usePathname } from "next/navigation";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminNav from "./AdminNav";
 
 vi.mock("next/navigation", () => ({ usePathname: vi.fn() }));
 
 describe("AdminNav", () => {
-  beforeEach(() => vi.mocked(usePathname).mockReturnValue("/admin"));
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(usePathname).mockReturnValue("/admin");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
 
   it("marks the users tab active on the admin index", () => {
     render(<AdminNav />);

--- a/src/components/AdminNav.tsx
+++ b/src/components/AdminNav.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const items = [
+  { href: "/admin", label: "Gebruikers" },
+  { href: "/admin/feedback", label: "Feedback" },
+] as const;
+
+/** Compact tab navigation shared by all admin screens. */
+export default function AdminNav() {
+  const pathname = usePathname() || "/admin";
+
+  return (
+    <nav className="admin-tabs" aria-label="Admin-onderdelen">
+      {items.map((item) => {
+        const active =
+          item.href === "/admin"
+            ? pathname === item.href
+            : pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={active ? "page" : undefined}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/lib/ai/gatewayModels.test.ts
+++ b/src/lib/ai/gatewayModels.test.ts
@@ -151,19 +151,24 @@ describe("getReportExtractGatewayModel", () => {
     vi.unstubAllEnvs();
   });
 
-  it("uses gpt-4o default when env unset", () => {
+  it("uses gpt-5.6-sol default when env unset", () => {
     vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "");
-    expect(getReportExtractGatewayModel()).toBe("openai/gpt-4o");
+    expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");
   });
 
-  it("remaps gpt-5 env override", () => {
+  it("remaps the legacy GPT-5 chat alias", () => {
     vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "openai/gpt-5-chat-latest");
-    expect(getReportExtractGatewayModel()).toBe("openai/gpt-4o");
+    expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");
   });
 
-  it("routes claude sonnet env override to anthropic gateway id", () => {
+  it("remaps provider-mismatched Claude ids", () => {
+    vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "openai/claude-sonnet-4-6");
+    expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");
+  });
+
+  it("remaps a bare Claude env override to the OpenAI extraction default", () => {
     vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "claude-sonnet-4-6");
-    expect(getReportExtractGatewayModel()).toBe("anthropic/claude-sonnet-4.6");
+    expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");
   });
 });
 

--- a/src/lib/ai/gatewayModels.test.ts
+++ b/src/lib/ai/gatewayModels.test.ts
@@ -166,6 +166,11 @@ describe("getReportExtractGatewayModel", () => {
     expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");
   });
 
+  it("remaps an empty OpenAI model id", () => {
+    vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "openai/");
+    expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");
+  });
+
   it("remaps a bare Claude env override to the OpenAI extraction default", () => {
     vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "claude-sonnet-4-6");
     expect(getReportExtractGatewayModel()).toBe("openai/gpt-5.6-sol");

--- a/src/lib/ai/gatewayModels.ts
+++ b/src/lib/ai/gatewayModels.ts
@@ -11,6 +11,9 @@ export const DEFAULT_STRUCTURED_GATEWAY_MODEL = "openai/gpt-4o";
 /** `generateText` default (match report narrative). */
 export const DEFAULT_TEXT_GATEWAY_MODEL = "openai/gpt-4o";
 
+/** Screenshot extraction default: strongest current OpenAI vision model. */
+export const DEFAULT_REPORT_EXTRACT_GATEWAY_MODEL = "openai/gpt-5.6-sol";
+
 const STRUCTURED_FALLBACK = DEFAULT_STRUCTURED_GATEWAY_MODEL;
 const TEXT_FALLBACK = DEFAULT_TEXT_GATEWAY_MODEL;
 
@@ -155,12 +158,37 @@ export function getReportGenerateGatewayModel(): string {
 
 /**
  * Model for screenshot/VLM `generateObject` in report extract. Honors
- * `REPORT_EXTRACT_OPENAI_MODEL` when set; remaps free-tier-blocked ids to
- * `openai/gpt-4o` (see Sentry JAVASCRIPT-NEXTJS-38).
+ * `REPORT_EXTRACT_OPENAI_MODEL` when set; remaps stale or provider-mismatched
+ * ids to the current OpenAI vision default.
  */
 export function getReportExtractGatewayModel(): string {
   const fromEnv = process.env.REPORT_EXTRACT_OPENAI_MODEL?.trim();
-  return resolveGatewayModel(fromEnv ?? "", "text").model;
+  return resolveReportExtractGatewayModel(fromEnv ?? "").model;
+}
+
+/** Keeps screenshot extraction on OpenAI and repairs stale/provider-mismatched overrides. */
+export function resolveReportExtractGatewayModel(
+  raw: string,
+): ResolvedGatewayModel {
+  const requested = raw.trim();
+  if (!requested) return { model: DEFAULT_REPORT_EXTRACT_GATEWAY_MODEL };
+
+  const slash = requested.indexOf("/");
+  const provider = slash >= 0 ? requested.slice(0, slash) : "openai";
+  const id = gatewayModelId(requested);
+  const invalidForOpenAi =
+    provider !== "openai" ||
+    id.startsWith("claude-") ||
+    id === "gpt-5-chat-latest" ||
+    id === "gpt-5.2-2025-12-11";
+
+  if (!invalidForOpenAi) {
+    return { model: toGatewayModelString(id, "openai") };
+  }
+  return {
+    model: DEFAULT_REPORT_EXTRACT_GATEWAY_MODEL,
+    substitutedFrom: requested,
+  };
 }
 
 /**

--- a/src/lib/ai/gatewayModels.ts
+++ b/src/lib/ai/gatewayModels.ts
@@ -177,6 +177,7 @@ export function resolveReportExtractGatewayModel(
   const provider = slash >= 0 ? requested.slice(0, slash) : "openai";
   const id = gatewayModelId(requested);
   const invalidForOpenAi =
+    !id ||
     provider !== "openai" ||
     id.startsWith("claude-") ||
     id === "gpt-5-chat-latest" ||

--- a/src/lib/reportExtractProvider.test.ts
+++ b/src/lib/reportExtractProvider.test.ts
@@ -47,7 +47,7 @@ describe("reportExtractProvider", () => {
     mockedGenerateObject.mockReset();
     mockedSentryCapture.mockReset();
     process.env = { ...originalEnv };
-    process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5.6-sol";
+    vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "gpt-5.6-sol");
     delete process.env.OPENAI_API_KEY;
     delete process.env.OCR_WORKER_URL;
     delete process.env.OCR_WORKER_TOKEN;
@@ -56,6 +56,7 @@ describe("reportExtractProvider", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
   });
 
@@ -80,28 +81,28 @@ describe("reportExtractProvider", () => {
     });
 
     it("defaults REPORT_EXTRACT_OPENAI_MODEL to gpt-5.6-sol when unset", () => {
-      delete process.env.REPORT_EXTRACT_OPENAI_MODEL;
+      vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", undefined);
       const cfg = getExtractProviderConfig();
       expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBeUndefined();
     });
 
     it("remaps removed gateway snapshot to gpt-5.6-sol", () => {
-      process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5.2-2025-12-11";
+      vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "gpt-5.2-2025-12-11");
       const cfg = getExtractProviderConfig();
       expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBe("gpt-5.2-2025-12-11");
     });
 
     it("remaps the legacy chat alias to gpt-5.6-sol", () => {
-      process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5-chat-latest";
+      vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "gpt-5-chat-latest");
       const cfg = getExtractProviderConfig();
       expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBe("gpt-5-chat-latest");
     });
 
     it("remaps claude-sonnet-4-6 to the OpenAI extraction default", () => {
-      process.env.REPORT_EXTRACT_OPENAI_MODEL = "claude-sonnet-4-6";
+      vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "claude-sonnet-4-6");
       const cfg = getExtractProviderConfig();
       expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBe("claude-sonnet-4-6");
@@ -229,7 +230,7 @@ describe("reportExtractProvider", () => {
     });
 
     it("uses gpt-5.6-sol when extract model env was a removed snapshot", async () => {
-      process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5.2-2025-12-11";
+      vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "gpt-5.2-2025-12-11");
       mockedGenerateObject.mockResolvedValueOnce({
         object: {
           homeTeam: "A",
@@ -253,7 +254,7 @@ describe("reportExtractProvider", () => {
     });
 
     it("replaces a stale Claude extract model with the OpenAI default", async () => {
-      process.env.REPORT_EXTRACT_OPENAI_MODEL = "claude-sonnet-4-6";
+      vi.stubEnv("REPORT_EXTRACT_OPENAI_MODEL", "claude-sonnet-4-6");
       mockedGenerateObject.mockResolvedValueOnce({
         object: {
           homeTeam: "A",

--- a/src/lib/reportExtractProvider.test.ts
+++ b/src/lib/reportExtractProvider.test.ts
@@ -47,7 +47,7 @@ describe("reportExtractProvider", () => {
     mockedGenerateObject.mockReset();
     mockedSentryCapture.mockReset();
     process.env = { ...originalEnv };
-    process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-4o";
+    process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5.6-sol";
     delete process.env.OPENAI_API_KEY;
     delete process.env.OCR_WORKER_URL;
     delete process.env.OCR_WORKER_TOKEN;
@@ -63,7 +63,7 @@ describe("reportExtractProvider", () => {
     it("defaults to vlm when provider is missing", () => {
       const cfg = getExtractProviderConfig();
       expect(cfg.provider).toBe("vlm");
-      expect(cfg.openAiModel).toBe("openai/gpt-4o");
+      expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
     });
 
     it("does not require OPENAI_API_KEY (gateway handles auth)", () => {
@@ -79,42 +79,42 @@ describe("reportExtractProvider", () => {
       );
     });
 
-    it("defaults REPORT_EXTRACT_OPENAI_MODEL to gpt-4o when unset", () => {
+    it("defaults REPORT_EXTRACT_OPENAI_MODEL to gpt-5.6-sol when unset", () => {
       delete process.env.REPORT_EXTRACT_OPENAI_MODEL;
       const cfg = getExtractProviderConfig();
-      expect(cfg.openAiModel).toBe("openai/gpt-4o");
+      expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBeUndefined();
     });
 
-    it("remaps removed gateway snapshot gpt-5.2-2025-12-11 to gpt-4o", () => {
+    it("remaps removed gateway snapshot to gpt-5.6-sol", () => {
       process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5.2-2025-12-11";
       const cfg = getExtractProviderConfig();
-      expect(cfg.openAiModel).toBe("openai/gpt-4o");
+      expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBe("gpt-5.2-2025-12-11");
     });
 
-    it("remaps free-tier-blocked gpt-5-chat-latest to gpt-4o", () => {
+    it("remaps the legacy chat alias to gpt-5.6-sol", () => {
       process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5-chat-latest";
       const cfg = getExtractProviderConfig();
-      expect(cfg.openAiModel).toBe("openai/gpt-4o");
+      expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
       expect(cfg.openAiModelSubstitutedFrom).toBe("gpt-5-chat-latest");
     });
 
-    it("routes claude-sonnet-4-6 to anthropic gateway id", () => {
+    it("remaps claude-sonnet-4-6 to the OpenAI extraction default", () => {
       process.env.REPORT_EXTRACT_OPENAI_MODEL = "claude-sonnet-4-6";
       const cfg = getExtractProviderConfig();
-      expect(cfg.openAiModel).toBe("anthropic/claude-sonnet-4.6");
-      expect(cfg.openAiModelSubstitutedFrom).toBeUndefined();
+      expect(cfg.openAiModel).toBe("openai/gpt-5.6-sol");
+      expect(cfg.openAiModelSubstitutedFrom).toBe("claude-sonnet-4-6");
     });
   });
 
   describe("resolveReportExtractOpenAiModel", () => {
-    it("returns openai/gpt-4o for empty input", () => {
+    it("returns openai/gpt-5.6-sol for empty input", () => {
       expect(resolveReportExtractOpenAiModel("")).toEqual({
-        model: "openai/gpt-4o",
+        model: "openai/gpt-5.6-sol",
       });
       expect(resolveReportExtractOpenAiModel("  ")).toEqual({
-        model: "openai/gpt-4o",
+        model: "openai/gpt-5.6-sol",
       });
     });
 
@@ -122,7 +122,7 @@ describe("reportExtractProvider", () => {
       expect(
         resolveReportExtractOpenAiModel("openai/gpt-5.2-2025-12-11"),
       ).toEqual({
-        model: "openai/gpt-4o",
+        model: "openai/gpt-5.6-sol",
         substitutedFrom: "openai/gpt-5.2-2025-12-11",
       });
     });
@@ -131,7 +131,7 @@ describe("reportExtractProvider", () => {
       expect(
         resolveReportExtractOpenAiModel("openai/gpt-5-chat-latest"),
       ).toEqual({
-        model: "openai/gpt-4o",
+        model: "openai/gpt-5.6-sol",
         substitutedFrom: "openai/gpt-5-chat-latest",
       });
     });
@@ -142,9 +142,19 @@ describe("reportExtractProvider", () => {
       });
     });
 
-    it("routes claude sonnet env ids to anthropic gateway id", () => {
+    it("remaps bare Claude ids to the OpenAI extraction default", () => {
       expect(resolveReportExtractOpenAiModel("claude-sonnet-4-6")).toEqual({
-        model: "anthropic/claude-sonnet-4.6",
+        model: "openai/gpt-5.6-sol",
+        substitutedFrom: "claude-sonnet-4-6",
+      });
+    });
+
+    it("remaps Claude ids even when incorrectly prefixed as OpenAI", () => {
+      expect(
+        resolveReportExtractOpenAiModel("openai/claude-sonnet-4-6"),
+      ).toEqual({
+        model: "openai/gpt-5.6-sol",
+        substitutedFrom: "openai/claude-sonnet-4-6",
       });
     });
   });
@@ -175,7 +185,7 @@ describe("reportExtractProvider", () => {
         model: string;
         messages: Array<{ content: Array<{ type: string }> }>;
       };
-      expect(args.model).toBe("openai/gpt-4o");
+      expect(args.model).toBe("openai/gpt-5.6-sol");
       expect(args.messages[0].content[1].type).toBe("image");
       expect(out.providerUsed).toBe("vlm");
       expect(out.fallbackUsed).toBe(false);
@@ -216,7 +226,7 @@ describe("reportExtractProvider", () => {
       expect(out.result.homeScore).toBe(5);
     });
 
-    it("uses gpt-4o gateway id when extract model env was a removed snapshot", async () => {
+    it("uses gpt-5.6-sol when extract model env was a removed snapshot", async () => {
       process.env.REPORT_EXTRACT_OPENAI_MODEL = "gpt-5.2-2025-12-11";
       mockedGenerateObject.mockResolvedValueOnce({
         object: {
@@ -231,7 +241,7 @@ describe("reportExtractProvider", () => {
         model: string;
         messages: Array<{ content: Array<{ type: string }> }>;
       };
-      expect(args.model).toBe("openai/gpt-4o");
+      expect(args.model).toBe("openai/gpt-5.6-sol");
       expect(args.messages[0].content[1].type).toBe("image");
       expect(out.providerUsed).toBe("vlm");
       expect(out.fallbackUsed).toBe(false);
@@ -240,7 +250,7 @@ describe("reportExtractProvider", () => {
       expect(out.result.homeTeam).toBe("A");
     });
 
-    it("uses anthropic gateway id when extract model env is claude-sonnet-4-6", async () => {
+    it("replaces a stale Claude extract model with the OpenAI default", async () => {
       process.env.REPORT_EXTRACT_OPENAI_MODEL = "claude-sonnet-4-6";
       mockedGenerateObject.mockResolvedValueOnce({
         object: {
@@ -254,8 +264,9 @@ describe("reportExtractProvider", () => {
       const args = mockedGenerateObject.mock.calls[0][0] as {
         model: string;
       };
-      expect(args.model).toBe("anthropic/claude-sonnet-4.6");
-      expect(out.model).toBe("anthropic/claude-sonnet-4.6");
+      expect(args.model).toBe("openai/gpt-5.6-sol");
+      expect(out.model).toBe("openai/gpt-5.6-sol");
+      expect(out.openAiModelSubstitutedFrom).toBe("claude-sonnet-4-6");
     });
 
     it("falls back to OCR in hybrid mode when VLM fails and reports the failure to Sentry", async () => {

--- a/src/lib/reportExtractProvider.test.ts
+++ b/src/lib/reportExtractProvider.test.ts
@@ -186,6 +186,7 @@ describe("reportExtractProvider", () => {
         messages: Array<{ content: Array<{ type: string }> }>;
       };
       expect(args.model).toBe("openai/gpt-5.6-sol");
+      expect(args).not.toHaveProperty("temperature");
       expect(args.messages[0].content[1].type).toBe("image");
       expect(out.providerUsed).toBe("vlm");
       expect(out.fallbackUsed).toBe(false);
@@ -219,6 +220,7 @@ describe("reportExtractProvider", () => {
       const normalizationArgs = mockedGenerateObject.mock.calls[0][0] as {
         prompt: string;
       };
+      expect(normalizationArgs).not.toHaveProperty("temperature");
       expect(normalizationArgs.prompt).toContain("RAW OCR TEXT");
       expect(out.providerUsed).toBe("ocr");
       expect(out.fallbackUsed).toBe(false);

--- a/src/lib/reportExtractProvider.ts
+++ b/src/lib/reportExtractProvider.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { z } from "zod";
-import { resolveGatewayModel } from "./ai/gatewayModels";
+import { resolveReportExtractGatewayModel } from "./ai/gatewayModels";
 
 // OpenAI's structured-output (strict mode) via the Vercel AI Gateway requires
 // every property listed in `properties` to also appear in `required`. Optional
@@ -111,10 +111,8 @@ export type ResolvedReportExtractOpenAiModel = {
 
 /**
  * Resolves `REPORT_EXTRACT_OPENAI_MODEL` to a gateway-supported `provider/model`
- * string. Uses `openai/gpt-4o` when unset, remaps premium or removed gateway ids
- * blocked on the AI Gateway free tier (see Sentry JAVASCRIPT-NEXTJS-1F,
- * JAVASCRIPT-NEXTJS-38), and normalizes Claude ids to `anthropic/` (see
- * JAVASCRIPT-NEXTJS-3E).
+ * string. Uses `openai/gpt-5.6-sol` when unset and remaps stale, legacy, or
+ * non-OpenAI ids to that vision-capable default.
  *
  * @param raw - Value of `REPORT_EXTRACT_OPENAI_MODEL` (may be empty).
  * @returns Full gateway model string for `generateObject`, and the original env value when rewritten.
@@ -122,7 +120,7 @@ export type ResolvedReportExtractOpenAiModel = {
 export function resolveReportExtractOpenAiModel(
   raw: string,
 ): ResolvedReportExtractOpenAiModel {
-  const resolved = resolveGatewayModel(raw, "text");
+  const resolved = resolveReportExtractGatewayModel(raw);
   return {
     model: resolved.model,
     substitutedFrom: resolved.substitutedFrom,
@@ -138,7 +136,7 @@ export function resolveReportExtractOpenAiModel(
  * production or `AI_GATEWAY_API_KEY` locally.
  *
  * When `REPORT_EXTRACT_OPENAI_MODEL` is unset, defaults to
- * `gpt-4o` (vision). A removed snapshot (`gpt-5.2-2025-12-11`) is remapped to
+ * `openai/gpt-5.6-sol` (vision). A removed snapshot or non-OpenAI model is remapped to
  * the same default so production does not depend on stale Vercel env values.
  */
 export function getExtractProviderConfig(): ExtractProviderConfig {

--- a/src/lib/reportExtractProvider.ts
+++ b/src/lib/reportExtractProvider.ts
@@ -261,7 +261,6 @@ async function callAiTextNormalization(args: {
     const { object } = await generateObject({
       model: args.model,
       schema: ExtractResultSchema,
-      temperature: 0.1,
       system: SYSTEM_PROMPT,
       prompt: buildNormalizationPrompt(args.rawText),
     });
@@ -331,7 +330,6 @@ async function callAiVisionExtraction(args: {
     const { object } = await generateObject({
       model: args.model,
       schema: ExtractResultSchema,
-      temperature: 0.1,
       system: SYSTEM_PROMPT,
       messages: [
         {


### PR DESCRIPTION
## Summary

- add shared admin navigation and responsive, native-feeling admin layouts
- add structural loading, empty, retry, pending, success, and rollback states across user and feedback administration
- improve user search, role editing, refresh behavior, and readable report-extraction errors
- switch report screenshot extraction to `openai/gpt-5.6-sol`
- repair stale or provider-mismatched extraction model overrides, including the previous Claude value, and surface model metadata in the admin tester

## Why the model changed

The failing production value (`openai/claude-sonnet-4-6`) combines the OpenAI provider namespace with a Claude model id, so AI Gateway cannot resolve it. Report extraction now uses the current OpenAI vision-capable default and safely substitutes stale/non-OpenAI overrides.

## Verification

- `npm test`: 612 passed, 28 intentionally skipped
- `npx tsc --noEmit`
- `npm run build`
- pre-commit lint: 0 errors (2 pre-existing warnings)

## Notes

- based on the latest `image` branch, including #630
- leaves `.claude/launch.json` untouched and untracked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Report extract model resolution and default changed in production-facing AI paths; admin role edits remain server-authoritative but UX changes are broad across admin surfaces.
> 
> **Overview**
> **Report screenshot extraction** now defaults to `openai/gpt-5.6-sol` instead of `gpt-4o`, with dedicated `resolveReportExtractGatewayModel` logic that keeps VLM extract on **OpenAI only** and rewrites stale, legacy, or provider-mismatched env values (including `openai/claude-*` and Claude overrides) to that vision default. Vision and OCR normalization calls no longer pass `temperature`. `/api/report/extract` adds a `meta` block (`providerUsed`, `model`, `fallbackUsed`) for clients; the admin match-report tester shows the model and fallback flag.
> 
> **Admin** gets shared **`AdminNav`** (Gebruikers / Feedback) on main, feedback, and loading shells, plus responsive admin CSS. The users page adds search, skeleton loading, load/save/refresh error handling, success toasts, shared UI buttons, and collapsible report testing with clearer API errors. The feedback inbox adds nav, filter styling, retry on load failure, optimistic status updates with per-row disabling, success toasts, list removal when a status no longer matches the filter, and filter-aware empty states.
> 
> Docs and tests are updated for the new extract default and remapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d330b24c1faec5223d61e345cca67ae6c416469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nieuwe functies**
  - Beheerderspagina’s hebben nu consistente navigatie tussen Gebruikers en Feedback.
  - Feedbackbeheer ondersteunt zoeken, filters, statusupdates, foutmeldingen, opnieuw proberen en duidelijke succesmeldingen.
  - De gebruikerspagina toont laad- en foutstatussen, zoekmogelijkheden en extra extractiemetadata.
  - Extractieresultaten tonen het gebruikte model en of een fallback is toegepast.

- **Bugfixes**
  - Ongeldige of niet-ondersteunde extractiemodellen worden voortaan correct vervangen door een vision-capable standaardmodel.
  - Verbeterde foutafhandeling en responsiviteit op kleinere schermen.

- **Documentatie**
  - De standaard voor rapportextractie is bijgewerkt naar `openai/gpt-5.6-sol`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->