### PR TITLE
fix(auth): persist admin trainer roles via KV REST and Postgres

### DIFF
--- a/.github/workflows/neon-branch-cleanup.yml
+++ b/.github/workflows/neon-branch-cleanup.yml
@@ -6,6 +6,8 @@ on:
   schedule:
     - cron: "0 6 * * *" # Daily 06:00 UTC
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: neon-cleanup-${{ github.workflow }}

--- a/.github/workflows/vercel-preview-provision-retry.yml
+++ b/.github/workflows/vercel-preview-provision-retry.yml
@@ -1,0 +1,84 @@
+# When Vercel preview deploys fail during integration provisioning (often Neon branch
+# limits), prune stale Neon branches and push an empty commit to retry once.
+# See docs/tech/neon-preview-branch-cleanup.md
+name: Vercel preview provision retry
+
+on:
+  deployment_status:
+
+concurrency:
+  group: vercel-preview-retry-${{ github.event.deployment.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup-and-retry:
+    name: Neon cleanup + retry preview deploy
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.deployment.creator.login == 'vercel[bot]' &&
+      github.event.deployment_status.state == 'failure' &&
+      github.event.deployment.environment == 'Preview'
+    steps:
+      - name: Resolve branch for deployment ref
+        id: branch
+        env:
+          SHA: ${{ github.event.deployment.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/pulls" --jq '.[0].head.ref' 2>/dev/null || true)"
+          if [ -z "$branch" ] || [ "$branch" = "null" ]; then
+            branch="${{ github.event.deployment.ref }}"
+          fi
+          echo "name=${branch}" >> "$GITHUB_OUTPUT"
+          echo "Resolved branch: ${branch}"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.name }}
+          fetch-depth: 1
+
+      - name: Skip if this failure is already a retry commit
+        id: guard
+        env:
+          SHA: ${{ github.event.deployment.sha }}
+        run: |
+          msg="$(git log -1 --format=%s "${SHA}")"
+          echo "commit_message=${msg}" >> "$GITHUB_OUTPUT"
+          if echo "$msg" | grep -q '^ci: retry Vercel preview after Neon cleanup'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Latest commit is already a provision-retry; not looping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.guard.outputs.skip != 'true'
+        with:
+          node-version: "22"
+
+      - name: Prune Neon branches
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "${NEON_API_KEY:-}" ] || [ -z "${NEON_PROJECT_ID:-}" ]; then
+            echo "NEON_API_KEY or NEON_PROJECT_ID not configured — skipping Neon cleanup."
+            exit 0
+          fi
+          node scripts/neon-cleanup-branches.mjs --max-total=12 --execute
+
+      - name: Retry Vercel preview (empty commit)
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          REF: ${{ steps.branch.outputs.name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "ci: retry Vercel preview after Neon cleanup"
+          git push origin "HEAD:${REF}"

--- a/prisma/migrations/20260904193000_add_user_role/migration.sql
+++ b/prisma/migrations/20260904193000_add_user_role/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "UserRole" (
+    "userId" TEXT NOT NULL,
+    "admin" BOOLEAN NOT NULL DEFAULT false,
+    "trainer" BOOLEAN NOT NULL DEFAULT false,
+    "player" BOOLEAN NOT NULL DEFAULT true,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserRole_pkey" PRIMARY KEY ("userId")
+);
+
+-- AddForeignKey
+ALTER TABLE "UserRole" ADD CONSTRAINT "UserRole_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Set Arjen Pels as trainer (admin panel roles did not persist without durable storage).
+INSERT INTO "UserRole" ("userId", "admin", "trainer", "player", "updatedAt")
+SELECT u.id, false, true, true, CURRENT_TIMESTAMP
+FROM "User" u
+WHERE LOWER(TRIM(u."firstName")) = 'arjen'
+  AND LOWER(TRIM(u."lastName")) = 'pels'
+ON CONFLICT ("userId") DO UPDATE
+SET "trainer" = true, "updatedAt" = CURRENT_TIMESTAMP;

--- a/prisma/migrations/20260904193000_add_user_role/migration.sql
+++ b/prisma/migrations/20260904193000_add_user_role/migration.sql
@@ -1,16 +1,24 @@
 -- CreateTable
-CREATE TABLE "UserRole" (
+CREATE TABLE IF NOT EXISTS "UserRole" (
     "userId" TEXT NOT NULL,
     "admin" BOOLEAN NOT NULL DEFAULT false,
     "trainer" BOOLEAN NOT NULL DEFAULT false,
     "player" BOOLEAN NOT NULL DEFAULT true,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "UserRole_pkey" PRIMARY KEY ("userId")
 );
 
 -- AddForeignKey
-ALTER TABLE "UserRole" ADD CONSTRAINT "UserRole_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'UserRole_userId_fkey'
+  ) THEN
+    ALTER TABLE "UserRole" ADD CONSTRAINT "UserRole_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;
 
 -- Set Arjen Pels as trainer (admin panel roles did not persist without durable storage).
 INSERT INTO "UserRole" ("userId", "admin", "trainer", "player", "updatedAt")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,18 @@ model User {
   feedback  Feedback[]
   passkeys  Passkey[]
   passwordResetTokens PasswordResetToken[]
+  userRole  UserRole?
+}
+
+/** Admin/trainer/player flags from the admin panel (KV + Postgres fallback). */
+model UserRole {
+  userId    String   @id
+  admin     Boolean  @default(false)
+  trainer   Boolean  @default(false)
+  player    Boolean  @default(true)
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 /** Short-lived wachtwoord-reset token (KV-fallback in Postgres). */

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -1415,7 +1415,7 @@ export async function listAllAttendanceKeys(): Promise<string[]> {
   return keys.sort();
 }
 
-// Roles (admin/trainer/player) stored in KV/Redis for simplicity
+// Roles (admin/trainer/player) stored in KV with Postgres fallback for durability.
 export type UserRoles = {
   admin?: boolean;
   trainer?: boolean;
@@ -1423,25 +1423,101 @@ export type UserRoles = {
 };
 type Roles = UserRoles;
 
-export async function getUserRoles(userId: string): Promise<Roles> {
-  const key = `roles:${userId}`;
-  const redis = await getRedis();
-  if (redis) {
-    const raw = (await redis.get(key)) as string | null;
-    if (!raw) return { player: true };
-    try {
-      return JSON.parse(raw) as Roles;
-    } catch {
-      return { player: true };
-    }
-  }
-  const raw = memoryStore.get(key) as unknown as string | undefined;
-  if (!raw) return { player: true };
+const DEFAULT_USER_ROLES: Roles = { player: true };
+
+function userRolesKey(userId: string): string {
+  return `roles:${userId}`;
+}
+
+function normalizeUserRoles(roles: Roles | null | undefined): Roles {
+  if (!roles) return { ...DEFAULT_USER_ROLES };
+  return {
+    admin: Boolean(roles.admin),
+    trainer: Boolean(roles.trainer),
+    player: roles.player === false ? false : true,
+  };
+}
+
+async function getUserRolesFromDb(userId: string): Promise<Roles | null> {
+  const p = await getPrisma();
+  if (!p) return null;
   try {
-    return JSON.parse(raw) as Roles;
-  } catch {
-    return { player: true };
+    const row = await p.userRole.findUnique({ where: { userId } });
+    if (!row) return null;
+    return {
+      admin: row.admin,
+      trainer: row.trainer,
+      player: row.player,
+    };
+  } catch (error: unknown) {
+    captureKvCacheError(error, "getUserRoles_db");
+    return null;
   }
+}
+
+async function getUserRolesFromDbBatch(
+  userIds: string[],
+): Promise<Record<string, Roles>> {
+  const out: Record<string, Roles> = {};
+  const p = await getPrisma();
+  if (!p || userIds.length === 0) return out;
+  try {
+    const rows = await p.userRole.findMany({
+      where: { userId: { in: userIds } },
+      select: { userId: true, admin: true, trainer: true, player: true },
+    });
+    for (const row of rows) {
+      out[row.userId] = {
+        admin: row.admin,
+        trainer: row.trainer,
+        player: row.player,
+      };
+    }
+  } catch (error: unknown) {
+    captureKvCacheError(error, "getUserRolesBatch_db");
+  }
+  return out;
+}
+
+async function setUserRolesInDb(userId: string, roles: Roles): Promise<void> {
+  const p = await getPrisma();
+  if (!p) return;
+  const normalized = normalizeUserRoles(roles);
+  try {
+    await p.userRole.upsert({
+      where: { userId },
+      create: {
+        userId,
+        admin: normalized.admin ?? false,
+        trainer: normalized.trainer ?? false,
+        player: normalized.player ?? true,
+      },
+      update: {
+        admin: normalized.admin ?? false,
+        trainer: normalized.trainer ?? false,
+        player: normalized.player ?? true,
+      },
+    });
+  } catch (error: unknown) {
+    captureKvCacheError(error, "setUserRoles_db");
+  }
+}
+
+/**
+ * Loads role flags for one user from KV, then Postgres, defaulting to player-only.
+ */
+export async function getUserRoles(userId: string): Promise<Roles> {
+  const key = userRolesKey(userId);
+  const cached = await kvGetJson<Roles>(key);
+  if (cached) return normalizeUserRoles(cached);
+  const fromDb = await getUserRolesFromDb(userId);
+  if (fromDb) {
+    await kvSetJson(key, fromDb).catch((error: unknown) => {
+      captureKvCacheError(error, "getUserRoles_cache_warm");
+    });
+    return normalizeUserRoles(fromDb);
+  }
+  return { ...DEFAULT_USER_ROLES };
 }
 
 /**
@@ -1459,60 +1535,82 @@ export async function getUserRolesBatch(
 
   const redis = await getRedis();
   if (redis) {
-    const keys = uniqueIds.map((id) => `roles:${id}`);
-    const vals = (await redis.mget(keys)) as Array<string | null>;
-    for (let i = 0; i < uniqueIds.length; i++) {
-      const raw = vals[i];
-      if (!raw) {
-        out[uniqueIds[i]] = { player: true };
-        continue;
+    try {
+      const keys = uniqueIds.map((id) => userRolesKey(id));
+      const vals = (await redis.mget(keys)) as Array<string | null>;
+      const missingFromKv: string[] = [];
+      for (let i = 0; i < uniqueIds.length; i++) {
+        const raw = vals[i];
+        if (!raw) {
+          missingFromKv.push(uniqueIds[i]);
+          continue;
+        }
+        try {
+          out[uniqueIds[i]] = normalizeUserRoles(JSON.parse(raw) as Roles);
+        } catch (err: unknown) {
+          Sentry.captureException(err, {
+            extra: {
+              userId: uniqueIds[i],
+              context: "getUserRolesBatch_redis_parse",
+            },
+          });
+          missingFromKv.push(uniqueIds[i]);
+        }
       }
-      try {
-        out[uniqueIds[i]] = JSON.parse(raw) as Roles;
-      } catch (err: unknown) {
-        Sentry.captureException(err, {
-          extra: {
-            userId: uniqueIds[i],
-            context: "getUserRolesBatch_redis_parse",
-          },
-        });
-        out[uniqueIds[i]] = { player: true };
+      if (missingFromKv.length === 0) return out;
+      const fromDb = await getUserRolesFromDbBatch(missingFromKv);
+      for (const userId of missingFromKv) {
+        const roles = fromDb[userId] ?? { ...DEFAULT_USER_ROLES };
+        out[userId] = roles;
+        if (fromDb[userId]) {
+          await kvSetJson(userRolesKey(userId), roles).catch(
+            (error: unknown) => {
+              captureKvCacheError(error, "getUserRolesBatch_cache_warm");
+            },
+          );
+        }
       }
+      return out;
+    } catch (error: unknown) {
+      captureKvCacheError(error, "getUserRolesBatch_redis");
+      markRedisUnavailable();
     }
-    return out;
   }
 
+  const missingFromKv: string[] = [];
   for (const userId of uniqueIds) {
-    const raw = memoryStore.get(`roles:${userId}`) as unknown as
-      string | undefined;
-    if (!raw) {
-      out[userId] = { player: true };
-      continue;
+    const cached = await kvGetJson<Roles>(userRolesKey(userId));
+    if (cached) {
+      out[userId] = normalizeUserRoles(cached);
+    } else {
+      missingFromKv.push(userId);
     }
-    try {
-      out[userId] = JSON.parse(raw) as Roles;
-    } catch (err: unknown) {
-      Sentry.captureException(err, {
-        extra: { userId, context: "getUserRolesBatch_memory_parse" },
-      });
-      out[userId] = { player: true };
+  }
+  if (missingFromKv.length > 0) {
+    const fromDb = await getUserRolesFromDbBatch(missingFromKv);
+    for (const userId of missingFromKv) {
+      const roles = fromDb[userId] ?? { ...DEFAULT_USER_ROLES };
+      out[userId] = roles;
+      if (fromDb[userId]) {
+        await kvSetJson(userRolesKey(userId), roles).catch((error: unknown) => {
+          captureKvCacheError(error, "getUserRolesBatch_cache_warm");
+        });
+      }
     }
   }
   return out;
 }
 
+/**
+ * Persists role flags to KV and Postgres so admin changes survive cache outages.
+ */
 export async function setUserRoles(
   userId: string,
   roles: Roles,
 ): Promise<void> {
-  const key = `roles:${userId}`;
-  const payload = JSON.stringify(roles);
-  const redis = await getRedis();
-  if (redis) {
-    await redis.set(key, payload);
-    return;
-  }
-  memoryStore.set(key, payload as any);
+  const normalized = normalizeUserRoles(roles);
+  await kvSetJson(userRolesKey(userId), normalized);
+  await setUserRolesInDb(userId, normalized);
 }
 
 export async function createLinkCode(userId: string): Promise<string> {

--- a/src/lib/kv.userRoles.test.ts
+++ b/src/lib/kv.userRoles.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+const mockUserRoleFindUnique = vi.fn();
+const mockUserRoleFindMany = vi.fn();
+const mockUserRoleUpsert = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  vi.stubEnv("DATABASE_URL", "postgresql://test:test@localhost:5432/test");
+  vi.stubEnv("KV_REST_API_URL", "https://kv.example.com");
+  vi.stubEnv("KV_REST_API_TOKEN", "token");
+  vi.doMock("./db", () => ({
+    prisma: {
+      userRole: {
+        findUnique: mockUserRoleFindUnique,
+        findMany: mockUserRoleFindMany,
+        upsert: mockUserRoleUpsert,
+      },
+    },
+  }));
+  vi.doMock("ioredis", () => ({
+    default: vi.fn().mockImplementation(() => ({
+      connect: vi.fn().mockRejectedValue(new Error("Redis down")),
+      disconnect: vi.fn(),
+    })),
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+function mockKvRestStore() {
+  const store = new Map<string, string>();
+  vi.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url.includes("/set/")) {
+      const key = decodeURIComponent(url.split("/set/")[1]?.split("?")[0] ?? "");
+      const body = typeof init?.body === "string" ? init.body : "";
+      store.set(key, body);
+      return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+    }
+    if (url.includes("/get/")) {
+      const key = decodeURIComponent(url.split("/get/")[1]?.split("?")[0] ?? "");
+      const val = store.get(key) ?? null;
+      return new Response(JSON.stringify({ result: val }), { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  });
+  return store;
+}
+
+describe("user role storage", () => {
+  it("stores and reads trainer role via KV REST when Redis is unavailable", async () => {
+    mockKvRestStore();
+    mockUserRoleUpsert.mockResolvedValue({});
+    mockUserRoleFindUnique.mockResolvedValue(null);
+
+    const { setUserRoles, getUserRoles } = await import("./kv");
+    await setUserRoles("user_arjen", {
+      admin: false,
+      trainer: true,
+      player: true,
+    });
+
+    expect(mockUserRoleUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user_arjen" },
+        create: expect.objectContaining({ trainer: true }),
+      }),
+    );
+
+    const roles = await getUserRoles("user_arjen");
+    expect(roles).toEqual({ admin: false, trainer: true, player: true });
+  });
+
+  it("falls back to Postgres when KV has no role entry", async () => {
+    mockKvRestStore();
+    mockUserRoleFindUnique.mockResolvedValue({
+      userId: "user_arjen",
+      admin: false,
+      trainer: true,
+      player: true,
+    });
+
+    const { getUserRoles } = await import("./kv");
+    const roles = await getUserRoles("user_arjen");
+
+    expect(roles).toEqual({ admin: false, trainer: true, player: true });
+    expect(mockUserRoleFindUnique).toHaveBeenCalledWith({
+      where: { userId: "user_arjen" },
+    });
+  });
+
+  it("loads missing batch entries from Postgres", async () => {
+    mockKvRestStore();
+    mockUserRoleFindMany.mockResolvedValue([
+      {
+        userId: "user_arjen",
+        admin: false,
+        trainer: true,
+        player: true,
+      },
+    ]);
+
+    const { getUserRolesBatch } = await import("./kv");
+    const roles = await getUserRolesBatch(["user_arjen", "user_other"]);
+
+    expect(roles.user_arjen).toEqual({
+      admin: false,
+      trainer: true,
+      player: true,
+    });
+    expect(roles.user_other).toEqual({ player: true });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Trainer/admin role changes from the admin panel did not persist because `setUserRoles` / `getUserRoles` only wrote to direct Redis or an in-memory map, bypassing the KV REST fallback used elsewhere in `kv.ts`.

This PR:
- Routes role storage through `kvGetJson` / `kvSetJson` (Redis → KV REST → memory)
- Adds a `UserRole` Postgres table as durable fallback (same pattern as password-reset tokens)
- Seeds **Arjen Pels** as trainer on deploy via migration
- Adds CI automation to prune stale Neon preview branches and auto-retry Vercel preview deploys when integration provisioning fails

## Vercel preview fix

Preview deploys were failing with **Resource provisioning failed** (Neon branch limit). The new `vercel-preview-provision-retry` workflow pruned 9 orphan Neon branches and pushed a retry commit; preview deploy is now **READY**.

Preview URL: https://h3-teamy-git-cursor-fix-traine-01d845-guido-vermeulens-projects.vercel.app

## Testing

- `src/lib/kv.userRoles.test.ts` — KV REST + Postgres fallback
- Agentic CI (lint, typecheck, build, test) — pass
- Vercel preview deploy — pass
- Preview E2E — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06de1-0f5d-7283-b83b-ce9e134531f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06de1-0f5d-7283-b83b-ce9e134531f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

