### PR TITLE
fix(pwa): skip service worker in dev, network-first for /_next/

### DIFF
--- a/docs/specs/functional.md
+++ b/docs/specs/functional.md
@@ -9,19 +9,22 @@ This document reflects the features that exist in the code today. Planned or fut
 ### Current Capabilities
 
 <!-- AUTOGEN:features -->
-| Feature | Docs |
-|---|---|
-| admin | docs/tech/admin/README.md |
-| arena | docs/tech/arena/README.md |
-| auth | docs/tech/auth/README.md |
-| branding | docs/tech/branding/README.md |
-| events | docs/tech/events/README.md |
-| identity-link | docs/tech/identity-link/README.md |
+
+| Feature        | Docs                               |
+| -------------- | ---------------------------------- |
+| admin          | docs/tech/admin/README.md          |
+| arena          | docs/tech/arena/README.md          |
+| auth           | docs/tech/auth/README.md           |
+| branding       | docs/tech/branding/README.md       |
+| events         | docs/tech/events/README.md         |
+| identity-link  | docs/tech/identity-link/README.md  |
 | password-reset | docs/tech/password-reset/README.md |
-| profile | docs/tech/profile/README.md |
-| reports | docs/tech/reports/README.md |
-| rsvp | docs/tech/rsvp/README.md |
-| training | docs/tech/training/README.md |
+| profile        | docs/tech/profile/README.md        |
+| pwa            | docs/tech/pwa/README.md            |
+| reports        | docs/tech/reports/README.md        |
+| rsvp           | docs/tech/rsvp/README.md           |
+| training       | docs/tech/training/README.md       |
+
 <!-- /AUTOGEN:features -->
 
 ### Implemented User Journeys
@@ -44,6 +47,7 @@ This document reflects the features that exist in the code today. Planned or fut
 ### API and Routes Inventory
 
 <!-- AUTOGEN:routes -->
+
 # Routes Inventory
 
 ## API Routes
@@ -109,6 +113,7 @@ This document reflects the features that exist in the code today. Planned or fut
 - /terms
 - /trainer/attendance
 - /trainer/attendance/[date]
+
 <!-- /AUTOGEN:routes -->
 
 ### Backlog / Out-of-scope for now

--- a/docs/tech/pwa/README.md
+++ b/docs/tech/pwa/README.md
@@ -1,0 +1,27 @@
+# PWA service worker
+
+## Summary
+
+`public/sw.js` gives the installed app (manifest in `src/app/manifest.ts`) a precached shell and offline images.
+It is registered by `src/components/ServiceWorkerRegistration.tsx` (rendered from `src/app/layout.tsx`) on
+production builds only. On every other build the component registers nothing and instead removes any worker
+left behind by a production build or a local `next start`, together with its caches, so `next dev` never runs
+stale chunks.
+
+## Caching strategy (`static-v6`)
+
+| Request                                                          | Strategy                      | Why                                                                                                                                                                           |
+| ---------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Navigations (HTML)                                               | Network only                  | Never serve a stale app shell.                                                                                                                                                |
+| `/api/*`                                                         | Network first                 | Fresh data; the cache is only a fallback.                                                                                                                                     |
+| `/_next/*` (chunks, CSS, fonts, optimised images)                | Network first, cache fallback | Production chunk names are content-hashed, so a fresh fetch is answered by the HTTP cache; `next dev` reuses the same chunk URLs across edits, so a cache hit would be stale. |
+| Other `GET` scripts, styles, images and fonts (e.g. `/logo.png`) | Cache first                   | Keeps the precached shell and images working offline.                                                                                                                         |
+
+Bump `CACHE_VERSION` in `public/sw.js` whenever the strategy or the precached list changes; the `activate`
+handler deletes every older cache.
+
+## Entry Points
+
+- Worker: `public/sw.js`.
+- Registration policy: `src/lib/serviceWorkerRegistration.ts` (`shouldRegisterServiceWorker`, `setupServiceWorker`).
+- Mount point: `src/components/ServiceWorkerRegistration.tsx`.

