### PR TITLE
test(report): run multipart request tests in the Node environment

### DIFF
--- a/src/app/api/report/extract/route.test.ts
+++ b/src/app/api/report/extract/route.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+// These tests build Request bodies with FormData/File; Node's Request rejects jsdom's File.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 import * as Sentry from "@sentry/nextjs";
@@ -12,7 +14,8 @@ vi.mock("@sentry/nextjs", () => ({
 }));
 
 vi.mock("@/lib/reportExtractProvider", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/reportExtractProvider")>();
+  const actual =
+    await importOriginal<typeof import("@/lib/reportExtractProvider")>();
   return {
     ...actual,
     extractReportFromImage: vi.fn(),
@@ -88,7 +91,10 @@ describe("POST /api/report/extract", () => {
 
   it("extracts report data from a valid image upload", async () => {
     const form = new FormData();
-    form.set("image", new File(["pixels"], "match.jpg", { type: "image/jpeg" }));
+    form.set(
+      "image",
+      new File(["pixels"], "match.jpg", { type: "image/jpeg" }),
+    );
     vi.mocked(extractReportFromImage).mockResolvedValue({
       result: { homeScore: 2, awayScore: 1 },
       rawText: "2-1",
@@ -110,7 +116,10 @@ describe("POST /api/report/extract", () => {
 
   it("returns provider errors and reports them to Sentry", async () => {
     const form = new FormData();
-    form.set("image", new File(["pixels"], "match.jpg", { type: "image/jpeg" }));
+    form.set(
+      "image",
+      new File(["pixels"], "match.jpg", { type: "image/jpeg" }),
+    );
     vi.mocked(extractReportFromImage).mockRejectedValue(
       new ExtractProviderError({
         message: "provider failed",

--- a/src/lib/multipartFormData.test.ts
+++ b/src/lib/multipartFormData.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+// These tests build Request bodies with FormData/File; Node's Request rejects jsdom's File.
 import { describe, expect, it } from "vitest";
 import {
   isInvalidMultipartBodyError,
@@ -72,7 +74,10 @@ describe("parseMultipartFormData", () => {
 
   it("returns parsed form data for valid multipart requests", async () => {
     const form = new FormData();
-    form.set("image", new File(["pixels"], "match.jpg", { type: "image/jpeg" }));
+    form.set(
+      "image",
+      new File(["pixels"], "match.jpg", { type: "image/jpeg" }),
+    );
 
     const req = new Request("http://localhost/api/report/extract", {
       method: "POST",


### PR DESCRIPTION
## Summary

The two test files added in #633 build `Request` bodies with `FormData`/`File`. Under the default jsdom environment, Node's `Request` rejects jsdom's `File` (`webidl.is.File` fails), so `parseMultipartFormData` and the extract route tests fail locally on Windows/Node 24 and block the pre-commit hook. They test server-side code, so they now run with `// @vitest-environment node`, where all 7 + 3 tests pass.

## Verification

- `npx vitest run src/lib/multipartFormData.test.ts src/app/api/report/extract/route.test.ts` green in the Node environment; full suite green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration and formatting; no runtime or production code changes.
> 
> **Overview**
> **Switches two server-side multipart upload test files to Vitest’s Node environment** so `Request`/`FormData`/`File` behave like production and tests stop failing when Node rejects jsdom’s `File` (e.g. Windows / Node 24, pre-commit).
> 
> Adds `// @vitest-environment node` and a short comment at the top of `multipartFormData.test.ts` and `route.test.ts`. Remaining diff is formatting only (wrapped `form.set` / `importOriginal` lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073c7f29f7979c2832e8705517b689a09f75db84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->