### PR TITLE
feat(arena): re-elect on host silence and keep a hidden tab hosting

### DIFF
--- a/src/components/cityArena/CityArenaOverlay.test.tsx
+++ b/src/components/cityArena/CityArenaOverlay.test.tsx
@@ -118,8 +118,10 @@ vi.mock("./useArenaRoom", () => {
     transport: () => null,
     zone: "wageningen",
     crew: [{ clientId: "me", seat: 0, name: "Jij", isHost: true, isYou: true }],
+    hostClientId: "me",
     isHost: true,
     failure: null,
+    reportHostLost: vi.fn(),
     leave: vi.fn(),
   };
   return { useArenaRoom: () => room };

--- a/src/components/cityArena/CityArenaOverlay.tsx
+++ b/src/components/cityArena/CityArenaOverlay.tsx
@@ -12,6 +12,7 @@ import { createPortal, preload } from "react-dom";
 import { ZONE_OPTIONS } from "@/lib/cityArena/constants";
 import { ArenaPhaseScreens } from "./ArenaPhaseScreens";
 import { ConnectionBanner } from "./ConnectionBanner";
+import { HostToast } from "./HostToast";
 import { useArenaRoom, type ArenaRoom } from "./useArenaRoom";
 import type { ArenaEntry } from "./arenaEntry";
 import { isDebugEnabled } from "@/lib/cityArena/debugFlag";
@@ -305,11 +306,14 @@ function netplayFor(room: ArenaRoom): ArenaNetplayOptions {
   return {
     transport: room.transport,
     ready: room.status === "ready",
+    connected: room.connection === "connected",
     roomCode: room.roomCode,
     clientId: room.clientId,
     clockOffsetMs: room.clockOffsetMs,
+    hostClientId: room.hostClientId,
     isHost: room.isHost,
     memberIds: room.crew.map((member) => member.clientId),
+    onHostLost: room.reportHostLost,
   };
 }
 
@@ -359,6 +363,10 @@ export default function CityArenaOverlay({
       onContextMenu={(event) => event.preventDefault()}
     >
       <ConnectionBanner state={room.connection} />
+      <HostToast
+        hostClientId={room.hostClientId}
+        hostName={room.crew.find((member) => member.isHost)?.name ?? null}
+      />
       <ArenaHudBar
         hud={game.hud}
         zones={game.zones}

--- a/src/components/cityArena/HostToast.test.tsx
+++ b/src/components/cityArena/HostToast.test.tsx
@@ -1,0 +1,43 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HOST_TOAST_MS, HostToast } from "./HostToast";
+
+describe("HostToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("says nothing about the first host: the lobby already names them", () => {
+    render(<HostToast hostClientId="a" hostName="Noor" />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("announces a new host for a few seconds, then goes quiet", () => {
+    const { rerender } = render(<HostToast hostClientId="a" hostName="Noor" />);
+    rerender(<HostToast hostClientId="b" hostName="Bram" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Nieuwe host: Bram");
+    act(() => {
+      vi.advanceTimersByTime(HOST_TOAST_MS);
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("does not announce a host who merely changed their name", () => {
+    const { rerender } = render(<HostToast hostClientId="a" hostName="Noor" />);
+    rerender(<HostToast hostClientId="a" hostName="Noortje" />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("names a new host the crew cannot name yet as unknown", () => {
+    const { rerender } = render(<HostToast hostClientId="a" hostName="Noor" />);
+    rerender(<HostToast hostClientId="b" hostName={null} />);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Nieuwe host: Onbekend",
+    );
+  });
+});

--- a/src/components/cityArena/HostToast.tsx
+++ b/src/components/cityArena/HostToast.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/** How long the toast stays up. */
+export const HOST_TOAST_MS = 4000;
+
+/** Props for {@link HostToast}. */
+export type HostToastProps = {
+  /** The elected host, or null while nobody is. */
+  hostClientId: string | null;
+  /** What that host is called, or null when the crew does not name them yet. */
+  hostName: string | null;
+};
+
+/**
+ * "Nieuwe host: Bram" (spec §6.6, copy in §16): shown for a few seconds when the room re-elects.
+ *
+ * The first host is not news — the lobby already names them — so only a change announces. A host
+ * who merely changed their name is not a new host either.
+ *
+ * @param props - The elected host and their name.
+ * @returns The toast, or nothing when there is nothing new to say.
+ */
+export function HostToast({
+  hostClientId,
+  hostName,
+}: HostToastProps): React.JSX.Element | null {
+  const previous = useRef<string | null>(null);
+  const [shown, setShown] = useState<string | null>(null);
+  useEffect(() => {
+    const before = previous.current;
+    previous.current = hostClientId;
+    if (!hostClientId || before === null || before === hostClientId)
+      return undefined;
+    setShown(hostName ?? "Onbekend");
+    const timer = setTimeout(() => setShown(null), HOST_TOAST_MS);
+    return () => clearTimeout(timer);
+  }, [hostClientId, hostName]);
+  if (!shown) return null;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="arena-label border-b border-[var(--arena-amber)] bg-[var(--arena-amber-dim)] px-3 py-2 text-center text-[var(--arena-amber)]"
+    >
+      Nieuwe host: {shown}
+    </div>
+  );
+}

--- a/src/components/cityArena/arenaRuntime.ts
+++ b/src/components/cityArena/arenaRuntime.ts
@@ -6,7 +6,7 @@ import {
   type Tally,
 } from "@/lib/cityArena/net/scoreboard";
 import { LOCAL_PLAYER_ID, addArenaPlayer } from "@/lib/cityArena/sim/arena";
-import type { HostLoop } from "@/lib/cityArena/net/hostLoop";
+import { HOST_TICK_HZ, type HostLoop } from "@/lib/cityArena/net/hostLoop";
 import type { ClientLoop } from "@/lib/cityArena/net/clientLoop";
 import { localPlayer, playerById } from "@/lib/cityArena/sim/players";
 import * as Sentry from "@sentry/nextjs";
@@ -112,6 +112,12 @@ const MAX_SIM_STEPS_PER_FRAME = 8;
 const LANDMARK_SNAP_DISTANCE_M = 200;
 /** Milliseconds per second, for converting between frame timestamps and simulation seconds. */
 const MS_PER_SECOND = 1000;
+/**
+ * How often a hidden tab steps the world. `requestAnimationFrame` stops entirely in a hidden
+ * tab, which would freeze the match for everyone this tab hosts; an interval keeps it stepping,
+ * throttled by the browser but not stopped, and migration covers the rest (spec §6.6).
+ */
+const HIDDEN_TICK_MS = MS_PER_SECOND / HOST_TICK_HZ;
 
 /** Data for the debug panel. */
 export type DebugSnapshot = {
@@ -649,7 +655,12 @@ function computeFrameDt(
   lastTimestamp: number | null,
 ): number {
   if (lastTimestamp === null) return SIM_STEP_S;
-  return Math.min(MAX_FRAME_S, (timestamp - lastTimestamp) / MS_PER_SECOND);
+  // Clamped below at zero as well: the interval that steps a hidden tab and the frame clock share
+  // a timeline, but a clock that steps back must never run the world backwards.
+  return Math.min(
+    MAX_FRAME_S,
+    Math.max(0, (timestamp - lastTimestamp) / MS_PER_SECOND),
+  );
 }
 
 /** Options threaded through the frame loop's per-frame and throttled-refresh helpers. */
@@ -795,17 +806,37 @@ function runFrame(
 /** Starts the requestAnimationFrame loop for one boot cycle; returns the cleanup that cancels it. */
 export function startFrameLoop(options: FrameLoopOptions): () => void {
   let handle = 0;
+  let interval: ReturnType<typeof setInterval> | null = null;
   let lastTimestamp: number | null = null;
-  const tick = (timestamp: number): void => {
+  const frame = (timestamp: number): void => {
     const runtime = options.runtimeRef.current;
     const canvas = options.canvasRef.current;
-    if (runtime && canvas) {
-      const dt = computeFrameDt(timestamp, lastTimestamp);
-      lastTimestamp = timestamp;
-      runFrame(timestamp, dt, runtime, canvas, options);
+    if (!runtime || !canvas) return;
+    const dt = computeFrameDt(timestamp, lastTimestamp);
+    lastTimestamp = timestamp;
+    runFrame(timestamp, dt, runtime, canvas, options);
+  };
+  const tick = (timestamp: number): void => {
+    frame(timestamp);
+    if (!document.hidden) handle = window.requestAnimationFrame(tick);
+  };
+  // Frames while the tab shows; the interval while it is hidden. Both clock the world by the
+  // same timeline, so the hand-over between them costs at most one clamped frame.
+  const onVisibility = (): void => {
+    if (document.hidden) {
+      window.cancelAnimationFrame(handle);
+      interval ??= setInterval(() => frame(performance.now()), HIDDEN_TICK_MS);
+      return;
     }
+    if (interval !== null) clearInterval(interval);
+    interval = null;
     handle = window.requestAnimationFrame(tick);
   };
-  handle = window.requestAnimationFrame(tick);
-  return () => window.cancelAnimationFrame(handle);
+  document.addEventListener("visibilitychange", onVisibility);
+  onVisibility();
+  return () => {
+    document.removeEventListener("visibilitychange", onVisibility);
+    window.cancelAnimationFrame(handle);
+    if (interval !== null) clearInterval(interval);
+  };
 }

--- a/src/components/cityArena/useArenaGame.test.tsx
+++ b/src/components/cityArena/useArenaGame.test.tsx
@@ -13,7 +13,7 @@ import {
   type FakeContext,
 } from "@/lib/cityArena/render/testing/fakeContext";
 import { createArenaState } from "@/lib/cityArena/sim/arena";
-import { createHostLoop } from "@/lib/cityArena/net/hostLoop";
+import { HOST_TICK_HZ, createHostLoop } from "@/lib/cityArena/net/hostLoop";
 import {
   createMemoryHub,
   createMemoryTransport,
@@ -615,11 +615,14 @@ function netplayFor(
   return {
     transport: () => transport,
     ready: true,
+    connected: true,
     roomCode: ROOM,
     clientId: "me",
     clockOffsetMs: 0,
+    hostClientId: overrides.isHost ? "me" : "host",
     isHost: false,
     memberIds: ["me"],
+    onHostLost: vi.fn(),
     ...overrides,
   };
 }
@@ -754,5 +757,59 @@ describe("netplay", () => {
     expect(result.current.peek()?.youId).toBe(again);
     expect(result.current.peek()?.seats.get("me")).toBe(again);
     host.stop();
+  });
+});
+
+describe("hidden tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("requestAnimationFrame", vi.fn());
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    Reflect.deleteProperty(document, "hidden");
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  /** Makes `document.hidden` report `hidden` and tells the page so. */
+  function setHidden(hidden: boolean): void {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => hidden,
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+  }
+
+  it("keeps stepping the world on an interval while hidden, and returns to frames when shown", async () => {
+    const { result } = await bootArenaWithCanvas({ debug: true });
+    const tick = getTick();
+    act(() => tick(0));
+    const framesRequested = vi.mocked(window.requestAnimationFrame).mock.calls
+      .length;
+    const tickBefore = window.__arena?.getState()?.tick ?? 0;
+
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval", "Date"] });
+    // The interval clocks the world by performance.now(), the frame clock's own timeline.
+    vi.spyOn(performance, "now").mockImplementation(() => Date.now());
+    setHidden(true);
+    act(() => {
+      vi.advanceTimersByTime((1000 / HOST_TICK_HZ) * 6);
+    });
+    expect(window.__arena?.getState()?.tick ?? 0).toBeGreaterThan(tickBefore);
+    expect(vi.mocked(window.requestAnimationFrame).mock.calls).toHaveLength(
+      framesRequested,
+    );
+
+    setHidden(false);
+    expect(vi.mocked(window.requestAnimationFrame).mock.calls).toHaveLength(
+      framesRequested + 1,
+    );
+    expect(result.current.phase).toBe("playing");
   });
 });

--- a/src/components/cityArena/useArenaRoom.test.tsx
+++ b/src/components/cityArena/useArenaRoom.test.tsx
@@ -1,0 +1,129 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { enterLobby, listLobbyRooms } from "@/lib/cityArena/net/lobbyPresence";
+import {
+  createMemoryHub,
+  createMemoryTransport,
+  type MemoryHub,
+} from "@/lib/cityArena/net/memoryTransport";
+import { openRoom } from "@/lib/cityArena/net/room";
+import type { PresenceData } from "@/lib/cityArena/net/transport";
+import type { ArenaEntry } from "./arenaEntry";
+import { useArenaRoom } from "./useArenaRoom";
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+const ROOM = "ABC234";
+
+/** Presence data for a desktop player. */
+function player(name: string): PresenceData {
+  return { name, colour: "#fff", role: "player", device: "desktop" };
+}
+
+/** Lets the hook's connection sequence — a handful of awaits — run to the end. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < 12; index += 1) await Promise.resolve();
+  });
+}
+
+/** Renders the hook as "me", called Guido, over `hub`. */
+function renderRoom(hub: MemoryHub, entry: ArenaEntry) {
+  return renderHook(() =>
+    useArenaRoom({
+      entry,
+      fallbackZone: "wageningen",
+      createTransport: () => createMemoryTransport(hub, "me", "Guido"),
+    }),
+  );
+}
+
+/** A room already open on the hub, hosted by Bram, who advertises it in the lobby. */
+async function bramsRoom(hub: MemoryHub): Promise<void> {
+  const bram = createMemoryTransport(hub, "bram", "Bram");
+  await openRoom(bram, ROOM, player("Bram"));
+  await enterLobby(bram, {
+    host: player("Bram"),
+    room: { roomCode: ROOM, zone: "wageningen", players: 1, phase: "lobby" },
+  });
+}
+
+describe("useArenaRoom", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens a fresh room as host and advertises it in the lobby", async () => {
+    const hub = createMemoryHub();
+    const { result } = renderRoom(hub, { kind: "new", zone: "campus" });
+    await settle();
+    expect(result.current.status).toBe("ready");
+    expect(result.current.isHost).toBe(true);
+    expect(result.current.hostClientId).toBe("me");
+    expect(result.current.clientId).toBe("me");
+    expect(result.current.crew).toEqual([
+      { clientId: "me", seat: 0, name: "Guido", isHost: true, isYou: true },
+    ]);
+    const rooms = await listLobbyRooms(createMemoryTransport(hub, "watcher"));
+    expect(rooms).toEqual([
+      expect.objectContaining({
+        roomCode: result.current.roomCode,
+        zone: "campus",
+        hostName: "Guido",
+      }),
+    ]);
+  });
+
+  it("joins an open room behind its host, in join order", async () => {
+    const hub = createMemoryHub();
+    await bramsRoom(hub);
+    const { result } = renderRoom(hub, {
+      kind: "join",
+      roomCode: ROOM,
+      zone: "wageningen",
+    });
+    await settle();
+    expect(result.current.status).toBe("ready");
+    expect(result.current.isHost).toBe(false);
+    expect(result.current.hostClientId).toBe("bram");
+    expect(result.current.crew.map((member) => member.clientId)).toEqual([
+      "bram",
+      "me",
+    ]);
+  });
+
+  it("re-elects without a host it was told is lost, and the new host takes the lobby", async () => {
+    const hub = createMemoryHub();
+    await bramsRoom(hub);
+    const { result } = renderRoom(hub, {
+      kind: "join",
+      roomCode: ROOM,
+      zone: "wageningen",
+    });
+    await settle();
+    act(() => result.current.reportHostLost("bram"));
+    expect(result.current.hostClientId).toBe("me");
+    expect(result.current.isHost).toBe(true);
+    expect(result.current.crew.find((member) => member.isHost)?.clientId).toBe(
+      "me",
+    );
+    await settle();
+    // Bram's advert is superseded: the lobby lists the room under its new host.
+    const rooms = await listLobbyRooms(createMemoryTransport(hub, "watcher"));
+    expect(rooms).toEqual([
+      expect.objectContaining({ roomCode: ROOM, hostName: "Guido" }),
+    ]);
+  });
+
+  it("keeps hosting when told it is lost itself and nobody else is there", async () => {
+    const hub = createMemoryHub();
+    const { result } = renderRoom(hub, { kind: "new", zone: "campus" });
+    await settle();
+    act(() => result.current.reportHostLost("me"));
+    expect(result.current.isHost).toBe(true);
+  });
+});

--- a/src/components/cityArena/useArenaRoom.ts
+++ b/src/components/cityArena/useArenaRoom.ts
@@ -10,12 +10,8 @@ import {
 } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { createAblyTransport } from "@/lib/cityArena/net/ablyTransport";
-import { electHost } from "@/lib/cityArena/net/election";
-import {
-  enterLobby,
-  leaveLobby,
-  updateLobby,
-} from "@/lib/cityArena/net/lobbyPresence";
+import { electPresentHost } from "@/lib/cityArena/net/election";
+import { enterLobby, leaveLobby } from "@/lib/cityArena/net/lobbyPresence";
 import {
   createRoomCode,
   joinRoom,
@@ -51,9 +47,16 @@ export type ArenaRoom = {
   transport: () => RealtimeTransport | null;
   zone: ZoneKey;
   crew: CrewMember[];
+  /** The elected host, or null while nobody is present. */
+  hostClientId: string | null;
   isHost: boolean;
   /** Set when a join was refused, so the lobby can say why in Dutch. */
   failure: JoinFailure | null;
+  /**
+   * Reports a host the game has stopped hearing from — or this client itself, when it hears
+   * someone else hosting — so the room re-elects without them (spec §6.6).
+   */
+  reportHostLost: (clientId: string) => void;
 };
 
 /** How {@link useArenaRoom} is configured. */
@@ -334,7 +337,9 @@ function useLobbyAdvertisement(
     const transport = transportRef.current;
     const code = codeRef.current;
     if (!transport || !code || !isHost || members.length === 0) return;
-    void updateLobby(transport, {
+    // Enter rather than update: a host elected mid-match was never in the lobby, and entering
+    // while already present is an update anyway.
+    void enterLobby(transport, {
       host: presenceFor(name),
       room: { roomCode: code, zone, players: members.length, phase: "lobby" },
     }).catch((error: unknown) => {
@@ -343,6 +348,33 @@ function useLobbyAdvertisement(
       });
     });
   }, [transportRef, codeRef, isHost, members.length, name, zone]);
+}
+
+/**
+ * The hosts this client has given up on, for the election to skip.
+ *
+ * A member who leaves is forgotten, so someone who comes back after a bad connection starts with
+ * a clean slate rather than being passed over for the rest of the evening.
+ */
+function useLostHosts(members: PresenceMember[]): {
+  lost: ReadonlySet<string>;
+  reportHostLost: (clientId: string) => void;
+} {
+  const [lost, setLost] = useState<ReadonlySet<string>>(new Set());
+  const reportHostLost = useCallback((clientId: string) => {
+    setLost((previous) =>
+      previous.has(clientId) ? previous : new Set([...previous, clientId]),
+    );
+  }, []);
+  useEffect(() => {
+    setLost((previous) => {
+      const present = [...previous].filter((id) =>
+        members.some((member) => member.clientId === id),
+      );
+      return present.length === previous.size ? previous : new Set(present);
+    });
+  }, [members]);
+  return { lost, reportHostLost };
 }
 
 /**
@@ -363,7 +395,11 @@ export function useArenaRoom(options: UseArenaRoomOptions): ArenaRoom & {
     options.createTransport ?? createAblyTransport,
   );
 
-  const hostClientId = useMemo(() => electHost(link.members), [link.members]);
+  const { lost, reportHostLost } = useLostHosts(link.members);
+  const hostClientId = useMemo(
+    () => electPresentHost(link.members, lost),
+    [link.members, lost],
+  );
   const crew = useMemo(
     () => crewFrom(link.members, link.myClientId, hostClientId),
     [link.members, link.myClientId, hostClientId],
@@ -395,8 +431,10 @@ export function useArenaRoom(options: UseArenaRoomOptions): ArenaRoom & {
     transport,
     zone,
     crew,
+    hostClientId,
     isHost,
     failure: link.failure,
+    reportHostLost,
     leave,
   };
 }

--- a/src/components/cityArena/useNetplay.test.ts
+++ b/src/components/cityArena/useNetplay.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Sentry from "@sentry/nextjs";
 import { createCollisionGrid } from "@/lib/cityArena/world/collisionGrid";
@@ -12,11 +12,16 @@ import {
   createMemoryTransport,
   type MemoryHub,
 } from "@/lib/cityArena/net/memoryTransport";
+import { HOST_SILENCE_MS } from "@/lib/cityArena/net/election";
 import { HOST_TICK_HZ } from "@/lib/cityArena/net/hostLoop";
 import { emptyTally } from "@/lib/cityArena/net/scoreboard";
 import { encodeSnapshot } from "@/lib/cityArena/net/snapshotWire";
 import type { Runtime } from "./arenaRuntime";
-import { useNetplay, type ArenaNetplayOptions } from "./useNetplay";
+import {
+  WATCH_POLL_MS,
+  useNetplay,
+  type ArenaNetplayOptions,
+} from "./useNetplay";
 
 vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
 
@@ -84,13 +89,41 @@ function member(
   return {
     transport: () => transport,
     ready: true,
+    connected: true,
     roomCode: ROOM,
     clientId,
     clockOffsetMs: 0,
+    hostClientId: overrides.isHost ? clientId : "host",
     isHost: false,
     memberIds: [clientId],
+    onHostLost: vi.fn(),
     ...overrides,
   };
+}
+
+/** A snapshot of `state` as `from` would publish it, seating `seats`. */
+function snapshotFrom(
+  hub: MemoryHub,
+  from: string,
+  state: Runtime["state"],
+  seats: [string, number][],
+): void {
+  void createMemoryTransport(hub, from)
+    .channel(`arena:room:${ROOM}`)
+    .publish(
+      "state",
+      encodeSnapshot(
+        state,
+        0,
+        {},
+        {
+          seats: new Map(seats),
+          tally: emptyTally(),
+          match: { phase: "lobby", since: 0 },
+        },
+      ),
+    );
+  hub.flush();
 }
 
 /**
@@ -145,6 +178,7 @@ describe("useNetplay", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("does nothing without a room, and nothing before the room is ready", () => {
@@ -226,7 +260,12 @@ describe("useNetplay", () => {
     // The host closes its tab: its presence leaves, and the joiner is elected.
     hostHook.unmount();
     joinerHook.rerender({
-      options: { ...joinerOptions, isHost: true, memberIds: ["joiner"] },
+      options: {
+        ...joinerOptions,
+        hostClientId: "joiner",
+        isHost: true,
+        memberIds: ["joiner"],
+      },
       booted: true,
     });
     expect(joiner.netplay.kind).toBe("host");
@@ -259,7 +298,7 @@ describe("useNetplay", () => {
       [seat, { playerId: seat, kills: 1, deaths: 2 }],
     ]);
     const match = { phase: "playing" as const, since: 5 };
-    void createMemoryTransport(hub, "old-host")
+    void createMemoryTransport(hub, "host")
       .channel(`arena:room:${ROOM}`)
       .publish(
         "state",
@@ -280,7 +319,12 @@ describe("useNetplay", () => {
     hub.flush();
     hostHook.unmount();
     joinerHook.rerender({
-      options: { ...joinerOptions, isHost: true, memberIds: ["joiner"] },
+      options: {
+        ...joinerOptions,
+        hostClientId: "joiner",
+        isHost: true,
+        memberIds: ["joiner"],
+      },
       booted: true,
     });
     if (joiner.netplay.kind !== "host") throw new Error("not hosting");
@@ -305,5 +349,75 @@ describe("useNetplay", () => {
       expect.any(Error),
       { tags: { area: "arena", kind: "client-seat" } },
     );
+  });
+
+  it("takes snapshots only from the elected host, however well an impostor seats it", () => {
+    const hub = createMemoryHub();
+    const host = fakeRuntime(1);
+    const joiner = fakeRuntime(2);
+    const crew = ["host", "joiner"];
+    renderNetplay(host, member(hub, "host", { isHost: true, memberIds: crew }));
+    renderNetplay(joiner, member(hub, "joiner", { memberIds: crew }));
+    if (host.netplay.kind !== "host") throw new Error("not hosting");
+    const seat = host.netplay.loop.seats().get("joiner")!;
+    snapshotFrom(hub, "impostor", host.state, [
+      ["impostor", 0],
+      ["joiner", seat],
+    ]);
+    expect(joiner.netplay.kind).toBe("offline");
+    publishSnapshot(host, hub);
+    expect(joiner.netplay.kind).toBe("client");
+  });
+
+  it("calls for a re-election once the host has been quiet for the silence window", () => {
+    vi.useFakeTimers();
+    const hub = createMemoryHub();
+    const options = member(hub, "joiner", { memberIds: ["host", "joiner"] });
+    renderNetplay(fakeRuntime(2), options);
+    act(() => {
+      vi.advanceTimersByTime(HOST_SILENCE_MS - WATCH_POLL_MS);
+    });
+    expect(options.onHostLost).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(WATCH_POLL_MS * 3);
+    });
+    expect(options.onHostLost).toHaveBeenCalledTimes(1);
+    expect(options.onHostLost).toHaveBeenCalledWith("host");
+  });
+
+  it("keeps the window open for as long as the host keeps publishing", () => {
+    vi.useFakeTimers();
+    const { host, hub, joinerOptions } = seatedPair();
+    for (let round = 0; round < 4; round += 1) {
+      act(() => {
+        vi.advanceTimersByTime(HOST_SILENCE_MS - WATCH_POLL_MS);
+      });
+      publishSnapshot(host, hub);
+    }
+    expect(joinerOptions.onHostLost).not.toHaveBeenCalled();
+  });
+
+  it("does not blame the host while its own connection is down", () => {
+    vi.useFakeTimers();
+    const hub = createMemoryHub();
+    const options = member(hub, "joiner", {
+      connected: false,
+      memberIds: ["host", "joiner"],
+    });
+    renderNetplay(fakeRuntime(2), options);
+    act(() => {
+      vi.advanceTimersByTime(HOST_SILENCE_MS * 2);
+    });
+    expect(options.onHostLost).not.toHaveBeenCalled();
+  });
+
+  it("steps down when another member publishes the world: the room re-elected while it was quiet", () => {
+    const hub = createMemoryHub();
+    const host = fakeRuntime(1);
+    const options = member(hub, "host", { isHost: true });
+    renderNetplay(host, options);
+    snapshotFrom(hub, "successor", host.state, [["successor", 0]]);
+    expect(options.onHostLost).toHaveBeenCalledTimes(1);
+    expect(options.onHostLost).toHaveBeenCalledWith("host");
   });
 });

--- a/src/components/cityArena/useNetplay.ts
+++ b/src/components/cityArena/useNetplay.ts
@@ -2,7 +2,7 @@
 
 /**
  * Runs the room's loop inside the runtime: the host loop when this client was elected, the
- * client loop otherwise.
+ * client loop otherwise — and notices when the host has gone (spec §6.6).
  *
  * The runtime keeps stepping alone until the room is ready, so the city is playable in the lobby
  * (spec §2) and a room that never connects still leaves the player something to drive around in.
@@ -11,10 +11,11 @@
 import { useEffect, useMemo, useRef, type RefObject } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { createClientLoop } from "@/lib/cityArena/net/clientLoop";
+import { createHostWatch, type HostWatch } from "@/lib/cityArena/net/election";
 import { createHostLoop, type HostLoop } from "@/lib/cityArena/net/hostLoop";
 import type { MatchState } from "@/lib/cityArena/net/matchPhase";
-import type { Tally } from "@/lib/cityArena/net/scoreboard";
 import { roomChannelName } from "@/lib/cityArena/net/room";
+import type { Tally } from "@/lib/cityArena/net/scoreboard";
 import {
   decodeSnapshot,
   type Snapshot,
@@ -29,25 +30,39 @@ export type ArenaNetplayOptions = {
   transport: () => RealtimeTransport | null;
   /** True once the room is entered and its presence set is known. */
   ready: boolean;
+  /** True while this client's own connection is up; a quiet host means nothing otherwise. */
+  connected: boolean;
   roomCode: string | null;
   /** This client's id — the user id — or empty before the connection reports it. */
   clientId: string;
   /** Server time minus local time, so both ends keep time by the same clock. */
   clockOffsetMs: number;
+  /** The elected host, or null while nobody is. Only its snapshots are trusted. */
+  hostClientId: string | null;
   /** Whether this client is the room's elected host right now. */
   isHost: boolean;
   /** Everyone present in the room, by client id, so the host can seat them. */
   memberIds: string[];
+  /**
+   * Called with the host to re-elect without: the one in `hostClientId` after it has been quiet
+   * for the silence window, or this client itself when, hosting, it hears another member publish
+   * the world — the room already moved on while this tab was throttled (spec §6.6).
+   */
+  onHostLost: (clientId: string) => void;
 };
 
 /** Separator for the member key; client ids are cuids, which never contain it. */
 const MEMBER_SEPARATOR = "|";
+
+/** How often the silence watch is fed; coarse is fine against a three-second window. */
+export const WATCH_POLL_MS = 500;
 
 /** What both loops are built from. */
 type LoopSetup = {
   transport: RealtimeTransport;
   roomCode: string;
   clientId: string;
+  hostClientId: string;
   clockOffsetMs: number;
 };
 
@@ -128,12 +143,15 @@ function syncSeats(
  * it saw as a client. Every seat the previous loop knew is claimed rather than added again, so a
  * migration keeps everyone's player where it was; whoever has since left is unseated by the
  * seating effect that runs next.
+ *
+ * @returns A function that stops listening for a rival, for the effect's cleanup.
  */
 function startHosting(
   runtime: Runtime,
   setup: LoopSetup,
   previous: Handover,
-): void {
+  onUsurped: () => void,
+): () => void {
   const loop = createHostLoop({
     transport: setup.transport,
     roomCode: setup.roomCode,
@@ -149,6 +167,12 @@ function startHosting(
   if (previous.match) loop.setMatch(previous.match);
   runtime.state = loop.state();
   runtime.netplay = { kind: "host", loop, playerId: previous.playerId };
+  const room = setup.transport.channel(roomChannelName(setup.roomCode));
+  return room.subscribe("state", (message) => {
+    // Another member publishing the world means the room re-elected while this tab was quiet.
+    // Stepping down is what stops the match forking into two.
+    if (message.clientId !== setup.clientId) onUsurped();
+  });
 }
 
 /** Builds the client loop around the seat the host named, primed with the snapshot that named it. */
@@ -166,6 +190,7 @@ function adoptSeat(
     state: runtime.state,
     random: runtime.random,
     serverTimeMs: () => Date.now() + setup.clockOffsetMs,
+    hostClientId: setup.hostClientId,
     onTick: (state) => runtime.sound.handleEvents(state.events),
   });
   loop.onSnapshot(snapshot);
@@ -177,13 +202,20 @@ function adoptSeat(
 /**
  * Joins as a client. A client cannot know which player it drives until the host's first snapshot
  * names it in `seats`, so this listens for that snapshot and builds the client loop around the
- * seat it names. Until then the runtime keeps roaming its own city.
+ * seat it names. Until then the runtime keeps roaming its own city. Every snapshot from the host,
+ * seated or not, also feeds the silence watch.
  *
  * @returns A function that stops listening, for the effect's cleanup.
  */
-function startJoining(runtime: Runtime, setup: LoopSetup): () => void {
+function startJoining(
+  runtime: Runtime,
+  setup: LoopSetup,
+  watch: () => HostWatch,
+): () => void {
   const room = setup.transport.channel(roomChannelName(setup.roomCode));
   return room.subscribe("state", (message) => {
+    if (message.clientId !== setup.hostClientId) return;
+    watch().sawSnapshot();
     if (runtime.netplay.kind !== "offline" || runtime.disposed) return;
     try {
       const snapshot = message.data as Snapshot;
@@ -210,6 +242,63 @@ function takeHandover(
   return stopNetplay(runtime, roomCode);
 }
 
+/** The scalar pieces of the options, so the effects below can list plain dependencies. */
+type NetplayInputs = {
+  transport: (() => RealtimeTransport | null) | undefined;
+  ready: boolean;
+  connected: boolean;
+  roomCode: string | null;
+  clientId: string;
+  clockOffsetMs: number;
+  hostClientId: string | null;
+  isHost: boolean;
+  memberKey: string;
+  onHostLost: ((clientId: string) => void) | undefined;
+};
+
+/** Reads the options into plain values; absent options read as a room that is not there. */
+function inputsFrom(options: ArenaNetplayOptions | undefined): NetplayInputs {
+  return {
+    transport: options?.transport,
+    ready: options?.ready ?? false,
+    connected: options?.connected ?? false,
+    roomCode: options?.roomCode ?? null,
+    clientId: options?.clientId ?? "",
+    clockOffsetMs: options?.clockOffsetMs ?? 0,
+    hostClientId: options?.hostClientId ?? null,
+    isHost: options?.isHost ?? false,
+    memberKey: options?.memberIds.join(MEMBER_SEPARATOR) ?? "",
+    onHostLost: options?.onHostLost,
+  };
+}
+
+/**
+ * Calls for a re-election once the host has been quiet for the silence window (spec §6.6).
+ *
+ * The watch is replaced whenever the host changes or this client's own connection comes back:
+ * quiet time under the previous host, or while nothing could arrive anyway, says nothing about
+ * the host that is publishing now.
+ */
+function useSilenceWatch(
+  watchRef: RefObject<HostWatch>,
+  active: boolean,
+  hostClientId: string | null,
+  onHostLost: ((clientId: string) => void) | undefined,
+): void {
+  useEffect(() => {
+    if (!active || !hostClientId || !onHostLost) return undefined;
+    watchRef.current = createHostWatch();
+    const timer = setInterval(() => {
+      const watch = watchRef.current;
+      watch.elapsed(WATCH_POLL_MS);
+      if (!watch.isSilent()) return;
+      clearInterval(timer);
+      onHostLost(hostClientId);
+    }, WATCH_POLL_MS);
+    return () => clearInterval(timer);
+  }, [watchRef, active, hostClientId, onHostLost]);
+}
+
 /**
  * Runs the right loop for the room once the world has booted, and swaps it when the election
  * changes. Without options — offline free roam, and every test that is not about the room —
@@ -224,13 +313,18 @@ export function useNetplay(
   booted: boolean,
   options: ArenaNetplayOptions | undefined,
 ): void {
-  const transport = options?.transport;
-  const ready = options?.ready ?? false;
-  const roomCode = options?.roomCode ?? null;
-  const clientId = options?.clientId ?? "";
-  const clockOffsetMs = options?.clockOffsetMs ?? 0;
-  const isHost = options?.isHost ?? false;
-  const memberKey = options?.memberIds.join(MEMBER_SEPARATOR) ?? "";
+  const {
+    transport,
+    ready,
+    connected,
+    roomCode,
+    clientId,
+    clockOffsetMs,
+    hostClientId,
+    isHost,
+    memberKey,
+    onHostLost,
+  } = inputsFrom(options);
   // Derived from the key rather than taken from the options, so a fresh array holding the same
   // members does not re-run the seating effect.
   const memberIds = useMemo(
@@ -238,24 +332,27 @@ export function useNetplay(
     [memberKey],
   );
   const handoverRef = useRef<Handover | null>(null);
+  const watchRef = useRef<HostWatch>(createHostWatch());
 
   useEffect(() => {
     const runtime = runtimeRef.current;
     const live = transport?.() ?? null;
     if (!runtime || !live || !booted || !ready || !roomCode || !clientId)
       return undefined;
+    if (!hostClientId) return undefined;
     const setup: LoopSetup = {
       transport: live,
       roomCode,
       clientId,
+      hostClientId,
       clockOffsetMs,
     };
     const previous = takeHandover(handoverRef, runtime, roomCode);
     const stopListening = isHost
-      ? startHosting(runtime, setup, previous)
-      : startJoining(runtime, setup);
+      ? startHosting(runtime, setup, previous, () => onHostLost?.(clientId))
+      : startJoining(runtime, setup, () => watchRef.current);
     return () => {
-      stopListening?.();
+      stopListening();
       handoverRef.current = stopNetplay(runtime, roomCode);
     };
   }, [
@@ -266,7 +363,9 @@ export function useNetplay(
     roomCode,
     clientId,
     clockOffsetMs,
+    hostClientId,
     isHost,
+    onHostLost,
   ]);
 
   // Declared after the loop effect and keyed on everything it is, so a freshly created host loop
@@ -283,7 +382,16 @@ export function useNetplay(
     roomCode,
     clientId,
     clockOffsetMs,
+    hostClientId,
     isHost,
+    onHostLost,
     memberIds,
   ]);
+
+  useSilenceWatch(
+    watchRef,
+    booted && ready && connected && !isHost,
+    hostClientId,
+    onHostLost,
+  );
 }

--- a/src/lib/cityArena/net/clientLoop.test.ts
+++ b/src/lib/cityArena/net/clientLoop.test.ts
@@ -415,3 +415,31 @@ describe("clientLoop match phase", () => {
     loop.stop();
   });
 });
+
+describe("clientLoop host filter", () => {
+  it("applies snapshots from the elected host and nobody else", () => {
+    const hub = createMemoryHub();
+    const loop = createClientLoop({
+      transport: createMemoryTransport(hub, "me"),
+      roomCode: ROOM,
+      world,
+      playerId: 0,
+      state: boot(41),
+      random: createRng(41),
+      serverTimeMs: () => 0,
+      hostClientId: "host",
+    });
+    const snapshot = encodeSnapshot({ ...boot(41), tick: 99 }, 0, {});
+    void createMemoryTransport(hub, "impostor")
+      .channel(`arena:room:${ROOM}`)
+      .publish("state", snapshot);
+    hub.flush();
+    expect(loop.state().tick).toBe(0);
+    void createMemoryTransport(hub, "host")
+      .channel(`arena:room:${ROOM}`)
+      .publish("state", snapshot);
+    hub.flush();
+    expect(loop.state().tick).toBe(99);
+    loop.stop();
+  });
+});

--- a/src/lib/cityArena/net/clientLoop.ts
+++ b/src/lib/cityArena/net/clientLoop.ts
@@ -48,6 +48,12 @@ export type ClientLoopOptions = {
   random: () => number;
   /** This client's estimate of host time. */
   serverTimeMs: () => number;
+  /**
+   * Only snapshots published by this client are applied; anyone else publishing on the channel is
+   * ignored, so a member cannot fork the match by playing host (spec §6.6). Omitted, every
+   * snapshot is trusted — the bots, and the loop's own tests.
+   */
+  hostClientId?: string;
   /** The step to run; injectable for tests. Defaults to `stepArena`. */
   step?: typeof stepArena;
   /** Called after every predicted tick, so sound can react to what this client just did. */
@@ -112,6 +118,11 @@ export function createClientLoop(options: ClientLoopOptions): ClientLoop {
 
   const unsubscribe = room.subscribe("state", (message) => {
     if (!running) return;
+    if (
+      options.hostClientId !== undefined &&
+      message.clientId !== options.hostClientId
+    )
+      return;
     try {
       onSnapshot(message.data as Snapshot);
     } catch (error: unknown) {

--- a/src/lib/cityArena/net/election.test.ts
+++ b/src/lib/cityArena/net/election.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { PresenceMember, PresenceRole } from "./transport";
-import { HOST_SILENCE_MS, createHostWatch, electHost } from "./election";
+import {
+  HOST_SILENCE_MS,
+  createHostWatch,
+  electHost,
+  electPresentHost,
+} from "./election";
 
 /** A present member with the fields the election actually reads. */
 function member(
@@ -139,5 +144,24 @@ describe("electHost with broken presence data", () => {
       timestamp: 1,
     } as unknown as PresenceMember;
     expect(electHost([half, desktop("d", 9)])).toBe("d");
+  });
+});
+
+describe("electPresentHost", () => {
+  it("skips a host the silence rule has given up on, in favour of the next in line", () => {
+    const members = [desktop("a", 1), desktop("b", 2), mobile("c", 3)];
+    expect(electPresentHost(members, new Set(["a"]))).toBe("b");
+    expect(electPresentHost(members, new Set(["a", "b"]))).toBe("c");
+  });
+
+  it("falls back to the plain election once everyone has been given up on", () => {
+    const members = [desktop("a", 1), desktop("b", 2)];
+    expect(electPresentHost(members, new Set(["a", "b"]))).toBe("a");
+  });
+
+  it("is the plain election when nobody has been given up on", () => {
+    const members = [mobile("c", 1), desktop("a", 2)];
+    expect(electPresentHost(members, new Set())).toBe(electHost(members));
+    expect(electPresentHost([], new Set())).toBeNull();
   });
 });

--- a/src/lib/cityArena/net/election.ts
+++ b/src/lib/cityArena/net/election.ts
@@ -94,3 +94,22 @@ export function createHostWatch(options: HostWatchOptions = {}): HostWatch {
     },
   };
 }
+
+/**
+ * The member who should host, skipping anyone the caller has given up on.
+ *
+ * Presence alone cannot tell a host whose tab the browser throttled from one that is fine, so
+ * the silence rule (spec §6.6) feeds in the ids it has stopped hearing from. They still count when
+ * nobody else is left: a room hosted by the quiet beats a room with no host at all.
+ *
+ * @param members - Everyone present, in any order.
+ * @param lost - Client ids the silence rule has given up on.
+ * @returns The host's client id, or `null` when nobody is present.
+ */
+export function electPresentHost(
+  members: PresenceMember[],
+  lost: ReadonlySet<string>,
+): string | null {
+  const heard = members.filter((member) => !lost.has(member.clientId));
+  return electHost(heard) ?? electHost(members);
+}


### PR DESCRIPTION
## What this does

The spec §6.6 leftovers after #666, so a room survives its host without anyone doing anything:

- **Snapshots only from the elected host.** `ClientLoop` takes a `hostClientId` and ignores anyone else publishing on the room channel; `useNetplay`'s seat listener does the same. A member cannot fork the match by playing host.
- **The 3 s silence rule.** A client feeds every snapshot from its host into `createHostWatch` (already in `election.ts`, unused until now) and polls it every 500 ms; after `HOST_SILENCE_MS` of nothing it reports the host lost. `useArenaRoom` keeps the ids it has given up on and elects with `electPresentHost`, which skips them — and falls back to the plain election when everyone has been given up on, because a room hosted by the quiet beats a room with no host. Silence is only counted while this client's own connection is up. A member who leaves is forgotten, so a rejoin starts clean.
- **The old host steps down.** A host that hears another member publish the world reports *itself* lost: the room re-elected while its tab was throttled, and stepping down is what stops the match forking into two. The existing handover (#666) then turns it into a client of the successor, keeping its player.
- **The new host takes the lobby.** `useLobbyAdvertisement` now `enter`s rather than `update`s — a host elected mid-match was never in the lobby, and Ably treats an enter-while-present as an update anyway (the in-memory transport, unlike Ably, ignored an update from a non-member, which is how the hook test caught it).
- **A hidden tab keeps hosting.** `requestAnimationFrame` stops in a hidden tab, which froze the world for everyone that tab hosted. `startFrameLoop` now switches to a 30 Hz `setInterval` on `visibilitychange` and back to frames when the tab shows; both clock the world by the same timeline, and `computeFrameDt` clamps at zero so the hand-over cannot run time backwards. Browsers throttle the interval to ~1 Hz in the background, which with the 5-tick catch-up cap is slow motion rather than silence — migration covers the rest, as the spec says.
- **"Nieuwe host: {naam}"** (`HostToast`, copy from spec §16): shown for four seconds when the host changes; not for the first host, which the lobby already names.

## Trust model, stated plainly

The step-down rule means the member next in line *could* take over by publishing snapshots, without the host actually being silent — they would become host anyway the moment the host left, and this is a game among friends behind a login and an admin flag. The server-side checks (`GET /api/arena/rooms` verifying the advertiser, `recordMatch` accepting only the elected host) still elect from raw presence: while an old host lingers in presence, the migrated host's advert can be dropped from the launcher list and its match result refused. Presence leaves within seconds of a tab closing, so this is a short window; making the server honour the silence rule would need it to observe snapshots, which is a separate decision.

## Tests

- `useNetplay.test.ts` (+5): an impostor's snapshot does not seat a client, the host's does; silence calls for a re-election exactly once after the window; a host that keeps publishing keeps the window open; no blame while the client's own connection is down; a host that hears another member publish steps down.
- `useArenaRoom.test.tsx` (new, 4, over the in-memory transport): open and advertise a room; join behind the host in join order; re-elect without a lost host and the new host takes the lobby; a lone host told it is lost keeps hosting.
- `election.test.ts` (+3) for `electPresentHost`; `clientLoop.test.ts` (+1) for the host filter; `HostToast.test.tsx` (new, 4); `useArenaGame.test.tsx` (+1): a hidden tab keeps stepping on the interval and returns to frames when shown.
- Full suite: 209 files, 1428 tests green; `npm run lint` and `tsc --noEmit` clean.

## Still open

- Smoothing a joiner's jump into the host's world on its first snapshot.
- The owner's two-device play-test (game behind login + admin flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core multiplayer election, snapshot trust, and host loop lifecycle; mistakes could fork matches or drop lobby ads, though behavior is heavily tested.
> 
> **Overview**
> Implements spec §6.6 so arena rooms survive a quiet or throttled host without manual intervention.
> 
> **Host trust and failover:** Clients only accept world snapshots from the elected `hostClientId` (`ClientLoop`, `useNetplay` seat listener). Non-hosts watch for ~3s of silence (while their own connection is up) and call `reportHostLost`; `useArenaRoom` tracks “lost” hosts and re-elects via `electPresentHost`, clearing lost ids when members leave. A host that hears another member publish `state` reports itself lost to avoid two authoritative worlds. Mid-match hosts re-advertise the room with `enterLobby` instead of `updateLobby`.
> 
> **Hidden-tab hosting:** When the document is hidden, `startFrameLoop` steps simulation on a host-rate interval instead of freezing on paused `requestAnimationFrame`; frame delta is clamped to ≥0 when switching clocks.
> 
> **UX:** `HostToast` shows “Nieuwe host: …” for four seconds on host *client id* change (not the first host or rename-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7938519b6cc188512c0d8a1c49a2a11576a1748e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->