--- a/public/sw.js
+++ b/public/sw.js
@@ -41,29 +41,42 @@ self.addEventListener("message", (event) => {
   }
 });
 
-async function networkFirst(request) {
+/**
+ * Stores a successful response in the cache, keeping the worker alive until the write completes
+ * (`respondWith` only covers the response itself).
+ */
+function cacheResponse(event, cache, response) {
+  if (!response.ok) return;
+  event.waitUntil(cache.put(event.request, response.clone()));
+}
+
+/**
+ * Fetches from the network and refreshes the cache on success; serves the cached copy only when
+ * the network fails, so a fresh response always wins while the server is reachable.
+ */
+async function networkFirst(event) {
   const cache = await caches.open(STATIC_CACHE);
   try {
-    const response = await fetch(request);
-    if (response.ok) {
-      cache.put(request, response.clone());
-    }
+    const response = await fetch(event.request);
+    cacheResponse(event, cache, response);
     return response;
   } catch (error) {
-    const cached = await cache.match(request);
+    const cached = await cache.match(event.request);
     if (cached) return cached;
     throw error;
   }
 }
 
-async function cacheFirst(request) {
+/**
+ * Serves the cached copy when present and otherwise fetches and caches the response, so the
+ * precached shell and images keep working offline.
+ */
+async function cacheFirst(event) {
   const cache = await caches.open(STATIC_CACHE);
-  const cached = await cache.match(request);
+  const cached = await cache.match(event.request);
   if (cached) return cached;
-  const response = await fetch(request);
-  if (response.ok) {
-    cache.put(request, response.clone());
-  }
+  const response = await fetch(event.request);
+  cacheResponse(event, cache, response);
   return response;
 }
 
@@ -86,11 +99,11 @@ self.addEventListener("fetch", (event) => {
   if (request.method !== "GET") return;
 
   if (url.pathname.startsWith(NEXT_BUILD_PREFIX)) {
-    event.respondWith(networkFirst(request));
+    event.respondWith(networkFirst(event));
     return;
   }
 
   if (CACHE_FIRST_DESTINATIONS.includes(request.destination)) {
-    event.respondWith(cacheFirst(request));
+    event.respondWith(cacheFirst(event));
   }
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,18 @@
 /* Service Worker: safe caching and instant updates */
-const CACHE_VERSION = "v5";
+const CACHE_VERSION = "v6";
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 
 // Only cache immutable static assets. Do NOT cache HTML (like '/') to avoid stale UIs.
 const STATIC_ASSETS = ["/logo.png"];
+
+// Next.js build output (chunks, CSS, fonts, optimised images). Served network-first: production
+// chunk names are content-hashed, so a fresh fetch is answered by the HTTP cache, while `next dev`
+// reuses the same chunk URLs across edits and restarts, so a cache-first hit would serve stale code.
+const NEXT_BUILD_PREFIX = "/_next/";
+
+// Everything else with one of these destinations (e.g. the precached shell and images) stays
+// cache-first so it keeps working offline.
+const CACHE_FIRST_DESTINATIONS = ["script", "style", "image", "font"];
 
 self.addEventListener("install", (event) => {
   self.skipWaiting();
@@ -32,6 +41,32 @@ self.addEventListener("message", (event) => {
   }
 });
 
+async function networkFirst(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    throw error;
+  }
+}
+
+async function cacheFirst(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  if (response.ok) {
+    cache.put(request, response.clone());
+  }
+  return response;
+}
+
 self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
@@ -48,19 +83,14 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Cache-first for static assets
-  const cacheableDestinations = ["script", "style", "image", "font"];
-  if (cacheableDestinations.includes(request.destination)) {
-    event.respondWith(
-      caches.open(STATIC_CACHE).then(async (cache) => {
-        const cached = await cache.match(request);
-        if (cached) return cached;
-        const response = await fetch(request);
-        if (request.method === "GET" && response.ok) {
-          cache.put(request, response.clone());
-        }
-        return response;
-      }),
-    );
+  if (request.method !== "GET") return;
+
+  if (url.pathname.startsWith(NEXT_BUILD_PREFIX)) {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (CACHE_FIRST_DESTINATIONS.includes(request.destination)) {
+    event.respondWith(cacheFirst(request));
   }
 });

--- a/src/app/api/report/extract/route.test.ts
+++ b/src/app/api/report/extract/route.test.ts
@@ -110,6 +110,7 @@ describe("POST /api/report/extract", () => {
     await expect(response.json()).resolves.toEqual({
       result: { homeScore: 2, awayScore: 1 },
       raw_text: "2-1",
+      meta: { providerUsed: "openai", model: "gpt-4o", fallbackUsed: false },
     });
     expect(vi.mocked(extractReportFromImage)).toHaveBeenCalledTimes(1);
   });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,11 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Root layout for every page: the global chrome (header, navigation, toasts, splash) around the
+ * page content plus the client-side service worker policy. Applies the Christmas theme when the
+ * `christmas_event` environment flag is set.
+ */
 export default function RootLayout({
   children,
 }: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import SessionStatus from "../components/SessionStatus";
 import FeedbackFab from "../components/FeedbackFab";
 import WhatsNewTour from "../components/WhatsNewTour";
 import AppSplash from "../components/AppSplash";
+import ServiceWorkerRegistration from "../components/ServiceWorkerRegistration";
 import { ToastRegion } from "../components/ui";
 
 export const metadata: Metadata = {
@@ -102,37 +103,7 @@ export default function RootLayout({
             </a>
           </footer>
         </Providers>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-          if ('serviceWorker' in navigator) {
-            window.addEventListener('load', function () {
-              navigator.serviceWorker.register('/sw.js').then((registration) => {
-                if (registration.waiting) {
-                  registration.waiting.postMessage({ type: 'SKIP_WAITING' });
-                  return;
-                }
-                registration.addEventListener('updatefound', () => {
-                  const newWorker = registration.installing;
-                  if (!newWorker) return;
-                  newWorker.addEventListener('statechange', () => {
-                    if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                      newWorker.postMessage({ type: 'SKIP_WAITING' });
-                    }
-                  });
-                });
-                let refreshing = false;
-                navigator.serviceWorker.addEventListener('controllerchange', () => {
-                  if (refreshing) return;
-                  refreshing = true;
-                  window.location.reload();
-                });
-              }).catch(()=>{});
-            });
-          }
-        `,
-          }}
-        />
+        <ServiceWorkerRegistration />
       </body>
     </html>
   );

--- a/src/components/ServiceWorkerRegistration.test.tsx
+++ b/src/components/ServiceWorkerRegistration.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ServiceWorkerRegistration from "./ServiceWorkerRegistration";
 import { setupServiceWorker } from "../lib/serviceWorkerRegistration";
@@ -16,6 +16,7 @@ describe("ServiceWorkerRegistration", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.unstubAllEnvs();
   });
 

--- a/src/components/ServiceWorkerRegistration.test.tsx
+++ b/src/components/ServiceWorkerRegistration.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ServiceWorkerRegistration from "./ServiceWorkerRegistration";
+import { setupServiceWorker } from "../lib/serviceWorkerRegistration";
+
+vi.mock("../lib/serviceWorkerRegistration", () => ({
+  setupServiceWorker: vi.fn(),
+}));
+
+describe("ServiceWorkerRegistration", () => {
+  const cleanup = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(setupServiceWorker).mockReturnValue(cleanup);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("applies the production policy for a production build and renders nothing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const { container } = render(<ServiceWorkerRegistration />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(setupServiceWorker).toHaveBeenCalledWith("production");
+  });
+
+  it("passes a non-production NODE_ENV through unchanged", () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    render(<ServiceWorkerRegistration />);
+
+    expect(setupServiceWorker).toHaveBeenCalledWith("development");
+  });
+
+  it("cancels the pending policy on unmount", () => {
+    const { unmount } = render(<ServiceWorkerRegistration />);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+import { setupServiceWorker } from "../lib/serviceWorkerRegistration";
+
+/**
+ * Mounts the service worker policy for this build: production builds register `public/sw.js`,
+ * every other build removes leftover workers so `next dev` never runs stale chunks. Renders nothing.
+ */
+export default function ServiceWorkerRegistration(): null {
+  useEffect(() => setupServiceWorker(process.env.NODE_ENV), []);
+  return null;
+}

--- a/src/lib/serviceWorkerRegistration.test.ts
+++ b/src/lib/serviceWorkerRegistration.test.ts
@@ -27,10 +27,12 @@ type FakeContainer = EventTarget & {
   getRegistrations: ReturnType<typeof vi.fn>;
 };
 
+/** Builds a `ServiceWorker` stand-in with a mutable `state` and a recorded `postMessage`. */
 function createFakeWorker(state: ServiceWorkerState): FakeWorker {
   return Object.assign(new EventTarget(), { state, postMessage: vi.fn() });
 }
 
+/** Builds a `ServiceWorkerRegistration` stand-in whose `unregister` resolves `true`. */
 function createFakeRegistration(
   overrides: Partial<Pick<FakeRegistration, "waiting" | "installing">> = {},
 ): FakeRegistration {
@@ -59,6 +61,7 @@ function installFakeContainer(
   return container;
 }
 
+/** Overrides `document.readyState`; `afterEach` drops the override via `Reflect.deleteProperty`. */
 function setDocumentReadyState(readyState: DocumentReadyState): void {
   Object.defineProperty(document, "readyState", {
     configurable: true,

--- a/src/lib/serviceWorkerRegistration.test.ts
+++ b/src/lib/serviceWorkerRegistration.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Sentry from "@sentry/nextjs";
+import {
+  SERVICE_WORKER_URL,
+  setupServiceWorker,
+  shouldRegisterServiceWorker,
+} from "./serviceWorkerRegistration";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+type FakeWorker = EventTarget & {
+  state: ServiceWorkerState;
+  postMessage: ReturnType<typeof vi.fn>;
+};
+
+type FakeRegistration = EventTarget & {
+  waiting: FakeWorker | null;
+  installing: FakeWorker | null;
+  unregister: ReturnType<typeof vi.fn>;
+};
+
+type FakeContainer = EventTarget & {
+  controller: FakeWorker | null;
+  register: ReturnType<typeof vi.fn>;
+  getRegistrations: ReturnType<typeof vi.fn>;
+};
+
+function createFakeWorker(state: ServiceWorkerState): FakeWorker {
+  return Object.assign(new EventTarget(), { state, postMessage: vi.fn() });
+}
+
+function createFakeRegistration(
+  overrides: Partial<Pick<FakeRegistration, "waiting" | "installing">> = {},
+): FakeRegistration {
+  return Object.assign(new EventTarget(), {
+    waiting: null,
+    installing: null,
+    unregister: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  });
+}
+
+/** Installs a fake `navigator.serviceWorker`; jsdom ships none, so the default is "unsupported". */
+function installFakeContainer(
+  overrides: Partial<Pick<FakeContainer, "controller">> = {},
+): FakeContainer {
+  const container: FakeContainer = Object.assign(new EventTarget(), {
+    controller: null,
+    register: vi.fn().mockResolvedValue(createFakeRegistration()),
+    getRegistrations: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  });
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: container,
+  });
+  return container;
+}
+
+function setDocumentReadyState(readyState: DocumentReadyState): void {
+  Object.defineProperty(document, "readyState", {
+    configurable: true,
+    value: readyState,
+  });
+}
+
+describe("shouldRegisterServiceWorker", () => {
+  it("registers only on production builds", () => {
+    expect(shouldRegisterServiceWorker("production")).toBe(true);
+    expect(shouldRegisterServiceWorker("development")).toBe(false);
+    expect(shouldRegisterServiceWorker("test")).toBe(false);
+    expect(shouldRegisterServiceWorker(undefined)).toBe(false);
+  });
+});
+
+describe("setupServiceWorker", () => {
+  const reload = vi.fn();
+  const cacheKeys = vi.fn();
+  const cacheDelete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDocumentReadyState("complete");
+    vi.stubGlobal("location", { reload });
+    cacheKeys.mockResolvedValue([]);
+    cacheDelete.mockResolvedValue(true);
+    vi.stubGlobal("caches", { keys: cacheKeys, delete: cacheDelete });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, "serviceWorker");
+    Reflect.deleteProperty(document, "readyState");
+    vi.unstubAllGlobals();
+  });
+
+  it("does nothing in browsers without service worker support", () => {
+    expect("serviceWorker" in navigator).toBe(false);
+
+    const cleanup = setupServiceWorker("production");
+
+    expect(cleanup).toBeTypeOf("function");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("registers the worker on production builds", async () => {
+    const container = installFakeContainer();
+
+    setupServiceWorker("production");
+
+    await vi.waitFor(() => {
+      expect(container.register).toHaveBeenCalledWith(SERVICE_WORKER_URL);
+    });
+    expect(container.getRegistrations).not.toHaveBeenCalled();
+    expect(cacheDelete).not.toHaveBeenCalled();
+  });
+
+  it("does not register the worker on development builds", async () => {
+    const container = installFakeContainer();
+
+    setupServiceWorker("development");
+
+    await vi.waitFor(() => {
+      expect(container.getRegistrations).toHaveBeenCalledTimes(1);
+    });
+    expect(container.register).not.toHaveBeenCalled();
+  });
+
+  it("removes leftover workers and caches on development builds without reloading an uncontrolled page", async () => {
+    const container = installFakeContainer();
+    const staleRegistration = createFakeRegistration();
+    container.getRegistrations.mockResolvedValue([staleRegistration]);
+    cacheKeys.mockResolvedValue(["static-v5", "static-v6"]);
+
+    setupServiceWorker("development");
+
+    await vi.waitFor(() => {
+      expect(cacheDelete).toHaveBeenCalledTimes(2);
+    });
+    expect(staleRegistration.unregister).toHaveBeenCalledTimes(1);
+    expect(cacheDelete).toHaveBeenCalledWith("static-v5");
+    expect(cacheDelete).toHaveBeenCalledWith("static-v6");
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads a development page that a leftover worker was still controlling", async () => {
+    const container = installFakeContainer({
+      controller: createFakeWorker("activated"),
+    });
+    container.getRegistrations.mockResolvedValue([createFakeRegistration()]);
+
+    setupServiceWorker("development");
+
+    await vi.waitFor(() => {
+      expect(reload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("waits for the load event before applying the policy and cancels on cleanup", () => {
+    setDocumentReadyState("loading");
+    const container = installFakeContainer();
+
+    const cleanup = setupServiceWorker("production");
+    expect(container.register).not.toHaveBeenCalled();
+
+    cleanup();
+    window.dispatchEvent(new Event("load"));
+    expect(container.register).not.toHaveBeenCalled();
+
+    setupServiceWorker("production");
+    window.dispatchEvent(new Event("load"));
+    expect(container.register).toHaveBeenCalledTimes(1);
+  });
+
+  it("activates a worker that is already waiting and reloads once it takes control", async () => {
+    const container = installFakeContainer();
+    const waitingWorker = createFakeWorker("installed");
+    container.register.mockResolvedValue(
+      createFakeRegistration({ waiting: waitingWorker }),
+    );
+
+    setupServiceWorker("production");
+
+    await vi.waitFor(() => {
+      expect(waitingWorker.postMessage).toHaveBeenCalledWith({
+        type: "SKIP_WAITING",
+      });
+    });
+    container.dispatchEvent(new Event("controllerchange"));
+    container.dispatchEvent(new Event("controllerchange"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("activates an updated worker once it is installed while an older worker controls the page", async () => {
+    const container = installFakeContainer({
+      controller: createFakeWorker("activated"),
+    });
+    const registration = createFakeRegistration();
+    container.register.mockResolvedValue(registration);
+
+    setupServiceWorker("production");
+    await vi.waitFor(() => {
+      expect(container.register).toHaveBeenCalledTimes(1);
+    });
+
+    const installingWorker = createFakeWorker("installing");
+    registration.installing = installingWorker;
+    registration.dispatchEvent(new Event("updatefound"));
+    installingWorker.dispatchEvent(new Event("statechange"));
+    expect(installingWorker.postMessage).not.toHaveBeenCalled();
+
+    installingWorker.state = "installed";
+    installingWorker.dispatchEvent(new Event("statechange"));
+    expect(installingWorker.postMessage).toHaveBeenCalledWith({
+      type: "SKIP_WAITING",
+    });
+  });
+
+  it("leaves a first install alone until it activates instead of skipping its waiting phase", async () => {
+    const container = installFakeContainer();
+    const registration = createFakeRegistration();
+    container.register.mockResolvedValue(registration);
+
+    setupServiceWorker("production");
+    await vi.waitFor(() => {
+      expect(container.register).toHaveBeenCalledTimes(1);
+    });
+
+    const installingWorker = createFakeWorker("installed");
+    registration.installing = installingWorker;
+    registration.dispatchEvent(new Event("updatefound"));
+    installingWorker.dispatchEvent(new Event("statechange"));
+    expect(installingWorker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed registration to Sentry", async () => {
+    const container = installFakeContainer();
+    const failure = new Error("registration blocked");
+    container.register.mockRejectedValue(failure);
+
+    setupServiceWorker("production");
+
+    await vi.waitFor(() => {
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        failure,
+        expect.objectContaining({ tags: { area: "service-worker" } }),
+      );
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed cleanup to Sentry", async () => {
+    const container = installFakeContainer();
+    const failure = new Error("registrations unavailable");
+    container.getRegistrations.mockRejectedValue(failure);
+
+    setupServiceWorker("development");
+
+    await vi.waitFor(() => {
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        failure,
+        expect.objectContaining({ tags: { area: "service-worker" } }),
+      );
+    });
+    expect(cacheDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/serviceWorkerRegistration.ts
+++ b/src/lib/serviceWorkerRegistration.ts
@@ -1,0 +1,129 @@
+import * as Sentry from "@sentry/nextjs";
+
+/** Path of the service worker script, served verbatim from `public/sw.js`. */
+export const SERVICE_WORKER_URL = "/sw.js";
+
+/** `process.env.NODE_ENV` of the only builds that register the worker. */
+const PRODUCTION_NODE_ENV = "production";
+
+/** Message type `public/sw.js` listens for to activate a waiting worker without a manual reload. */
+const SKIP_WAITING_MESSAGE_TYPE = "SKIP_WAITING";
+
+const SENTRY_CONTEXT = { tags: { area: "service-worker" } };
+
+/**
+ * True when the worker should be registered for this build.
+ *
+ * `next dev` reuses stable, unhashed chunk URLs under `/_next/static/chunks/` across edits and
+ * restarts, so a worker that caches them keeps serving stale code. Only production builds, whose
+ * chunk names are content-hashed, register the worker.
+ */
+export function shouldRegisterServiceWorker(
+  nodeEnv: string | undefined,
+): boolean {
+  return nodeEnv === PRODUCTION_NODE_ENV;
+}
+
+/** `navigator.serviceWorker`, or `null` when the browser does not support service workers. */
+function getServiceWorkerContainer(): ServiceWorkerContainer | null {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return null;
+  }
+  return navigator.serviceWorker;
+}
+
+/** Reloads the page once a new worker takes control, so every chunk comes from the new build. */
+function reloadOnControllerChange(container: ServiceWorkerContainer): void {
+  container.addEventListener(
+    "controllerchange",
+    () => {
+      window.location.reload();
+    },
+    { once: true },
+  );
+}
+
+/** Tells a worker that finished installing to activate now instead of waiting for all tabs to close. */
+function activateWorker(worker: ServiceWorker): void {
+  worker.postMessage({ type: SKIP_WAITING_MESSAGE_TYPE });
+}
+
+/**
+ * Registers the worker and wires up its update flow: a worker that is already waiting, or one that
+ * finishes installing while an older worker controls the page, is told to skip waiting, and the
+ * page reloads once the new worker takes control. A failed registration is reported to Sentry;
+ * the app works without the worker.
+ */
+async function registerServiceWorker(
+  container: ServiceWorkerContainer,
+): Promise<void> {
+  try {
+    const registration = await container.register(SERVICE_WORKER_URL);
+    reloadOnControllerChange(container);
+    if (registration.waiting) {
+      activateWorker(registration.waiting);
+      return;
+    }
+    registration.addEventListener("updatefound", () => {
+      const installingWorker = registration.installing;
+      if (!installingWorker) return;
+      installingWorker.addEventListener("statechange", () => {
+        if (installingWorker.state === "installed" && container.controller) {
+          activateWorker(installingWorker);
+        }
+      });
+    });
+  } catch (error: unknown) {
+    Sentry.captureException(error, SENTRY_CONTEXT);
+  }
+}
+
+/**
+ * Unregisters every worker for this origin and deletes all of its caches, then reloads the page
+ * when a worker was controlling it so no stale chunk stays in use. Runs on non-production builds:
+ * a worker left behind by a production build or a local `next start` would otherwise keep serving
+ * cached `/_next/` chunks to `next dev`. Failures are reported to Sentry.
+ */
+async function unregisterServiceWorkers(
+  container: ServiceWorkerContainer,
+): Promise<void> {
+  try {
+    const wasControlled = container.controller !== null;
+    const registrations = await container.getRegistrations();
+    await Promise.all(
+      registrations.map((registration) => registration.unregister()),
+    );
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+    if (wasControlled) window.location.reload();
+  } catch (error: unknown) {
+    Sentry.captureException(error, SENTRY_CONTEXT);
+  }
+}
+
+/**
+ * Applies the build's service worker policy once the page has finished loading, so registration
+ * never competes with the initial page resources: production builds register `public/sw.js`,
+ * every other build removes leftover workers and their caches. Browsers without service worker
+ * support are left alone. Returns a cleanup that cancels a still-pending `load` listener, for use
+ * as a React effect.
+ */
+export function setupServiceWorker(nodeEnv: string | undefined): () => void {
+  const container = getServiceWorkerContainer();
+  if (!container) return () => {};
+
+  const applyPolicy = (): void => {
+    if (shouldRegisterServiceWorker(nodeEnv)) {
+      void registerServiceWorker(container);
+      return;
+    }
+    void unregisterServiceWorkers(container);
+  };
+
+  if (document.readyState === "complete") {
+    applyPolicy();
+    return () => {};
+  }
+  window.addEventListener("load", applyPolicy, { once: true });
+  return () => window.removeEventListener("load", applyPolicy);
+}


### PR DESCRIPTION
## Summary

`public/sw.js` served stale `/_next/static/chunks/*.js` files in local development, surviving code changes and `next dev` restarts, because it cached every `script` response cache-first and `next dev` reuses the same unhashed chunk URLs. Only unregistering the worker and deleting the `static-v5` cache fixed it.

This PR makes the worker safe for development and keeps the production offline behaviour:

- **Registration gate**: `public/sw.js` is registered only when `process.env.NODE_ENV === "production"`. On every other build the app registers nothing and instead unregisters leftover workers, deletes their caches and reloads a page that a stale worker was still controlling, so developers who already have `static-v5` installed recover automatically.
- **Network-first for `/_next/`**: chunks, CSS, fonts and optimised images are fetched from the network first and fall back to the cache only when the fetch fails. Production chunk names are content-hashed, so the fresh fetch is answered by the HTTP cache; previously loaded chunks keep working offline. Navigations stay network-only, `/api/*` stays network-first, and the precached shell (`/logo.png`) and other images stay cache-first. Cache version bumped to `static-v6`, so the `activate` handler drops `static-v5`.
- **Registration moved out of the inline script** in `src/app/layout.tsx` into `src/lib/serviceWorkerRegistration.ts` (`shouldRegisterServiceWorker`, `setupServiceWorker`) and a `ServiceWorkerRegistration` client component. Registration and cleanup failures are reported to Sentry (`area: service-worker`) instead of the previous silent `.catch(() => {})`.
- **Tests**: `src/lib/serviceWorkerRegistration.test.ts` mocks `navigator.serviceWorker`, `caches` and `location` to cover the gate for production/development/unsupported browsers, the leftover-worker cleanup and reload, the `load`-event deferral and effect cleanup, the skip-waiting update flow, and both Sentry error paths. `src/components/ServiceWorkerRegistration.test.tsx` covers the component with `vi.stubEnv("NODE_ENV", …)`.
- **Carried base fix (unrelated to the worker)**: `image` has been red since 2f532e2 (#631) added `meta` to the `POST /api/report/extract` response without updating `src/app/api/report/extract/route.test.ts`. This PR merges `image` and carries the one-line test fix (1f1d6b0) so CI can pass; it no-ops once `image` carries an equivalent fix. Details in the PR comment.

Behaviour note: a worker that is already waiting at registration time now also triggers the one-time reload once it takes control; the inline script only wired the reload for workers that finished installing after registration.

Verification: `npx vitest run` (818 tests, 790 passed, 28 skipped), `npm run lint` (0 errors, 2 pre-existing warnings in untouched files), `npx tsc --noEmit`, `npm run build`, Prettier on all changed files, `npm run check:merge-conflicts`.

## User-facing release (“Wat is nieuw”)

De tour opent alleen als `package.json`-versie een bijpassende sleutel in `src/lib/changelog.ts` heeft én de gebruiker die versie nog niet heeft bevestigd.

- [x] Nee — geen release richting eindgebruikers (alleen intern/technisch)
- [ ] Ja — **`package.json`-versie verhoogd** en **zelfde versie als sleutel** toegevoegd in `src/lib/changelog.ts` (stappen + geldige `data-tour`-targets waar nodig)

## Docs

- [x] Updated relevant feature docs under `docs/tech/...`
- [x] `npm run docs:generate` succeeds locally
- Links:
  - Feature doc(s): `docs/tech/pwa/README.md` (new: registration policy and caching strategy table)
  - `docs/specs/functional.md`: feature table row for `pwa`, regenerated by `npm run docs:generate`
  - Functional spec section(s): n/a (technical change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVXxc7L8NuYxMUuiBEVzba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters production PWA caching and registration for every client; behavior is intentional but wrong caching or cleanup could affect offline use or dev reloads.
> 
> **Overview**
> Fixes **stale JavaScript during local development** when a production service worker cached `/_next/` chunks cache-first while `next dev` reuses the same chunk URLs.
> 
> **Service worker (`public/sw.js`)** bumps cache to `static-v6`, routes `/_next/*` through **network-first** (cache only on network failure), and keeps navigations network-only, `/api/*` network-first, and other static assets cache-first. Shared `networkFirst` / `cacheFirst` helpers handle cache writes via `event.waitUntil`.
> 
> **Registration** moves out of the inline script in `layout.tsx` into `serviceWorkerRegistration.ts` and a `ServiceWorkerRegistration` client component: the worker registers **only when `NODE_ENV === "production"`**; non-production builds unregister leftover workers, clear caches, and reload if a worker was controlling the page. Update flow uses skip-waiting plus a one-time reload on `controllerchange`; failures go to Sentry (`area: service-worker`). Vitest covers registration, cleanup, and update paths.
> 
> **Docs** add `docs/tech/pwa/README.md` and list **pwa** in the functional spec feature table. **Unrelated:** `route.test.ts` for report extract now expects the `meta` field on successful responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c53ee79eeae780563f488c4c2ce91e5a63286208. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->